### PR TITLE
Add DATABASE_SCHEMA environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM node:12.18-alpine
 
-ENV DATABASE_URL "postgresql://umami:umami@db:5432/umami"
+ARG DATABASE_TYPE
+
+ENV DATABASE_URL "postgresql://umami:umami@db:5432/umami" \
+    DATABASE_TYPE=$DATABASE_TYPE
 
 COPY . /app
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: postgresql://umami:umami@db:5432/umami
+      DATABASE_TYPE: postgresql
       HASH_SALT: replace-me-with-a-random-string
     depends_on:
       - db

--- a/scripts/copy-db-schema.js
+++ b/scripts/copy-db-schema.js
@@ -2,15 +2,15 @@ require('dotenv').config();
 const fs = require('fs');
 const path = require('path');
 
-const db = process.env.DATABASE_URL.split(':')[0];
+const databaseType = process.env.DATABASE_TYPE || process.env.DATABASE_URL.split(':')[0];
 
-if (!db) {
-  throw new Error('Database not specified');
+if (!databaseType) {
+  throw new Error('Database schema not specified');
 }
 
-console.log(`Database detected: ${db}`);
+console.log(`Database schema detected: ${databaseType}`);
 
-const src = path.resolve(__dirname, `../prisma/schema.${db}.prisma`);
+const src = path.resolve(__dirname, `../prisma/schema.${databaseType}.prisma`);
 const dest = path.resolve(__dirname, '../prisma/schema.prisma');
 
 fs.copyFileSync(src, dest);


### PR DESCRIPTION
This PR adds a `DATABASE_SCHEMA` environment variable, which determines which Prisma schema to use, and allows the Docker image to be built without the `DATABASE_URL`.

Closes #45 