### PR TITLE
share page loading

### DIFF
--- a/pages/share/[...id].js
+++ b/pages/share/[...id].js
@@ -6,6 +6,7 @@ import NotFound from 'pages/404';
 import { get } from 'lib/web';
 
 export default function SharePage() {
+  const [loading, setLoading] = useState(true);
   const [websiteId, setWebsiteId] = useState();
   const [notFound, setNotFound] = useState(false);
   const router = useRouter();
@@ -23,9 +24,15 @@ export default function SharePage() {
 
   useEffect(() => {
     if (id) {
-      loadData();
+      loadData().finally(() => {
+        setLoading(false);
+      });
+    } else {
+      setLoading(false);
     }
   }, [id]);
+
+  if (loading) return null;
 
   if (!id || notFound) {
     return <NotFound />;


### PR DESCRIPTION
Right now as it is, a shared URL always starts showing 404.

Since there isn't a spinner, just returning null, just like pages/dashboard.js

PS: This was just a small fast fix, the proper way of doing this should be through [getServerSideProps](https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering)