### PR TITLE
feat: allow building image from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: '3'
 services:
   umami:
     image: ghcr.io/mikecao/umami:postgresql-latest
+    build: .
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
I don't know if this might have other implications (like whether or not it would default to pulling or building a newer image once you want to update),

but I found this useful when e.g. [implementing a translation](https://github.com/mikecao/umami/pull/585) and the `yarn dev` thingie just didn't work, thus building the docker image right from `docker-compose build` or just `docker-compose up --build`.

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>