### PR TITLE
fix bigint ui

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client';
 import chalk from 'chalk';
 
 BigInt.prototype.toJSON = function () {
-  return this.toString();
+  return Number(this);
 };
 
 const options = {


### PR DESCRIPTION
Fix issue with UI not loading tables due to 'y' axis returning as a string.