### PR TITLE
Update the links for current repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install -g yarn
 ### Get the source code and install packages
 
 ```
-git clone https://github.com/mikecao/umami.git
+git clone https://github.com/umami-software/umami.git
 cd umami
 yarn install
 ```

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
   "description": "Umami is a simple, fast, website analytics alternative to Google Analytics.",
   "keywords": ["analytics", "charts", "statistics", "web-analytics"],
   "website": "https://umami.is",
-  "repository": "https://github.com/mikecao/umami",
+  "repository": "https://github.com/umami-software/umami",
   "addons": ["heroku-postgresql"],
   "env": {
     "HASH_SALT": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   umami:
-    image: ghcr.io/mikecao/umami:postgresql-latest
+    image: ghcr.io/umami-software/umami:postgresql-latest
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
This PR updates the references to the project repository since it is changed to `umami-software/umami`.

I spotted this while updating `umami` to `v1.34.0`, I pulled the docker image but it didn't update when I run the container. Then I realized the repository is moved to an organization. 