### PR TITLE
Fix Heroku deployment

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm run start-env

--- a/package.json
+++ b/package.json
@@ -127,5 +127,8 @@
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-recommended": "^7.0.0",
     "tar": "^6.1.2"
-  }
+  },
+  "cacheDirectories": [
+    ".next/cache"
+  ]
 }


### PR DESCRIPTION
After removing the Procfile the deployment on Heroku works again.

Heroku started the server twice which led to double (wrong) port assignments and runtime errors.
Next.js seems to default to the ports provided by Heroku:
https://github.com/vercel/next.js/issues/10338

By removing the Procfile Heroku starts the server by default with `yarn start`.

I wasn't sure whether the script `start-env.js` could be safely removed w/o affecting other scenarios.
Adding cacheDirectories remove the cache warning in the Heroku build logs.