### PR TITLE
feat: :sparkles: customize theme and locale based on query params

### DIFF
--- a/hooks/useLocale.js
+++ b/hooks/useLocale.js
@@ -48,5 +48,14 @@ export default function useLocale() {
     }
   }, [locale]);
 
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const locale = url.searchParams.get('locale');
+
+    if (locale) {
+      saveLocale(locale);
+    }
+  }, []);
+
   return { locale, saveLocale, messages, dir, dateLocale };
 }

--- a/hooks/useTheme.js
+++ b/hooks/useTheme.js
@@ -23,5 +23,14 @@ export default function useTheme() {
     document.body.setAttribute('data-theme', theme);
   }, [theme]);
 
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const theme = url.searchParams.get('theme');
+
+    if (['light', 'dark'].includes(theme)) {
+      saveTheme(theme);
+    }
+  }, []);
+
   return [theme, saveTheme];
 }


### PR DESCRIPTION
For #1349 

In general terms we can now customize theme and locale based on the query parameters.
For theme the query param would be `?theme`. 
Example:  `?theme=dark` or `?theme=light`

For locale the query param would be `?locale`.
Example: `?locale=en-US`