### PR TITLE
Add `Cache-Control` header for tracker script

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -57,6 +57,16 @@ module.exports = {
         source: '/:path*',
         headers,
       },
+      {
+        source: '/umami.js',
+        headers: [
+          ...headers,
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=86400',
+          },
+        ],
+      },
     ];
   },
   async rewrites() {

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ module.exports = {
         headers,
       },
       {
-        source: '/((?!telemetry).*\\.js)',
+        source: '/((?!telemetry\\.js).*\\.js)',
         headers: [
           ...headers,
           {

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ module.exports = {
         headers,
       },
       {
-        source: '/((?!telemetry).*.js)',
+        source: '/((?!telemetry).*\\.js)',
         headers: [
           ...headers,
           {

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ module.exports = {
         headers,
       },
       {
-        source: '/(.*\\.js)',
+        source: '/((?!telemetry).*.js)',
         headers: [
           ...headers,
           {

--- a/next.config.js
+++ b/next.config.js
@@ -58,7 +58,7 @@ module.exports = {
         headers,
       },
       {
-        source: '/umami.js',
+        source: '/(.*\\.js)',
         headers: [
           ...headers,
           {


### PR DESCRIPTION
This PR adds `Cache-Control` header for tracker script. Presently, the tracker script is provided with a `Cache-Control` header `max-age=0`, therefore the script is requested from the server every time a page is loaded. It would be better if the script was cached. This PR adds the `Cache-Control` header with `max-age=86400` which will cache the script for 24 hours.