### PR TITLE
Fix session error

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -50,14 +50,17 @@ export async function getSession(req) {
         device,
       });
 
-      if (!session) {
-        return null;
-      }
     } catch (e) {
       if (!e.message.includes('Unique constraint')) {
         throw e;
+      } else {
+        session = await getSessionByUuid(session_uuid);
       }
     }
+  }
+  
+  if (!session) {
+    return null;
   }
 
   const { session_id } = session;


### PR DESCRIPTION
Fix "Cannot destructure property 'session_id' of 'session' as it is null" error
Sometimes with a large number of requests, an error occurs when searching for a session.
1. Session not found. "session === null"
2. Next, we try to create it, but we get into "catch", i.e. our "session" variable is "null". If we get the error "Unique constraint failed on the fields: (`session_uuid`)", then the session was created in another request and we need to get it.