### PR TITLE
Add yesterday option

### DIFF
--- a/components/common/DateFilter.js
+++ b/components/common/DateFilter.js
@@ -19,6 +19,10 @@ export const filterOptions = [
     value: '24hour',
   },
   {
+    label: <FormattedMessage id="label.yesterday" defaultMessage="Yesterday" />,
+    value: '-1day',
+  },
+  {
     label: <FormattedMessage id="label.this-week" defaultMessage="This week" />,
     value: '1week',
     divider: true,

--- a/lang/ca-ES.json
+++ b/lang/ca-ES.json
@@ -62,6 +62,7 @@
   "label.username": "Nom d'usuari",
   "label.view-details": "Veure els detalls",
   "label.websites": "Llocs web",
+  "label.yesterday": "Ahir",
   "message.active-users": "{x} {x, plural, one {visitant actual} other {visitants actuals}}",
   "message.confirm-delete": "Segur que vols esborrar {target}?",
   "message.confirm-reset": "Segur que vols restablir les estadístiques de {target}?",

--- a/lang/de-DE.json
+++ b/lang/de-DE.json
@@ -62,6 +62,7 @@
   "label.username": "Benutzername",
   "label.view-details": "Details anzeigen",
   "label.websites": "Webseiten",
+  "label.yesterday": "Gestern",
   "message.active-users": "{x} {x, plural, one {aktiver Besucher} other {aktive Besucher}}",
   "message.confirm-delete": "Sind Sie sich sicher, {target} zu löschen?",
   "message.confirm-reset": "Sind Sie sicher, dass Sie die Statistiken von {target} zurücksetzen wollen?",

--- a/lang/en-GB.json
+++ b/lang/en-GB.json
@@ -62,6 +62,7 @@
   "label.username": "Username",
   "label.view-details": "View details",
   "label.websites": "Websites",
+  "label.yesterday": "Yesterday",
   "message.active-users": "{x} current {x, plural, one {visitor} other {visitors}}",
   "message.confirm-delete": "Are you sure you want to delete {target}?",
   "message.confirm-reset": "Are you sure you want to reset {target}'s statistics?",

--- a/lang/en-US.json
+++ b/lang/en-US.json
@@ -62,6 +62,7 @@
   "label.username": "Username",
   "label.view-details": "View details",
   "label.websites": "Websites",
+  "label.yesterday": "Yesterday",
   "message.active-users": "{x} current {x, plural, one {visitor} other {visitors}}",
   "message.confirm-delete": "Are you sure you want to delete {target}?",
   "message.confirm-reset": "Are you sure you want to reset {target}'s statistics?",

--- a/lang/es-MX.json
+++ b/lang/es-MX.json
@@ -62,6 +62,7 @@
   "label.username": "Nombre de usuario",
   "label.view-details": "Ver detalles",
   "label.websites": "Sitios",
+  "label.yesterday": "Ayer",
   "message.active-users": "{x} {x, plural, one {activo} other {activos}}",
   "message.confirm-delete": "¿Estás seguro(a) de querer eliminar {target}?",
   "message.confirm-reset": "¿Seguro que deseas restablecer las estadísticas de {target}?",

--- a/lang/fr-FR.json
+++ b/lang/fr-FR.json
@@ -62,6 +62,7 @@
   "label.username": "Nom d'utilisateur",
   "label.view-details": "Voir les details",
   "label.websites": "Sites",
+  "label.yesterday": "Hier",
   "message.active-users": "{x} {x, plural, one {visiteur} other {visiteurs}} actuellement",
   "message.confirm-delete": "Êtes-vous sûr de vouloir supprimer {target} ?",
   "message.confirm-reset": "Êtes-vous sûr de vouloir réinistialiser les statistiques de {target} ?",

--- a/lang/it-IT.json
+++ b/lang/it-IT.json
@@ -62,6 +62,7 @@
   "label.username": "Nome utente",
   "label.view-details": "Vedi dettagli",
   "label.websites": "Siti web",
+  "label.yesterday": "Ieri",
   "message.active-users": "{x} {x, plural, one {visitatore} other {visitatori}} online",
   "message.confirm-delete": "Sei sicuro di voler eliminare {target}?",
   "message.confirm-reset": "Sei sicuro di voler azzerare le statistiche di {target}?",

--- a/lib/date.js
+++ b/lib/date.js
@@ -7,6 +7,8 @@ import {
   addYears,
   subHours,
   subDays,
+  subMonths,
+  subYears,
   startOfMinute,
   startOfHour,
   startOfDay,
@@ -39,7 +41,7 @@ export function getDateRange(value, locale = 'en-US') {
   const now = new Date();
   const dateLocale = getDateLocale(locale);
 
-  const match = value.match(/^(?<num>[0-9]+)(?<unit>hour|day|week|month|year)$/);
+  const match = value.match(/^(?<num>[0-9-]+)(?<unit>hour|day|week|month|year)$/);
 
   if (!match) return;
 
@@ -72,6 +74,39 @@ export function getDateRange(value, locale = 'en-US') {
         return {
           startDate: startOfYear(now),
           endDate: endOfYear(now),
+          unit: 'month',
+          value,
+        };
+    }
+  }
+
+  if (+num === -1) {
+    switch (unit) {
+      case 'day':
+        return {
+          startDate: subDays(startOfDay(now), 1),
+          endDate: subDays(endOfDay(now), 1),
+          unit: 'hour',
+          value,
+        };
+      case 'week':
+        return {
+          startDate: subDays(startOfWeek(now, { locale: dateLocale }), 7),
+          endDate: subDays(endOfWeek(now, { locale: dateLocale }), 1),
+          unit: 'day',
+          value,
+        };
+      case 'month':
+        return {
+          startDate: subMonths(startOfMonth(now), 1),
+          endDate: subMonths(endOfMonth(now), 1),
+          unit: 'day',
+          value,
+        };
+      case 'year':
+        return {
+          startDate: subYears(startOfYear(now), 1),
+          endDate: subYears(endOfYear(now), 1),
           unit: 'month',
           value,
         };

--- a/public/intl/messages/ca-ES.json
+++ b/public/intl/messages/ca-ES.json
@@ -397,6 +397,12 @@
       "value": "Llocs web"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Ahir"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/de-DE.json
+++ b/public/intl/messages/de-DE.json
@@ -397,6 +397,12 @@
       "value": "Webseiten"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Gestern"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/en-GB.json
+++ b/public/intl/messages/en-GB.json
@@ -397,6 +397,12 @@
       "value": "Websites"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Yesterday"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/en-US.json
+++ b/public/intl/messages/en-US.json
@@ -397,6 +397,12 @@
       "value": "Websites"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Yesterday"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/es-MX.json
+++ b/public/intl/messages/es-MX.json
@@ -397,6 +397,12 @@
       "value": "Sitios"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Ayer"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/fr-FR.json
+++ b/public/intl/messages/fr-FR.json
@@ -389,6 +389,12 @@
       "value": "Sites"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Hier"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,

--- a/public/intl/messages/it-IT.json
+++ b/public/intl/messages/it-IT.json
@@ -397,6 +397,12 @@
       "value": "Siti web"
     }
   ],
+  "label.yesterday": [
+    {
+      "type": 0,
+      "value": "Ieri"
+    }
+  ],
   "message.active-users": [
     {
       "type": 1,


### PR DESCRIPTION
First of all, thanks for all the hours you've dedicated to this project!

This PR adds a _Yesterday_ option to the date-range selector (value: `-1day`). 

I'm aware that you have previously [expressed doubt about the usefulness](https://github.com/umami-software/umami/pull/106#issuecomment-688603703) of this option. In our use case, though, we're frequently checking how our sites and applications fared the day before. Other users have also requested this feature — this PR closes #1217.

The key changes are in:
- components/common/DateFilter.js — add menu option
- lib/date.js — interpretation of `-Xunit` values
- (All other file changes are related to translations)

The implementation in _lib/date.js_ also allows _Last week_ (value: `-1week`), _Last month_ (`-1month`), _Last year_ (`-1year`) options, but they are not surfaced in the UI. Adding them to the menu made it a bit overwhelming and for those longer periods it is probably simpler for the user to use the _Custom range_ option.

I've added translations for Spanish, German, French, Italian, and Catalan. 

This is my first PR to this repo, so please let me know if you'd prefer for instance to send separate PRs for translation-related changes.

Thanks!