### PR TITLE
Show events in metrics bar

### DIFF
--- a/components/metrics/MetricsBar.js
+++ b/components/metrics/MetricsBar.js
@@ -43,7 +43,7 @@ export default function MetricsBar({ websiteId, className }) {
     setFormat(state => !state);
   }
 
-  const { pageviews, uniques, bounces, totaltime } = data || {};
+  const { pageviews, uniques, bounces, totaltime, events } = data || {};
   const num = Math.min(data && uniques.value, data && bounces.value);
   const diffs = data && {
     pageviews: pageviews.value - pageviews.change,
@@ -68,6 +68,12 @@ export default function MetricsBar({ websiteId, className }) {
             label={<FormattedMessage id="metrics.visitors" defaultMessage="Visitors" />}
             value={uniques.value}
             change={uniques.change}
+            format={formatFunc}
+          />
+          <MetricCard
+            label={<FormattedMessage id="metrics.events" defaultMessage="Events" />}
+            value={events.value}
+            change={events.change}
             format={formatFunc}
           />
           <MetricCard

--- a/queries/analytics/stats/getWebsiteStats.js
+++ b/queries/analytics/stats/getWebsiteStats.js
@@ -25,7 +25,12 @@ async function relationalQuery(website_id, start_at, end_at, filters = {}) {
     filters,
     params,
   );
-  const { joinSession: joinEventSession } = parseFilters('event', null, filters, params);
+  const { eventQuery, joinSession: joinEventSession } = parseFilters(
+    'event',
+    null,
+    { ...filters, event_url: filters.url },
+    params,
+  );
 
   return rawQuery(
     `
@@ -54,6 +59,7 @@ async function relationalQuery(website_id, start_at, end_at, filters = {}) {
         ${joinEventSession}
       where event.website_id=$1
       and event.created_at between $2 and $3
+      ${eventQuery}
       ${sessionQuery}
     ) stats_events
     `,
@@ -70,7 +76,12 @@ async function clickhouseQuery(website_id, start_at, end_at, filters = {}) {
     params,
     'session_uuid',
   );
-  const { joinSession: joinEventSession } = parseFilters('event', null, filters, params);
+  const { eventQuery, joinSession: joinEventSession } = parseFilters(
+    'event',
+    null,
+    filters,
+    params,
+  );
 
   return rawQueryClickhouse(
     `
@@ -101,6 +112,7 @@ async function clickhouseQuery(website_id, start_at, end_at, filters = {}) {
         ${joinEventSession}
       where event.website_id=$1
         and ${getBetweenDatesClickhouse('event.created_at', start_at, end_at)}
+        ${eventQuery}
         ${sessionQuery}
     ) stats_events
       `,


### PR DESCRIPTION
This PR adds events to MetricsBar and closes #1431. All pages (dashboard, website, real-time) would have the triad (views, visitors, events):

<img width="1140" alt="Screenshot 2022-08-26 at 13 10 18" src="https://user-images.githubusercontent.com/2129481/186892005-1435162c-fc01-4ff5-a2b3-54f150594a9c.png">

According to [your comment here](https://github.com/umami-software/umami/issues/1431#issuecomment-1215484201), it might not be super-interesting to show this metric in the dashboard page. Please let me know if you prefer to hide it in that case; I believe, though, that for consistence it would be better to show it always. 

Session filters (OS, browser, device, country), as well as the URL filter, work with this implementation correctly and affect the events metric. View-related filter "referrer" does not affect the metric. Maybe when selecting such a filter we could gray out the "events" metric?

I look forward to your feedback!

Please note that the ClickHouse queries have been implemented, but unfortunately I couldn't test them.