### PR TITLE
Fixed bug in MetricCard: plus sign disappears on click.

### DIFF
--- a/components/metrics/MetricCard.js
+++ b/components/metrics/MetricCard.js
@@ -29,9 +29,9 @@ const MetricCard = ({
                 : !reverseColors
                 ? styles.negative
                 : styles.positive
-            }`}
+            } ${change >= 0 ? styles.plusSign : ''}`}
           >
-            {changeProps.x.interpolate(x => `${change >= 0 ? '+' : ''}${format(x)}`)}
+            {changeProps.x.interpolate(x => format(x))}
           </animated.span>
         )}
       </div>

--- a/components/metrics/MetricCard.module.css
+++ b/components/metrics/MetricCard.module.css
@@ -37,3 +37,7 @@
 .change.negative {
   color: var(--red500);
 }
+
+.change.plusSign::before {
+  content: '+';
+}


### PR DESCRIPTION
This fixes a small visual glitch when clicking on MetricCards. The plus sign sometimes disappeared:

![Screen Recording 2022-08-26 at 16 41 21](https://user-images.githubusercontent.com/2129481/186953148-9e2fbce6-177b-4bb0-8d08-5e1cc0dd393c.gif)

Due to the way react-spring works, I only managed to recover the '+' sign via CSS, using a `::before` selector. But maybe there's a better solution!