### PR TITLE
Update `tracker/index.js`: `fetch()` with `keepalive`

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -87,6 +87,7 @@
       method: 'POST',
       body: JSON.stringify({ type, payload }),
       headers: assign({ 'Content-Type': 'application/json' }, { ['x-umami-cache']: cache }),
+      keepalive: true,
     })
       .then(res => res.text())
       .then(text => (cache = text));


### PR DESCRIPTION
Added `keepalive: true` to `fetch()` in the tracker script, based on the discussions in https://github.com/umami-software/umami/issues/1470#issuecomment-1230108554.