### PR TITLE
Fix unique dot colors in the realtime logs

### DIFF
--- a/lib/format.js
+++ b/lib/format.js
@@ -74,7 +74,7 @@ export function stringToColor(str) {
   let color = '#';
   for (let i = 0; i < 3; i++) {
     let value = (hash >> (i * 8)) & 0xff;
-    color += ('00' + value.toString(16)).substring(-2);
+    color += ('00' + value.toString(16)).slice(-2);
   }
   return color;
 }


### PR DESCRIPTION
This PR fixes the unique dot colors in the realtime logs and closes #1496.

It seems like the (now deprecated) `subst` function was directly replaced with `substring`, which takes different parameters. Using `slice` instead will produce the desired result.

Looking forward to feedback!

> Sidenote: I'm trying out Umami for my small company and loving it so far! Also I'm participating in hacktoberfest, so I would love a `hacktoberfest-accepted` label on this PR :)