### PR TITLE
Fix missing function argument of getFilterQuery

### DIFF
--- a/lib/clickhouse.js
+++ b/lib/clickhouse.js
@@ -62,7 +62,7 @@ function getBetweenDates(field, start_at, end_at) {
     and ${getDateFormat(end_at)}`;
 }
 
-function getFilterQuery(table, column, filters = {}, params = []) {
+function getFilterQuery(table, filters = {}, params = []) {
   const query = Object.keys(filters).reduce((arr, key) => {
     const filter = filters[key];
 
@@ -122,7 +122,7 @@ function getFilterQuery(table, column, filters = {}, params = []) {
   return query.join('\n');
 }
 
-function parseFilters(table, column, filters = {}, params = [], sessionKey = 'session_id') {
+function parseFilters(table, filters = {}, params = [], sessionKey = 'session_id') {
   const { domain, url, event_url, referrer, os, browser, device, country, event_name, query } =
     filters;
 
@@ -139,9 +139,9 @@ function parseFilters(table, column, filters = {}, params = [], sessionKey = 'se
       os || browser || device || country
         ? `inner join session on ${table}.${sessionKey} = session.${sessionKey}`
         : '',
-    pageviewQuery: getFilterQuery('pageview', column, pageviewFilters, params),
-    sessionQuery: getFilterQuery('session', column, sessionFilters, params),
-    eventQuery: getFilterQuery('event', column, eventFilters, params),
+    pageviewQuery: getFilterQuery('pageview', pageviewFilters, params),
+    sessionQuery: getFilterQuery('session', sessionFilters, params),
+    eventQuery: getFilterQuery('event', eventFilters, params),
   };
 }
 

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -85,7 +85,7 @@ function getTimestampInterval(field) {
   }
 }
 
-function getFilterQuery(table, column, filters = {}, params = []) {
+function getFilterQuery(table, filters = {}, params = []) {
   const query = Object.keys(filters).reduce((arr, key) => {
     const filter = filters[key];
 
@@ -145,7 +145,7 @@ function getFilterQuery(table, column, filters = {}, params = []) {
   return query.join('\n');
 }
 
-function parseFilters(table, column, filters = {}, params = [], sessionKey = 'session_id') {
+function parseFilters(table, filters = {}, params = [], sessionKey = 'session_id') {
   const { domain, url, event_url, referrer, os, browser, device, country, event_name, query } =
     filters;
 
@@ -162,9 +162,9 @@ function parseFilters(table, column, filters = {}, params = [], sessionKey = 'se
       os || browser || device || country
         ? `inner join session on ${table}.${sessionKey} = session.${sessionKey}`
         : '',
-    pageviewQuery: getFilterQuery('pageview', column, pageviewFilters, params),
-    sessionQuery: getFilterQuery('session', column, sessionFilters, params),
-    eventQuery: getFilterQuery('event', column, eventFilters, params),
+    pageviewQuery: getFilterQuery('pageview', pageviewFilters, params),
+    sessionQuery: getFilterQuery('session', sessionFilters, params),
+    eventQuery: getFilterQuery('event', eventFilters, params),
   };
 }
 

--- a/queries/analytics/pageview/getPageviewMetrics.js
+++ b/queries/analytics/pageview/getPageviewMetrics.js
@@ -14,7 +14,6 @@ async function relationalQuery(website_id, start_at, end_at, column, table, filt
   const params = [website_id, start_at, end_at];
   const { pageviewQuery, sessionQuery, eventQuery, joinSession } = parseFilters(
     table,
-    column,
     filters,
     params,
   );
@@ -39,7 +38,6 @@ async function clickhouseQuery(website_id, start_at, end_at, column, table, filt
   const params = [website_id];
   const { pageviewQuery, sessionQuery, eventQuery, joinSession } = parseFilters(
     table,
-    column,
     filters,
     params,
     'session_uuid',

--- a/queries/analytics/pageview/getPageviewParams.js
+++ b/queries/analytics/pageview/getPageviewParams.js
@@ -8,12 +8,11 @@ export async function getPageviewParams(...args) {
   });
 }
 
-async function relationalQuery(website_id, start_at, end_at, column, table, filters = {}) {
+async function relationalQuery(website_id, start_at, end_at, table, filters = {}) {
   const { parseFilters, rawQuery } = prisma;
   const params = [website_id, start_at, end_at];
   const { pageviewQuery, sessionQuery, eventQuery, joinSession } = parseFilters(
     table,
-    column,
     filters,
     params,
   );

--- a/queries/analytics/pageview/getPageviewStats.js
+++ b/queries/analytics/pageview/getPageviewStats.js
@@ -21,12 +21,7 @@ async function relationalQuery(
 ) {
   const { getDateQuery, parseFilters, rawQuery } = prisma;
   const params = [website_id, start_at, end_at];
-  const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
-    'pageview',
-    null,
-    filters,
-    params,
-  );
+  const { pageviewQuery, sessionQuery, joinSession } = parseFilters('pageview', filters, params);
 
   return rawQuery(
     `select ${getDateQuery('pageview.created_at', unit, timezone)} t,
@@ -56,7 +51,6 @@ async function clickhouseQuery(
   const params = [website_id];
   const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
     'pageview',
-    null,
     filters,
     params,
     sessionKey,

--- a/queries/analytics/session/getSessionMetrics.js
+++ b/queries/analytics/session/getSessionMetrics.js
@@ -12,12 +12,7 @@ export async function getSessionMetrics(...args) {
 async function relationalQuery(website_id, start_at, end_at, field, filters = {}) {
   const { parseFilters, rawQuery } = prisma;
   const params = [website_id, start_at, end_at];
-  const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
-    'pageview',
-    null,
-    filters,
-    params,
-  );
+  const { pageviewQuery, sessionQuery, joinSession } = parseFilters('pageview', filters, params);
 
   return rawQuery(
     `select ${field} x, count(*) y
@@ -42,7 +37,6 @@ async function clickhouseQuery(website_id, start_at, end_at, field, filters = {}
   const params = [website_id];
   const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
     'pageview',
-    null,
     filters,
     params,
     'session_uuid',

--- a/queries/analytics/stats/getWebsiteStats.js
+++ b/queries/analytics/stats/getWebsiteStats.js
@@ -12,12 +12,7 @@ export async function getWebsiteStats(...args) {
 async function relationalQuery(website_id, start_at, end_at, filters = {}) {
   const { getDateQuery, getTimestampInterval, parseFilters, rawQuery } = prisma;
   const params = [website_id, start_at, end_at];
-  const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
-    'pageview',
-    null,
-    filters,
-    params,
-  );
+  const { pageviewQuery, sessionQuery, joinSession } = parseFilters('pageview', filters, params);
 
   return rawQuery(
     `select sum(t.c) as "pageviews",
@@ -46,7 +41,6 @@ async function clickhouseQuery(website_id, start_at, end_at, filters = {}) {
   const params = [website_id];
   const { pageviewQuery, sessionQuery, joinSession } = parseFilters(
     'pageview',
-    null,
     filters,
     params,
     'session_uuid',


### PR DESCRIPTION
In getEventMetrics no `column` argument is passed to getFilterQuery ([Code](https://github.com/umami-software/umami/blob/0cb14f3f6c4fd542da0f20ae55849f88ce357d6d/queries/analytics/event/getEventMetrics.js#L31)) although it is required. Thus, the subsequent arguments are shifted by one. This leads to wrong API responses, since the filters are not properly applied.

One option is to pass a null value as the `column` argument. However, it is not used in getFilterQuery. Therefore, I removed it.