### PR TITLE
Feature/advanced branding

### DIFF
--- a/components/common/EmptyPlaceholder.js
+++ b/components/common/EmptyPlaceholder.js
@@ -7,7 +7,11 @@ import styles from './EmptyPlaceholder.module.css';
 function EmptyPlaceholder({ msg, children }) {
   return (
     <div className={styles.placeholder}>
-      <Icon className={styles.icon} icon={<Logo />} size="xlarge" />
+      <Icon
+        icon={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || <Logo />}
+        size="xlarge"
+        className={styles.icon}
+      />
       <h2 className={styles.msg}>{msg}</h2>
       {children}
     </div>

--- a/components/common/Icon.js
+++ b/components/common/Icon.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Image from 'next/image';
 import styles from './Icon.module.css';
 
 function Icon({ icon, className, size = 'medium', ...props }) {
@@ -15,7 +16,7 @@ function Icon({ icon, className, size = 'medium', ...props }) {
       })}
       {...props}
     >
-      {icon}
+      {typeof icon === 'string' ? <Image src={icon} width={20} height={20} /> : icon}
     </div>
   );
 }

--- a/components/forms/LoginForm.js
+++ b/components/forms/LoginForm.js
@@ -77,7 +77,7 @@ export default function LoginForm() {
           <Form>
             <div className={styles.header}>
               <Icon icon={<Logo />} size="xlarge" className={styles.icon} />
-              <h1 className="center">umami</h1>
+              <h1 className="center">{process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}</h1>
             </div>
             <FormRow>
               <label htmlFor="username">

--- a/components/forms/LoginForm.js
+++ b/components/forms/LoginForm.js
@@ -76,7 +76,11 @@ export default function LoginForm() {
         {() => (
           <Form>
             <div className={styles.header}>
-              <Icon icon={<Logo />} size="xlarge" className={styles.icon} />
+              <Icon
+                icon={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || <Logo />}
+                size="xlarge"
+                className={styles.icon}
+              />
               <h1 className="center">{process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}</h1>
             </div>
             <FormRow>

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -26,7 +26,11 @@ export default function Header() {
       {allowUpdate && <UpdateNotice />}
       <header className={classNames(styles.header, 'row')}>
         <div className={styles.title}>
-          <Icon icon={<Logo />} size="large" className={styles.logo} />
+          <Icon
+            icon={process.env.NEXT_PUBLIC_CUSTOM_FAVICON_URL || <Logo />}
+            size="large"
+            className={styles.logo}
+          />
           <Link
             href={isSharePage ? process.env.NEXT_PUBLIC_CUSTOM_HOMEPAGE_URL || HOMEPAGE_URL : '/'}
           >

--- a/components/layout/Header.js
+++ b/components/layout/Header.js
@@ -27,7 +27,11 @@ export default function Header() {
       <header className={classNames(styles.header, 'row')}>
         <div className={styles.title}>
           <Icon icon={<Logo />} size="large" className={styles.logo} />
-          <Link href={isSharePage ? HOMEPAGE_URL : '/'}>umami</Link>
+          <Link
+            href={isSharePage ? process.env.NEXT_PUBLIC_CUSTOM_HOMEPAGE_URL || HOMEPAGE_URL : '/'}
+          >
+            {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}
+          </Link>
         </div>
         <HamburgerButton />
         {user && (

--- a/components/layout/Layout.js
+++ b/components/layout/Layout.js
@@ -10,7 +10,10 @@ export default function Layout({ title, children, header = true, footer = true }
   return (
     <>
       <Head>
-        <title>umami{title && ` - ${title}`}</title>
+        <title>
+          {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}
+          {title && ` - ${title}`}
+        </title>
       </Head>
 
       {header && <Header />}

--- a/lang/de-DE.json
+++ b/lang/de-DE.json
@@ -79,7 +79,7 @@
   "message.no-data-available": "Keine Daten vorhanden.",
   "message.no-websites-configured": "Es ist keine Webseite vorhanden.",
   "message.page-not-found": "Seite nicht gefunden.",
-  "message.powered-by": "Betrieben durch {name}",
+  "message.powered-by": "Powered by {name}",
   "message.reset-warning": "Alle Daten für diese Webseite werden gelöscht, jedoch bleibt der Tracking Code bestehen.",
   "message.save-success": "Erfolgreich gespeichert.",
   "message.share-url": "Dies ist die öffentliche URL zum Teilen für {target}.",

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,7 @@ const pkg = require('./package.json');
 
 const contentSecurityPolicy = `
   default-src 'self';
-  img-src *;
+  img-src * 'self' data:;
   script-src 'self' 'unsafe-eval';
   style-src 'self' 'unsafe-inline';
   connect-src 'self' api.umami.is;
@@ -51,6 +51,10 @@ module.exports = {
     });
 
     return config;
+  },
+  images: {
+    dangerouslyAllowSVG: true,
+    domains: [new URL(process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL).hostname],
   },
   async headers() {
     return [

--- a/next.config.js
+++ b/next.config.js
@@ -53,7 +53,6 @@ module.exports = {
     return config;
   },
   images: {
-    dangerouslyAllowSVG: true,
     domains: [new URL(process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL).hostname],
   },
   async headers() {

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -27,12 +27,33 @@ export default function App({ Component, pageProps }) {
   return (
     <Intl>
       <Head>
-        <link rel="icon" href={`${basePath}/favicon.ico`} />
-        <link rel="apple-touch-icon" sizes="180x180" href={`${basePath}/apple-touch-icon.png`} />
-        <link rel="icon" type="image/png" sizes="32x32" href={`${basePath}/favicon-32x32.png`} />
-        <link rel="icon" type="image/png" sizes="16x16" href={`${basePath}/favicon-16x16.png`} />
+        <link
+          rel="icon"
+          href={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || `${basePath}/favicon.ico`}
+        />
+        <link
+          rel="apple-touch-icon"
+          sizes="180x180"
+          href={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || `${basePath}/apple-touch-icon.png`}
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="32x32"
+          href={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || `${basePath}/favicon-32x32.png`}
+        />
+        <link
+          rel="icon"
+          type="image/png"
+          sizes="16x16"
+          href={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || `${basePath}/favicon-16x16.png`}
+        />
         <link rel="manifest" href={`${basePath}/site.webmanifest`} />
-        <link rel="mask-icon" href={`${basePath}/safari-pinned-tab.svg`} color="#5bbad5" />
+        <link
+          rel="mask-icon"
+          href={process.env.NEXT_PUBLIC_CUSTOM_LOGO_URL || `${basePath}/safari-pinned-tab.svg`}
+          color="#5bbad5"
+        />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#2f2f2f" media="(prefers-color-scheme: dark)" />

--- a/public/intl/messages/de-DE.json
+++ b/public/intl/messages/de-DE.json
@@ -582,7 +582,7 @@
   "message.powered-by": [
     {
       "type": 0,
-      "value": "Betrieben durch "
+      "value": "Powered by "
     },
     {
       "type": 1,


### PR DESCRIPTION
In this Feature I´ve added the ability to change the branding of umami. The "Powered by" branding is not affected by this config vars.

Added ENV-Vars:
- NEXT_PUBLIC_CUSTOM_LOGO_URL (Custom Logo for the Login-Page, Header and EmptyPlaceholder)
- NEXT_PUBLIC_CUSTOM_HOMEPAGE_URL (Custom Homepage Url for the Shared-Pages)
-  NEXT_PUBLIC_CUSTOM_TITLE (Custom Website Title)
- NEXT_PUBLIC_CUSTOM_FAVICON_URL (Custom Favicon)

ToDo:
- Maybe add a better support for svg images as Custom Logos. Currently it is working but the styles didn´t get applied to the next/Image component
- Maybe add more options for the Custom Favicon. Currently the same image will be used for every meta tag in the WebsiteHeader.