### PR TITLE
custom fr-FR date format

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -198,6 +198,11 @@ export const customFormats = {
     p: 'ha',
     pp: 'h:mm:ss',
   },
+  'fr-FR': {
+    'M/d': 'd/M',
+    'MMM d': 'd MMM',
+    'EEE M/d': 'EEE d/M',
+  },
 };
 
 export function dateFormat(date, str, locale = 'en-US') {


### PR DESCRIPTION
In some views, BarChart shows uncommon date formats for France in fr-FR locale (day month order).
This PR sets the appropriate formats.

By the way, nice to see where Umami is heading👍