### PR TITLE
Disable tracking if file is local/localhost

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -7,7 +7,7 @@
     document,
     history,
   } = window;
-  const { hostname, pathname, search } = location;
+  const { hostname, pathname, search, protocol } = location;
   const { currentScript } = document;
 
   if (!currentScript) return;
@@ -45,7 +45,8 @@
   const trackingDisabled = () =>
     (localStorage && localStorage.getItem('umami.disabled')) ||
     (dnt && doNotTrack()) ||
-    (domain && !domains.includes(hostname));
+    (domain && !domains.includes(hostname)) ||
+    (/^localhost$|^127(\.[0-9]+){0,2}\.[0-9]+$|^\[::1?\]$/.test(hostname) || protocol === 'file:');
 
   const _data = 'data-';
   const _false = 'false';


### PR DESCRIPTION
If the requested resource is from a localhost URL or a file, Umami will disable tracking entirely. This adds a meager 118 bytes to the file size and is very important for a testing environment, I know I personally don't wan't Umami tracking my localhost hits.