### PR TITLE
Make timezone and unit optional

### DIFF
--- a/pages/api/websites/[id]/events.js
+++ b/pages/api/websites/[id]/events.js
@@ -18,7 +18,7 @@ export default async (req, res) => {
 
     const { id: websiteId, start_at, end_at, unit, tz, url, event_name } = req.query;
 
-    if (!moment.tz.zone(tz) || !unitTypes.includes(unit)) {
+    if ((tz && !moment.tz.zone(tz)) || (unit && !unitTypes.includes(unit))) {
       return badRequest(res);
     }
     const startDate = new Date(+start_at);

--- a/pages/api/websites/[id]/pageviews.js
+++ b/pages/api/websites/[id]/pageviews.js
@@ -33,7 +33,7 @@ export default async (req, res) => {
     const startDate = new Date(+start_at);
     const endDate = new Date(+end_at);
 
-    if (!moment.tz.zone(tz) || !unitTypes.includes(unit)) {
+    if ((tz && !moment.tz.zone(tz)) || (unit && !unitTypes.includes(unit))) {
       return badRequest(res);
     }
 


### PR DESCRIPTION
On the `getEventMetrics` and `getPageviewStats` functions, `timezone` and `unit` has default values. So these fields should be validated only if it is present on the API call.