### PR TITLE
Updates to th-TH translation

### DIFF
--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -64,7 +64,7 @@
   "label.websites": "เว็บไซต์",
   "message.active-users": "มีผู้ใช้งาน {x} {x, plural, one {คนในขณะนี้} other {คนในขณะนี้}}",
   "message.confirm-delete": "คุณแน่ใจหรือไม่ว่าต้องการลบ {target} ?",
-  "message.confirm-reset": "คุณแน่ใจหรือไม่ว่าต้องการรีเซตข้อมูลสถิติของ {target} ?",
+  "message.confirm-reset": "คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตข้อมูลสถิติของ {target} ?",
   "message.copied": "คัดลอกแล้ว!",
   "message.delete-warning": "ข้อมูลที่เกี่ยวข้องทั้งหมดจะถูกลบ.",
   "message.edit-dashboard": "Edit dashboard",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -64,6 +64,7 @@
   "label.username": "ชื่อผู้ใช้",
   "label.view-details": "แสดงรายละเอียด",
   "label.websites": "เว็บไซต์",
+  "label.yesterday": "เมื่อวาน",
   "message.active-users": "มีผู้ใช้งาน {x} {x, plural, one {คนในขณะนี้} other {คนในขณะนี้}}",
   "message.confirm-delete": "คุณแน่ใจหรือไม่ว่าต้องการลบ {target} ?",
   "message.confirm-reset": "คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตข้อมูลสถิติของ {target} ?",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -44,7 +44,7 @@
   "label.realtime": "เรียลไทม์",
   "label.realtime-logs": "Log แบบเรียลไทม์",
   "label.refresh": "รีเฟรช",
-  "label.required": "ต้องการ",
+  "label.required": "จำเป็น",
   "label.reset": "รีเซต",
   "label.reset-website": "รีเซตข้อมูลสถิติ",
   "label.save": "บันทึก",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -1,6 +1,7 @@
 {
   "label.accounts": "บัญชี",
   "label.add-account": "เพิ่มบัญชี",
+  "label.add-filter": "สร้างตัวกรอง",
   "label.add-website": "เพิ่มเว็บไซต์",
   "label.administrator": "ผู้ดูแลระบบ",
   "label.all": "ทั้งหมด",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -103,7 +103,7 @@
   "metrics.operating-systems": "ระบบปฏิบัติการ",
   "metrics.page-views": "การเข้าชม",
   "metrics.pages": "หน้าเพจ",
-  "metrics.query-parameters": "Query parameters",
+  "metrics.query-parameters": "พารามิเตอร์ URL",
   "metrics.referrers": "แหล่งที่มา",
   "metrics.screens": "ขนาดหน้าจอ",
   "metrics.unique-visitors": "ผู้เข้าชม",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -67,7 +67,7 @@
   "message.confirm-reset": "คุณแน่ใจหรือไม่ว่าต้องการรีเซ็ตข้อมูลสถิติของ {target} ?",
   "message.copied": "คัดลอกแล้ว!",
   "message.delete-warning": "ข้อมูลที่เกี่ยวข้องทั้งหมดจะถูกลบ.",
-  "message.edit-dashboard": "Edit dashboard",
+  "message.edit-dashboard": "แก้ไขแดชบอร์ด",
   "message.failure": "เกิดข้อผิดพลาด.",
   "message.get-share-url": "รับลิงก์สำหรับแชร์",
   "message.get-tracking-code": "รับโค้ดสำหรับใช้ติดตาม",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -50,6 +50,7 @@
   "label.reset": "รีเซต",
   "label.reset-website": "รีเซตข้อมูลสถิติ",
   "label.save": "บันทึก",
+  "label.search": "ค้นหา",
   "label.settings": "ตั้งค่า",
   "label.share-url": "แชร์ลิงก์",
   "label.single-day": "วันที่",

--- a/lang/th-TH.json
+++ b/lang/th-TH.json
@@ -1,6 +1,7 @@
 {
   "label.accounts": "บัญชี",
   "label.add-account": "เพิ่มบัญชี",
+  "label.add-column": "สร้างคอลัมน์",
   "label.add-filter": "สร้างตัวกรอง",
   "label.add-website": "เพิ่มเว็บไซต์",
   "label.administrator": "ผู้ดูแลระบบ",


### PR DESCRIPTION
This PR modifies 2 of the Thai translations, and adds 6 more. As I'm not a native speaker, I've provided justification in each of the commit notes unless it's a common word (eg. Yesterday). All translations have been run past two native speakers for accuracy and typos, one native speaker is familiar with tech jargon.

Remaining to translate are:
1. label.event-data
2. label.field-name
3. label.type
4. label.value

I've found the interface where these are used, and spent a few minutes playing around, but I can't work it out and documentation doesn't seem to exist for it yet.