### PR TITLE
Adding registered_country fallback to getCountry

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -73,7 +73,8 @@ export async function getCountry(req, ip) {
 
   const result = lookup.get(ip);
 
-  return result?.country?.iso_code;
+  // country can not be set, fallback to registerd_country in this case
+  return result?.country?.iso_code ?? result?.registered_country?.iso_code;
 }
 
 export async function getClientInfo(req, { screen }) {


### PR DESCRIPTION
In some cases the Country object is not returned.
This adds a fallback of the Registered Country object in case this occurs.

Resolves #1744 