### PR TITLE
Stylized macOS + sorted Desktop & Mobile OS names

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -83,29 +83,29 @@ export const URL_LENGTH = 500;
 export const EVENT_NAME_LENGTH = 50;
 
 export const DESKTOP_OS = [
-  'Windows 3.11',
-  'Windows 95',
-  'Windows 98',
+  'BeOS',
+  'Chrome OS',
+  'Linux',
+  'macOS',
+  'Open BSD',
+  'OS/2',
+  'QNX',
+  'Sun OS',
+  'Windows 10',
   'Windows 2000',
-  'Windows XP',
-  'Windows Server 2003',
-  'Windows Vista',
+  'Windows 3.11',
   'Windows 7',
   'Windows 8',
   'Windows 8.1',
-  'Windows 10',
+  'Windows 95',
+  'Windows 98',
   'Windows ME',
-  'Open BSD',
-  'Sun OS',
-  'Linux',
-  'Mac OS',
-  'QNX',
-  'BeOS',
-  'OS/2',
-  'Chrome OS',
+  'Windows Server 2003',
+  'Windows Vista',
+  'Windows XP',
 ];
 
-export const MOBILE_OS = ['iOS', 'Android OS', 'BlackBerry OS', 'Windows Mobile', 'Amazon OS'];
+export const MOBILE_OS = ['Amazon OS', 'Android OS', 'BlackBerry OS', 'iOS', 'Windows Mobile'];
 
 export const BROWSERS = {
   aol: 'AOL',


### PR DESCRIPTION
Since iOS was stylized, I thought it was consistent if we also stylized macOS (it's not Mac OS anymore, it's (macOS)[https://en.wikipedia.org/wiki/MacOS]). 

Also took a quick moment to sort the values for Desktop and Mobile OS names in order to more easily locate at a glance the item being looked for.

Happy to remove the sorting if it breaks anything though as long as we can keep macOS instead of Mac OS.