### PR TITLE
Upgrade Postgres to 15

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - db
     restart: always
   db:
-    image: postgres:12-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_DB: umami
       POSTGRES_USER: umami


### PR DESCRIPTION
I know, there is no plug and play when it comes to migrating postgres databases, but new users shouldnt have to start with an old version. I tested 15 and it works pretty fine 👍 

Migration steps:
``` bash
docker-compose exec db pg_dump -h localhost -U umami umami > umami.sql #create db-dump
docker-compose down #stop all containers
#replace image to postgres:15-alpine,you should use a new volume and start with an empty cluster
docker-compose pull 
docker-compose up -d db #start only the database
docker-compose exec db dropdb -h localhost -U umami umami #drop the existing (empty) database
docker-compose exec db createdb -h localhost -U umami umami #create a new database
docker-compose exec -T db psql -h localhost -U umami umami < umami.sql #import your old dump
docker-compose up -d #start the other containers
```
and you are ready to roll 🎉 