### PR TITLE
README: docker compose detach as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ or change the [port](https://nextjs.org/docs/api-reference/cli#production) to se
 To build the umami container and start up a Postgres database, run:
 
 ```bash
-docker compose up
+docker compose up -d
 ```
 
 Alternatively, to pull just the Umami Docker image with PostgreSQL support:


### PR DESCRIPTION
I think it would be best if we set the detach mode to default. 
I am still confused on how to quit the normal mode without killing the containers, as seen in here:
https://github.com/docker/compose/issues/4560


