### PR TITLE
Prevent indexing content by search engines

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -37,6 +37,7 @@ export default function App({ Component, pageProps }) {
         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
         <meta name="theme-color" content="#2f2f2f" media="(prefers-color-scheme: dark)" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex,nofollow" />
       </Head>
       <div className="container" dir={dir}>
         <Component {...pageProps} />


### PR DESCRIPTION
Search engines should not index `umami` pages because analytics insights is not something that a normal user should be aware of.