### PR TITLE
Prevent indexing content by search engines

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -52,6 +52,7 @@ export default function App({ Component, pageProps }) {
           <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
           <meta name="theme-color" content="#2f2f2f" media="(prefers-color-scheme: dark)" />
           <meta name="viewport" content="width=device-width, initial-scale=1" />
+          <meta name="robots" content="noindex,nofollow" />
         </Head>
         <Component {...pageProps} />
         {!pathname.includes('/share/') && <Script src={`${basePath}/telemetry.js`} />}


### PR DESCRIPTION
It seems that the changes of my former pull request https://github.com/umami-software/umami/pull/1883 got lost when `umami` `v2` was released recently. So I create the pull request again 🙂 

Search engines should not index umami pages because analytics insights is not something that a normal user should be aware of.