### PR TITLE
fix version sql on check_db.js

### DIFF
--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -50,7 +50,7 @@ async function checkConnection() {
 }
 
 async function checkDatabaseVersion(databaseType) {
-  const query = await prisma.$queryRaw`select version() version`;
+  const query = await prisma.$queryRaw`select version() as version`;
   const version = semver.valid(semver.coerce(query[0].version));
 
   const minVersion = databaseType === 'postgresql' ? '9.4.0' : '5.6.0';


### PR DESCRIPTION
The check_db.js script is breaking on postgresql due to a missing _as_ in the sql query.
Fixes #1903