### PR TITLE
fix: use new script name in update-tracker.js

### DIFF
--- a/scripts/update-tracker.js
+++ b/scripts/update-tracker.js
@@ -6,7 +6,7 @@ const path = require('path');
 const endPoint = process.env.COLLECT_API_ENDPOINT;
 
 if (endPoint) {
-  const file = path.resolve(__dirname, '../public/umami.js');
+  const file = path.resolve(__dirname, '../public/script.js');
 
   const tracker = fs.readFileSync(file);
 


### PR DESCRIPTION
fix #1905 