### PR TITLE
ensure some translations

### DIFF
--- a/components/pages/settings/teams/TeamSettings.js
+++ b/components/pages/settings/teams/TeamSettings.js
@@ -49,7 +49,7 @@ export default function TeamSettings({ teamId }) {
         title={
           <Breadcrumbs>
             <Item>
-              <Link href="/settings/teams">Teams</Link>
+              <Link href="/settings/teams">{formatMessage(labels.teams)}</Link>
             </Item>
             <Item>{values?.name}</Item>
           </Breadcrumbs>

--- a/components/pages/settings/users/UsersTable.js
+++ b/components/pages/settings/users/UsersTable.js
@@ -6,10 +6,12 @@ import UserDeleteForm from './UserDeleteForm';
 import { ROLES } from 'lib/constants';
 import useMessages from 'hooks/useMessages';
 import SettingsTable from 'components/common/SettingsTable';
+import useLocale from 'hooks/useLocale';
 
 export default function UsersTable({ data = [], onDelete }) {
   const { formatMessage, labels } = useMessages();
   const { user } = useUser();
+  const { dateLocale } = useLocale();
 
   const columns = [
     { name: 'username', label: formatMessage(labels.username), style: { flex: 1.5 } },
@@ -22,6 +24,7 @@ export default function UsersTable({ data = [], onDelete }) {
     if (key === 'created') {
       return formatDistance(new Date(row.createdAt), new Date(), {
         addSuffix: true,
+        locale: dateLocale,
       });
     }
     if (key === 'role') {

--- a/components/pages/settings/websites/WebsiteData.js
+++ b/components/pages/settings/websites/WebsiteData.js
@@ -34,7 +34,7 @@ export default function WebsiteData({ websiteId, onSave }) {
         description={formatMessage(messages.deleteWebsiteWarning)}
       >
         <ModalTrigger>
-          <Button variant="danger">Delete</Button>
+          <Button variant="danger">{formatMessage(labels.delete)}</Button>
           <Modal title={formatMessage(labels.deleteWebsite)}>
             {close => (
               <WebsiteDeleteForm websiteId={websiteId} onSave={handleDelete} onClose={close} />


### PR DESCRIPTION
Following strings were not localized, whereas their translation being available:
- "Teams" in the breadcrumb of a team settings page.
- "Delete" button in the data tab of a website settings page.
- Indication about the user creation date in the users page.