### PR TITLE
Adjusted tracking script to find parent a-tag for click tracking

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -112,13 +112,21 @@
     };
 
     const callback = e => {
+      const findATagParent = (rootElem, maxSearchDepth) => {
+        let currentElement = rootElem;
+        for (let i = 0; i < maxSearchDepth; i++) {
+          if (currentElement.tagName === 'A') 
+            return currentElement;
+          currentElement = currentElement.parentElement;
+        }
+        return null;
+      };
+
       const el = e.target;
       const anchor =
         el.tagName === 'A'
           ? el
-          : el.parentElement && el.parentElement.tagName === 'A'
-          ? el.parentElement
-          : null;
+          : findATagParent(el, 5);
 
       if (anchor) {
         const { href, target } = anchor;


### PR DESCRIPTION
Adjusts the tracking script to find a parent a-tag (currently up to a depth of five elements). This helps with click event tracking with elements like this:

```html
<a class="button is-outlined" 
    href="https://example.com"
    target="_blank" rel="noopener"
    data-umami-event="some event"
    data-umami-event-articleurl="some-article"
    data-umami-event-articlename="/some-article.html"
>
    <span class="icon-text">
        <span class="icon">
            <i class="fas fa-solid fa-envelope"></i>
        </span>
        <span>Send to example.com</span>
    </span>
</a>
``` 

Closes #1939 