### PR TITLE
fix some css for RTL

### DIFF
--- a/components/common/Favicon.module.css
+++ b/components/common/Favicon.module.css
@@ -1,3 +1,3 @@
 .favicon {
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }

--- a/components/common/FilterLink.module.css
+++ b/components/common/FilterLink.module.css
@@ -14,7 +14,7 @@
 
 .row .link {
   display: none;
-  margin-left: 20px;
+  margin-inline-start: 20px;
 }
 
 .row .label {

--- a/components/layout/Grid.module.css
+++ b/components/layout/Grid.module.css
@@ -10,16 +10,16 @@
 }
 
 .row > .col {
-  border-left: 1px solid var(--base300);
+  border-inline-start: 1px solid var(--base300);
 }
 
 .row > .col:first-child {
-  border-left: 0;
-  padding-left: 0;
+  border-inline-start: 0;
+  padding-inline-start: 0;
 }
 
 .row > .col:last-child {
-  padding-right: 0;
+  padding-inline-end: 0;
 }
 
 @media only screen and (max-width: 992px) {
@@ -29,7 +29,7 @@
 
   .row > .col {
     border-top: 1px solid var(--base300);
-    border-left: 0;
+    border-inline-end: 0;
     padding: 20px 0;
   }
 }

--- a/components/metrics/DataTable.module.css
+++ b/components/metrics/DataTable.module.css
@@ -68,8 +68,8 @@
 
 .value {
   width: 50px;
-  text-align: right;
-  margin-right: 10px;
+  text-align: end;
+  margin-inline-end: 10px;
   font-weight: 600;
   cursor: pointer;
 }
@@ -79,7 +79,7 @@
   width: 50px;
   color: var(--base600);
   border-left: 1px solid var(--base600);
-  padding-left: 10px;
+  padding-inline-start: 10px;
   z-index: 1;
 }
 

--- a/components/metrics/Legend.module.css
+++ b/components/metrics/Legend.module.css
@@ -13,7 +13,7 @@
 }
 
 .label + .label {
-  margin-left: 20px;
+  margin-inline-start: 20px;
 }
 
 .hidden {


### PR DESCRIPTION
some CSS fixes for RTL, I had to change some '*-left' to '*-inline-start' and for '*-inline-right: '-end'


## in chart legends:
 
Before:
<img width="259" alt="Screenshot 2023-04-20 at 9 04 00 PM" src="https://user-images.githubusercontent.com/1952412/233451780-8dff296f-dd71-4b46-a1c0-4863fea2eb26.png">

After:
<img width="271" alt="Screenshot 2023-04-20 at 9 03 50 PM" src="https://user-images.githubusercontent.com/1952412/233451835-d8b22fa8-120f-479d-8199-bb4531199f7d.png">

## in data table

Before:
<img width="990" alt="Screenshot 2023-04-20 at 8 59 43 PM" src="https://user-images.githubusercontent.com/1952412/233451966-a978f63c-ff7a-404d-92a3-f45901fa6cf5.png">

After:
<img width="1008" alt="Screenshot 2023-04-20 at 8 58 48 PM" src="https://user-images.githubusercontent.com/1952412/233452000-2b18e1c9-1da7-44f7-9187-cd94fe9ccc08.png">
