### PR TITLE
Fix "x-umami-cache: undefined"

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -162,11 +162,16 @@
 
   const send = payload => {
     if (trackingDisabled()) return;
-
+    const headers = {
+      'Content-Type': 'application/json'
+    };
+    if (typeof cache !== 'undefined') {
+      headers['x-umami-cache'] = cache;
+    }
     return fetch(endpoint, {
       method: 'POST',
       body: JSON.stringify({ type: 'event', payload }),
-      headers: { 'Content-Type': 'application/json', ['x-umami-cache']: cache },
+      headers: headers
     })
       .then(res => res.text())
       .then(text => (cache = text));


### PR DESCRIPTION
Do not send the x-umami-cache request header when the cache is not defined (the first request sent to the umami server when the visitor opens the page)