### PR TITLE
Fix for #1940: Add no parent null-check

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -119,6 +119,8 @@
             return currentElement;
           }
           currentElement = currentElement.parentElement;
+          if (currentElement === null) // if there is no parent element 
+            return null;
         }
         return null;
       };


### PR DESCRIPTION
This is a subsequent fix for MR #1940: The script throws exceptions, when there is no parent element (e.g. when clicking directly inside the body tag). This little fix makes sure that the method to find a parent a-tag stops when there is no parent element.