### PR TITLE
fix for #1940: check if there is no parent element

### DIFF
--- a/tracker/index.js
+++ b/tracker/index.js
@@ -119,6 +119,9 @@
             return currentElement;
           }
           currentElement = currentElement.parentElement;
+          if (currentElement === null) {
+            return null;
+          }
         }
         return null;
       };


### PR DESCRIPTION
The script throws exceptions, when there is no parent element (e.g. when clicking directly inside the body tag). This little fix makes sure that the method to find a parent a-tag return null when there is no parent element.

Error reporting example:
```
Uncaught TypeError: Cannot read properties of null (reading 'tagName')
    at script.js:1:2071
    at ...
```