### PR TITLE
delete a redundant volume mapping

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,6 @@ services:
       POSTGRES_USER: umami
       POSTGRES_PASSWORD: umami
     volumes:
-      - ./sql/schema.postgresql.sql:/docker-entrypoint-initdb.d/schema.postgresql.sql:ro
       - umami-db-data:/var/lib/postgresql/data
     restart: always
 volumes:


### PR DESCRIPTION
I'd like to propose to delete from docker-compose a redundant volume mapping. As I see that `sql` directory had been deleted and now umami-app is responsible for migration.