### PR TITLE
Fix undefined websiteId in dynamic realtime page api request.

### DIFF
--- a/pages/realtime/[id]/index.js
+++ b/pages/realtime/[id]/index.js
@@ -10,7 +10,7 @@ export default function RealtimeDetailsPage() {
   const { formatMessage, labels } = useMessages();
   const { get, useQuery } = useApi();
   const { data: website } = useQuery(['websites', websiteId], () =>
-    get(`/websites/${websiteId}`, { enabled: !!websiteId }),
+    websiteId ? get(`/websites/${websiteId}`, { enabled: !!websiteId }) : null,
   );
   const title = `${formatMessage(labels.realtime)}${website?.name ? ` - ${website.name}` : ''}`;
 


### PR DESCRIPTION
Thought I'd create a PR with my fix from yesterday #1999

When viewing the network requests on the dynamic realtime page the api request url has undefined where the `websiteId` should be for the initial request. This is because it is initially undefined. To fix this I have simply used a ternary operator to check the `websiteId` exists before making the api request.