### PR TITLE
Roll back prisma to 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@fontsource/inter": "^4.5.15",
-    "@prisma/client": "4.13.0",
+    "@prisma/client": "4.9.0",
     "@tanstack/react-query": "^4.16.1",
     "@umami/prisma-client": "^0.2.0",
     "@umami/redis-client": "^0.2.0",
@@ -141,7 +141,7 @@
     "postcss-preset-env": "7.8.3",
     "postcss-rtlcss": "^4.0.1",
     "prettier": "^2.6.2",
-    "prisma": "4.13.0",
+    "prisma": "4.9.0",
     "prompts": "2.4.2",
     "rollup": "^2.70.1",
     "rollup-plugin-delete": "^2.0.0",


### PR DESCRIPTION
Fix for https://github.com/umami-software/umami/issues/1865