### PR TITLE
Fix: `BarChar` to correctly show year instead of epoch when unit is year

### DIFF
--- a/components/metrics/BarChart.js
+++ b/components/metrics/BarChart.js
@@ -52,6 +52,8 @@ export function BarChart({
           return dateFormat(d, 'MMM d', locale);
         case 'month':
           return dateFormat(d, 'MMM', locale);
+        case 'year':
+          return dateFormat(d, 'YYY', locale);
         default:
           return label;
       }


### PR DESCRIPTION
## Bug

The bar chart graph for both page views and events was showing the epoch instead of the year when selecting "All time" as a date filter option.

## Problem

The `switch` statement inside `BarChart` component was missing a `case` for `unit === 'year'`, the value that `unit` evaluates to when selecting "All time" in the `DateFilter`. That was generating the epoch value to be rendering instead of the year value, which is the expected.

## Fix

Just add the missing `case` 😉 

## Before

The bug was affecting both page view bar charts and events bar charts.

<img width="1145" alt="Captura de pantalla 2023-05-16 a las 20 49 13" src="https://github.com/umami-software/umami/assets/14878189/5bbbd86c-14a4-4522-8c04-71d89abac0a7">
<img width="747" alt="Captura de pantalla 2023-05-16 a las 20 47 45" src="https://github.com/umami-software/umami/assets/14878189/430b614b-faaf-4a3f-b805-9600e16af404">

## After

<img width="1137" alt="Captura de pantalla 2023-05-16 a las 20 51 35" src="https://github.com/umami-software/umami/assets/14878189/9c4eef98-d0c4-45f8-be35-f51922c35695">
<img width="729" alt="Captura de pantalla 2023-05-16 a las 20 51 41" src="https://github.com/umami-software/umami/assets/14878189/778fd121-b701-4dc7-b2ea-42e0db72345f">