### PR TITLE
chore(tracker): :label: could not use `string` in `EventData`

### DIFF
--- a/tracker/index.d.ts
+++ b/tracker/index.d.ts
@@ -1,4 +1,4 @@
-type TrackedProperties = {
+export type TrackedProperties = {
   /**
    * Hostname of server
    *
@@ -55,7 +55,7 @@ type TrackedProperties = {
   website: string;
 };
 
-type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
 
 /**
  *
@@ -65,74 +65,89 @@ type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] }
  * - Arrays are converted to a String, with the same max length of 500.
  * - Objects have a max of 50 properties. Arrays are considered 1 property.
  */
-type EventData = Record<string, object>;
-type EventProperties = {
+export interface EventData {
+  [key: string]: number | string | EventData | number[] | string[] | EventData[];
+}
+
+export type EventProperties = {
+  /**
+   * NOTE: event names will be truncated past 50 characters
+   */
   name: string;
   data?: EventData;
-} & WithRequired<TrackedProperties, 'website'>
-| WithRequired<TrackedProperties, 'website'>;
+} & WithRequired<TrackedProperties, 'website'>;
+export type PageViewProperties = WithRequired<TrackedProperties, 'website'>;
+export type CustomEventFunction = (
+  props: PageViewProperties,
+) => EventProperties | PageViewProperties;
+
+export type UmamiTracker = {
+  track: {
+    /**
+     * Track a page view
+     *
+     * @example ```
+     * umami.track();
+     * ```
+     */
+    (): Promise<string>;
+
+    /**
+     * Track an event with a given name
+     *
+     * NOTE: event names will be truncated past 50 characters
+     *
+     * @example ```
+     * umami.track('signup-button');
+     * ```
+     */
+    (eventName: string): Promise<string>;
+
+    /**
+     * Tracks an event with dynamic data.
+     *
+     * NOTE: event names will be truncated past 50 characters
+     *
+     * When tracking events, the default properties are included in the payload. This is equivalent to running:
+     *
+     * ```js
+     * umami.track(props => ({
+     *   ...props,
+     *   name: 'signup-button',
+     *   data: {
+     *     name: 'newsletter',
+     *     id: 123
+     *   }
+     * }));
+     * ```
+     *
+     * @example ```
+     * umami.track('signup-button', { name: 'newsletter', id: 123 });
+     * ```
+     */
+    (eventName: string, obj: EventData): Promise<string>;
+
+    /**
+     * Tracks a page view with custom properties
+     *
+     * @example ```
+     * umami.track({ website: 'e676c9b4-11e4-4ef1-a4d7-87001773e9f2', url: '/home', title: 'Home page' });
+     * ```
+     */
+    (properties: PageViewProperties): Promise<string>;
+
+    /**
+     * Tracks an event with fully customizable dynamic data
+     * Ilf you don't specify any `name` and/or `data`, it will be treated as a page view
+     *
+     * @example ```
+     * umami.track((props) => ({ ...props, url: path }));
+     * ```
+     */
+    (eventFunction: CustomEventFunction): Promise<string>;
+  };
+};
 
 interface Window {
-  umami: {
-    track: {
-      /**
-       * Track a page view
-       *
-       * @example ```
-       * umami.track();
-       * ```
-       */
-      (): Promise<string>;
-
-      /**
-       * Track an event with a given name
-       *
-       * @example ```
-       * umami.track('signup-button');
-       * ```
-       */
-      (eventName: string): Promise<string>;
-
-      /**
-       * Tracks an event with dynamic data.
-       *
-       * When tracking events, the default properties are included in the payload. This is equivalent to running:
-       *
-       * ```js
-       * umami.track(props => ({
-       *   ...props,
-       *   name: 'signup-button',
-       *   data: {
-       *     name: 'newsletter',
-       *     id: 123
-       *   }
-       * }));
-       * ```
-       *
-       * @example ```
-       * umami.track('signup-button', { name: 'newsletter', id: 123 });
-       * ```
-       */
-      (eventName: string, obj: EventData): Promise<string>;
-
-      /**
-       * Tracks a page view with custom properties
-       *
-       * @example ```
-       * umami.track({ website: 'e676c9b4-11e4-4ef1-a4d7-87001773e9f2', url: '/home', title: 'Home page' });
-       * ```
-       */
-      (properties: WithRequired<Partial<TrackedProperties>, 'website'>): Promise<string>;
-
-      /**
-       * Tracks an event with fully customizable dynamic data
-       * Ilf you don't specify any `name` and/or `data`, it will be treated as a page view
-       *
-       * @example ```
-       * umami.track((props) => ({ ...props, url: path }));
-       * ```
-       */
-      (eventFunction: (prop: TrackedProperties) => EventProperties): Promise<string>;
-    };
-  };
+  umami: UmamiTracker;
 }


### PR DESCRIPTION
- EventData was incorrectly typed `Record<string, object>` which did not allow for the most common `string` attribute
- UmamiTracker is now exported to be used elsewhere if needed
- A note has been added on event names being truncated to 50 characters