### PR TITLE
Bring back none referrers in self hosted

### DIFF
--- a/queries/analytics/pageview/getPageviewMetrics.ts
+++ b/queries/analytics/pageview/getPageviewMetrics.ts
@@ -45,7 +45,7 @@ async function relationalQuery(
   let excludeDomain = '';
 
   if (column === 'referrer_domain') {
-    excludeDomain = 'and website_event.referrer_domain != $6';
+    excludeDomain = 'and (website_event.referrer_domain != $6 or website_event.referrer_domain is null)';
     params.push(website.domain);
   }
 


### PR DESCRIPTION
Fix #2076 
Value comparisons exclude null entries on MySQL and PostgreSQL
(No issue in Cloud, none referrers were still showed)