### PR TITLE
Fix: Bring back new release message

### DIFF
--- a/components/messages.js
+++ b/components/messages.js
@@ -270,4 +270,8 @@ export const messages = defineMessages({
     id: 'message.no-event-data',
     defaultMessage: 'No event data is available.',
   },
+  newVersionAvailable: {
+    id: 'new-version-available',
+    defaultMessage: 'A new version of Umami {version} is available!',
+  },
 });


### PR DESCRIPTION
- app crash, it says [@formatjs/intl] An id must be provided to format a message.
- issue reference - https://github.com/umami-software/umami/issues/2113