### PR TITLE
Fixes #2124

### DIFF
--- a/pages/api/config.ts
+++ b/pages/api/config.ts
@@ -14,7 +14,7 @@ export default async (req: NextApiRequest, res: NextApiResponse<ConfigResponse>)
     return ok(res, {
       basePath: process.env.BASE_PATH || '',
       trackerScriptName: process.env.TRACKER_SCRIPT_NAME,
-      updatesDisabled: !!process.env.DISABLE_UPDATES,
+      updatesDisabled: process.env?.DISABLE_UPDATES === 'true' ? true : false,
       telemetryDisabled: !!process.env.DISABLE_TELEMETRY,
       cloudMode: !!process.env.CLOUD_MODE,
     });


### PR DESCRIPTION
Disable update checks when DISABLE_UPDATES is not set

For some reason, the values of the `.env` file seem to be parsed as strings, so something like `DISABLE_UPDATES=false` will always get evaluated as `true`, given the previous config method that is, `!!process.env?.DISABLE_UPDATES`.
My solution seems to fix it.