### PR TITLE
Feat: Add default_lang enviroment variable

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,7 +13,7 @@ export const REPO_URL = 'https://github.com/umami-software/umami';
 export const UPDATES_URL = 'https://api.umami.is/v1/updates';
 export const TELEMETRY_PIXEL = 'https://i.umami.is/a.png';
 
-export const DEFAULT_LOCALE = 'en-US';
+export const DEFAULT_LOCALE = process.env.defaultLang ?? 'en-US';
 export const DEFAULT_THEME = 'light';
 export const DEFAULT_ANIMATION_DURATION = 300;
 export const DEFAULT_DATE_RANGE = '24hour';

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,7 +13,7 @@ export const REPO_URL = 'https://github.com/umami-software/umami';
 export const UPDATES_URL = 'https://api.umami.is/v1/updates';
 export const TELEMETRY_PIXEL = 'https://i.umami.is/a.png';
 
-export const DEFAULT_LOCALE = process.env.defaultLang ?? 'en-US';
+export const DEFAULT_LOCALE = process.env.defaultLocale ?? 'en-US';
 export const DEFAULT_THEME = 'light';
 export const DEFAULT_ANIMATION_DURATION = 300;
 export const DEFAULT_DATE_RANGE = '24hour';

--- a/next.config.js
+++ b/next.config.js
@@ -74,7 +74,7 @@ if (process.env.CLOUD_MODE && process.env.CLOUD_URL && process.env.DISABLE_LOGIN
 const config = {
   env: {
     currentVersion: pkg.version,
-    defaultLang: process.env.DEFAULT_LANG,
+    defaultLocale: process.env.DEFAULT_LOCALE,
     isProduction: process.env.NODE_ENV === 'production',
   },
   basePath: process.env.BASE_PATH,

--- a/next.config.js
+++ b/next.config.js
@@ -74,6 +74,7 @@ if (process.env.CLOUD_MODE && process.env.CLOUD_URL && process.env.DISABLE_LOGIN
 const config = {
   env: {
     currentVersion: pkg.version,
+    defaultLang: process.env.DEFAULT_LANG,
     isProduction: process.env.NODE_ENV === 'production',
   },
   basePath: process.env.BASE_PATH,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "umami",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A simple, fast, privacy-focused alternative to Google Analytics.",
   "author": "Mike Cao <mike@mikecao.com>",
   "license": "MIT",


### PR DESCRIPTION
This update allows defining a default language in the .env file, so that it will be used when the user has not yet selected the preferred language.

Example: DEFAULT_LANG=pt-BR

Note: When performing the update, it is necessary to run the commands

1. yarm build
2. pm2 restart <id> --update-env

If this PR is accepted, it is necessary to add the new option .env -> DEFAULT_LANG in the documentation