### PR TITLE
To resolve the runtime error:warn  - "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -78,7 +78,6 @@ const config = {
     isProduction: process.env.NODE_ENV === 'production',
   },
   basePath: process.env.BASE_PATH,
-  output: 'standalone',
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
To resolve the runtime error:warn  - "next start" does not work with "output: standalone" configuration. Use "node .next/standalone/server.js" instead.