### PR TITLE
Fix chart with a single day custom range

### DIFF
--- a/src/components/input/MonthSelect.js
+++ b/src/components/input/MonthSelect.js
@@ -12,11 +12,10 @@ import { startOfMonth, endOfMonth } from 'date-fns';
 import Icons from 'components/icons';
 import { useLocale } from 'components/hooks';
 import { formatDate } from 'lib/date';
-import { getDateLocale } from 'lib/lang';
 import styles from './MonthSelect.module.css';
 
 export function MonthSelect({ date = new Date(), onChange }) {
-  const { locale } = useLocale();
+  const { locale, dateLocale } = useLocale();
   const month = formatDate(date, 'MMMM', locale);
   const year = date.getFullYear();
   const ref = useRef();
@@ -40,7 +39,7 @@ export function MonthSelect({ date = new Date(), onChange }) {
             {close => (
               <CalendarMonthSelect
                 date={date}
-                locale={getDateLocale(locale)}
+                locale={dateLocale}
                 onSelect={handleChange.bind(null, close)}
               />
             )}
@@ -57,7 +56,7 @@ export function MonthSelect({ date = new Date(), onChange }) {
             {close => (
               <CalendarYearSelect
                 date={date}
-                locale={getDateLocale(locale)}
+                locale={dateLocale}
                 onSelect={handleChange.bind(null, close)}
               />
             )}

--- a/src/components/metrics/DatePickerForm.js
+++ b/src/components/metrics/DatePickerForm.js
@@ -50,6 +50,7 @@ export function DatePickerForm({
             date={singleDate}
             minDate={minDate}
             maxDate={maxDate}
+            locale={dateLocale}
             onChange={setSingleDate}
           />
         )}

--- a/src/components/metrics/DatePickerForm.js
+++ b/src/components/metrics/DatePickerForm.js
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Button, ButtonGroup, Calendar } from 'react-basics';
-import { isAfter, isBefore, isSameDay } from 'date-fns';
+import { isAfter, isBefore, isSameDay, startOfDay, endOfDay } from 'date-fns';
 import useLocale from 'components/hooks/useLocale';
 import { getDateLocale } from 'lib/lang';
 import { FILTER_DAY, FILTER_RANGE } from 'lib/constants';
@@ -31,9 +31,9 @@ export function DatePickerForm({
 
   const handleSave = () => {
     if (selected === FILTER_DAY) {
-      onChange(`range:${singleDate.getTime()}:${singleDate.getTime()}`);
+      onChange(`range:${startOfDay(singleDate).getTime()}:${endOfDay(singleDate).getTime()}`);
     } else {
-      onChange(`range:${startDate.getTime()}:${endDate.getTime()}`);
+      onChange(`range:${startOfDay(startDate).getTime()}:${endOfDay(endDate).getTime()}`);
     }
   };
 

--- a/src/components/metrics/DatePickerForm.js
+++ b/src/components/metrics/DatePickerForm.js
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { Button, ButtonGroup, Calendar } from 'react-basics';
 import { isAfter, isBefore, isSameDay, startOfDay, endOfDay } from 'date-fns';
 import useLocale from 'components/hooks/useLocale';
-import { getDateLocale } from 'lib/lang';
 import { FILTER_DAY, FILTER_RANGE } from 'lib/constants';
 import useMessages from 'components/hooks/useMessages';
 import styles from './DatePickerForm.module.css';
@@ -21,7 +20,7 @@ export function DatePickerForm({
   const [singleDate, setSingleDate] = useState(defaultStartDate);
   const [startDate, setStartDate] = useState(defaultStartDate);
   const [endDate, setEndDate] = useState(defaultEndDate);
-  const { locale } = useLocale();
+  const { dateLocale } = useLocale();
   const { formatMessage, labels } = useMessages();
 
   const disabled =
@@ -60,14 +59,14 @@ export function DatePickerForm({
               date={startDate}
               minDate={minDate}
               maxDate={endDate}
-              locale={getDateLocale(locale)}
+              locale={dateLocale}
               onChange={setStartDate}
             />
             <Calendar
               date={endDate}
               minDate={startDate}
               maxDate={maxDate}
-              locale={getDateLocale(locale)}
+              locale={dateLocale}
               onChange={setEndDate}
             />
           </>

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -78,7 +78,9 @@ export function parseDateRange(value, locale = 'en-US') {
     const endDate = new Date(+endTime);
 
     return {
-      ...getDateRangeValues(startDate, endDate),
+      startDate,
+      endDate,
+      unit: getMinimumUnit(startDate, endDate),
       value,
     };
   }
@@ -253,14 +255,6 @@ export function getMinimumUnit(startDate, endDate) {
   }
 
   return 'year';
-}
-
-export function getDateRangeValues(startDate, endDate) {
-  return {
-    startDate: startOfDay(startDate),
-    endDate: endOfDay(endDate),
-    unit: getMinimumUnit(startDate, endDate),
-  };
 }
 
 export function getDateFromString(str) {


### PR DESCRIPTION
Chart is currently broken using single day custom range:
![chart](https://github.com/umami-software/umami/assets/12450219/c5d16a61-52b0-478b-9026-da5c837dd2cb)

`getMinimumUnit` is called with two same dates, hence a 0 minutes difference is computed between the two and 'minute' is returned.

This PR handles this at the root cause (date picker)
and lets range date parser be an exact parser between two dates.

It also adds localization to the single day calendar and leverages already set dateLocale.