### PR TITLE
fix: :bug: gulp error so that error in sending data does not affect the action triggering it

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -187,7 +187,8 @@
       headers,
     })
       .then(res => res.text())
-      .then(text => (cache = text));
+      .then(text => (cache = text))
+      .catch(() => {}); // no-op, gulp error
   };
 
   const track = (obj, data) => {


### PR DESCRIPTION
Basically right now if there are any ad blockers blocking umami scripts and actions, if the website consumer has hooked in umami events on link clicks, those are failing because the send action is not catching the error, so it blocks the link redirection action as well.

By gulping the error, it should not affect the user's action if for any reason analytics send event fails.