### PR TITLE
Corrected and Updated start-env script

### DIFF
--- a/scripts/start-env.js
+++ b/scripts/start-env.js
@@ -1,4 +1,8 @@
 require('dotenv').config();
 const cli = require('next/dist/cli/next-start');
 
-cli.nextStart(['-p', process.env.PORT || 3000, '-H', process.env.HOSTNAME || '0.0.0.0']);
+cli.nextStart({
+  '--port': process.env.PORT || 3000,
+  '--hostname': process.env.HOSTNAME || '0.0.0.0',
+  _: [],
+});


### PR DESCRIPTION
Related to issue #2308 

Update on `./scripts/start-env.js` [ not working anymore because of an undefined `_` property in object passed in `cli.nextStart` : 


Before

```
require('dotenv').config();
const cli = require('next/dist/cli/next-start');

cli.nextStart(['-p', process.env.PORT || 3000, '-H', process.env.HOSTNAME || '0.0.0.0']);
```

After

```
require('dotenv').config();
const cli = require('next/dist/cli/next-start');

cli.nextStart({
  '--port': process.env.PORT || 3000,
  '--hostname': process.env.HOSTNAME || '0.0.0.0',
  _: [],
});
```
