### PR TITLE
Support wildcard filters

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -92,6 +92,7 @@ export const OPERATORS = {
   lessThanEquals: 'lte',
   before: 'bf',
   after: 'af',
+  like: 'like',
 } as const;
 
 export const DATA_TYPES = {

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -98,6 +98,8 @@ function mapFilter(column, operator, name, type = 'varchar') {
       return `${column} = {{${name}::${type}}}`;
     case OPERATORS.notEquals:
       return `${column} != {{${name}::${type}}}`;
+    case OPERATORS.like:
+      return `${column} LIKE {{${name}::${type}}}`;
     default:
       return '';
   }

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -112,6 +112,14 @@ function getFilterQuery(filters: QueryFilters = {}, options: QueryOptions = {}):
     const column = FILTER_COLUMNS[name] ?? options?.columns?.[name];
 
     if (value !== undefined && column) {
+      if (value?.value) {
+        if (typeof value.value === 'string' && value.value.indexOf('*') > -1) {
+          // If input contains *, convert to a LIKE
+          value.value = value.value.replace(/%/, '\\%').replace('*', '%');
+          value.filter = OPERATORS.like;
+        }
+      }
+
       arr.push(`and ${mapFilter(column, operator, name)}`);
 
       if (name === 'referrer') {


### PR DESCRIPTION
I'm offering this here for discussion, as [requested by @MariusVB](https://github.com/artfulrobot/umami/commit/2257ad7b709d39d2dba1478f5c1c0f1ccd0a44d3#commitcomment-130956299); not as a "please merge this now". If it's unhelpful, please just close. There's a lot I don't know about this project.

There's 2 commits, neither is tested.

1. 4389fd72c2b751862482a47dc9fa16bd03ae5821 Support the LIKE operator. This seems like it might be a way to offer a LIKE operator at the query level. It doesn't expose it in the UI, but perhaps it means there's a way to manually construct a URL, which might enable the feature for technically capable types who just need the feature in a hurry for certain reports. This code *might* work, and it *might* be simple enough to add LIKE to the UI.

2. 5b7e38234791f2ebbc44d1811c63260e50f8c06c Support automatically using the LIKE operator (as opposed to equals) if the input contains `*` character(s). This commit is likely highly contentious, and probably not what is wanted long term, if at all! It might not work anyway; I'm not sure how mutable the filters object is.

