### PR TITLE
Solve issue : #2358

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -194,7 +194,7 @@ export function incrementDateRange(value, increment) {
 
   const { num, unit } = selectedUnit;
 
-  const sub = num * increment;
+  const sub = Math.abs(num) * increment;
 
   switch (unit) {
     case 'hour':


### PR DESCRIPTION
_(This is my first pull request ever, I hope I don't do anything stupid!)_

This is my proposal to correct the issue #2358.

Here is my approach : the "Yesterday" label is only one who have negative `value`, and this negative `value` interfer with the `incrementDateRange` function, so I use Math.abs to transform the negative to positive `value`, and now the -1 / +1 buttons seems to be correct, for every ranges.