### PR TITLE
Ensure country in region code

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -107,11 +107,16 @@ export async function getLocation(ip, req) {
   const result = lookup.get(ip);
 
   if (result) {
+    const country = result.country?.iso_code ?? result?.registered_country?.iso_code;
+    const subdivision1 = result.subdivisions?.[0]?.iso_code;
+    const subdivision2 = result.subdivisions?.[1]?.names?.en;
+    const city = result.city?.names?.en;
+
     return {
-      country: result.country?.iso_code ?? result?.registered_country?.iso_code,
-      subdivision1: result.subdivisions?.[0]?.iso_code,
-      subdivision2: result.subdivisions?.[1]?.names?.en,
-      city: result.city?.names?.en,
+      country,
+      subdivision1: getRegionCode(country, subdivision1),
+      subdivision2,
+      city,
     };
   }
 }


### PR DESCRIPTION
Fixes #2383

Starting from Umami 2.6.0 and when maxmind is used,
subdivision1 doesn't include country code, leading to the unexpected behaviours mentioned in issue.

Country was appended before in `createSession.ts` from analytics queries