### PR TITLE
Update moment to moment-timezone. Fixes charts

### DIFF
--- a/src/lib/yup.ts
+++ b/src/lib/yup.ts
@@ -1,4 +1,4 @@
-import moment from 'moment';
+import moment from 'moment-timezone';
 import * as yup from 'yup';
 import { UNIT_TYPES } from './constants';
 


### PR DESCRIPTION
Might be related to #1490.

My environment is a fresh Supabase and NextJS install.

Before:
<img width="1379" alt="Screenshot 2023-11-14 at 10 35 52 PM" src="https://github.com/umami-software/umami/assets/4521335/bbabf6f5-5c26-4642-9cc4-c8a77ff4fb3e">

After:
<img width="1349" alt="Screenshot 2023-11-14 at 10 41 10 PM" src="https://github.com/umami-software/umami/assets/4521335/c3da6807-83d9-445b-b313-9c1ae4753aae">
