### PR TITLE
Allow setting custom data on autotracked pageviews via data attribute on script element

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -50,6 +50,15 @@
     }
   };
 
+  const getPageviewEventData = () => Object.fromEntries(
+    [...currentScript.attributes]
+      .filter(attribute => eventRegex.match(attribute.name))
+      .map(attribute => {
+        const match = attribute.name.match(eventRegex);
+        return [match[1], attribute.value]
+      })
+  )
+
   const getPayload = () => ({
     website,
     hostname,
@@ -189,7 +198,7 @@
     })
       .then(res => res.text())
       .then(text => (cache = text))
-      .catch(() => {}); // no-op, gulp error
+      .catch(() => { }); // no-op, gulp error
   };
 
   const track = (obj, data) => {
@@ -204,7 +213,7 @@
     } else if (typeof obj === 'function') {
       return send(obj(getPayload()));
     }
-    return send(getPayload());
+    return send({ ...getPayload(), data: getPageviewEventData() });
   };
 
   const identify = data => send({ ...getPayload(), data }, 'identify');


### PR DESCRIPTION
This would allow setting custom data, like [Plausible allows with what they call "Custom Properties"](https://plausible.io/docs/custom-props/for-pageviews).

This is very useful to track how much people are on e.g. a version, how much people use the dark theme, how much pageviews are from logged-in users, etc.