### PR TITLE
Replace all instances of "publically" with "publicly"

### DIFF
--- a/public/intl/messages/en-US.json
+++ b/public/intl/messages/en-US.json
@@ -1382,7 +1382,7 @@
   "message.share-url": [
     {
       "type": 0,
-      "value": "Your website stats are publically available at the following URL:"
+      "value": "Your website stats are publicly available at the following URL:"
     }
   ],
   "message.team-already-member": [

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -227,7 +227,7 @@ export const messages = defineMessages({
   },
   shareUrl: {
     id: 'message.share-url',
-    defaultMessage: 'Your website stats are publically available at the following URL:',
+    defaultMessage: 'Your website stats are publicly available at the following URL:',
   },
   trackingCode: {
     id: 'message.tracking-code',

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -207,7 +207,7 @@
   "message.reset-website": "To reset this website, type {confirmation} in the box below to confirm.",
   "message.reset-website-warning": "All statistics for this website will be deleted, but your settings will remain intact.",
   "message.saved": "Saved.",
-  "message.share-url": "Your website stats are publically available at the following URL:",
+  "message.share-url": "Your website stats are publicly available at the following URL:",
   "message.team-already-member": "You are already a member of the team.",
   "message.team-not-found": "Team not found.",
   "message.team-websites-info": "Websites can be viewed by anyone on the team.",


### PR DESCRIPTION
This PR corrects a spelling error in the Share URL page

![image](https://github.com/umami-software/umami/assets/8981287/4e2ec3cb-04fb-4cef-b79b-3b87d56d867f)
