### PR TITLE
Log IP address on failed login attempts

### DIFF
--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -16,8 +16,10 @@ import {
 import { getUserByUsername } from 'queries';
 import * as yup from 'yup';
 import { ROLES } from 'lib/constants';
+import { getIpAddress } from 'lib/detect';
 
 const log = debug('umami:auth');
+const logFailed = debug('umami:auth:failed');
 
 export interface LoginRequestBody {
   username: string;
@@ -68,6 +70,7 @@ export default async (
     }
 
     log('Login failed:', { username, user });
+    logFailed(`Login from ip ${getIpAddress(req)} failed.`);
 
     return unauthorized(res, 'message.incorrect-username-password');
   }

--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -19,7 +19,6 @@ import { ROLES } from 'lib/constants';
 import { getIpAddress } from 'lib/detect';
 
 const log = debug('umami:auth');
-const logFailed = debug('umami:auth:failed');
 
 export interface LoginRequestBody {
   username: string;
@@ -69,8 +68,7 @@ export default async (
       });
     }
 
-    log('Login failed:', { username, user });
-    logFailed(`Login from ip ${getIpAddress(req)} failed.`);
+    log(`Login from ip ${getIpAddress(req)} with username "${username.replace(/["\r\n]/g, '')}" failed.`);
 
     return unauthorized(res, 'message.incorrect-username-password');
   }


### PR DESCRIPTION
This pull requests implements logging of the IP address on failed login attempts. This makes it possible to monitor Umami with an IPS like [Crowdsec](https://github.com/crowdsecurity/crowdsec).

I added an additional log line instead of modifying the existing `Login failed: ...` line, because I wanted to prevent the logging of sensible user data.

Closes #1314