### PR TITLE
Allow setting visitor IP when registering event through API

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -203,6 +203,7 @@ export const UUID_REGEX =
   /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/;
 export const HOSTNAME_REGEX =
   /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/;
+export const IP_REGEX = /^((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])(\.(?!$)|$)){4}$/;
 
 export const DESKTOP_SCREEN_WIDTH = 1920;
 export const LAPTOP_SCREEN_WIDTH = 1024;

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -123,7 +123,7 @@ export async function getLocation(ip, req) {
 
 export async function getClientInfo(req: NextApiRequestCollect, { screen }) {
   const userAgent = req.headers['user-agent'];
-  const ip = getIpAddress(req);
+  const ip = req.body.payload.ip || getIpAddress(req);
   const location = await getLocation(ip, req);
   const country = location?.country;
   const subdivision1 = location?.subdivision1;

--- a/src/pages/api/send.ts
+++ b/src/pages/api/send.ts
@@ -1,6 +1,6 @@
 import ipaddr from 'ipaddr.js';
 import isbot from 'isbot';
-import { COLLECTION_TYPE, HOSTNAME_REGEX } from 'lib/constants';
+import { COLLECTION_TYPE, HOSTNAME_REGEX, IP_REGEX } from 'lib/constants';
 import { secret } from 'lib/crypto';
 import { getIpAddress } from 'lib/detect';
 import { useCors, useSession, useValidate } from 'lib/middleware';
@@ -14,6 +14,7 @@ export interface CollectRequestBody {
   payload: {
     data: { [key: string]: any };
     hostname: string;
+    ip: string;
     language: string;
     referrer: string;
     screen: string;
@@ -53,6 +54,7 @@ const schema = {
       .shape({
         data: yup.object(),
         hostname: yup.string().matches(HOSTNAME_REGEX).max(100),
+        ip: yup.string().matches(IP_REGEX),
         language: yup.string().max(35),
         referrer: yup.string().max(500),
         screen: yup.string().max(11),


### PR DESCRIPTION
Hi there,

Thank you for an awesome application and for the hosted cloud service.

I want to switch to exclusively using server-side tracking for pageviews and events via the API. While the `/api/send` endpoint fulfills most of my requirements, it lacks the ability to transmit the visitor IP. Currently, the sender's IP, which is my server, is used when registering pageviews and events. Which in turn means that I am missing out on visitor location data.

I've addressed this by introducing the option to send the visitor IP as part of the payload. If no IP is supplied it falls back to the current implementation.

Let me know what you think.

Thanks!