### PR TITLE
Fix metrics search when a value is null.

### DIFF
--- a/src/components/metrics/MetricsTable.tsx
+++ b/src/components/metrics/MetricsTable.tsx
@@ -90,7 +90,7 @@ export function MetricsTable({
         items = items.filter(({ x, ...data }) => {
           const value = formatValue(x, type, data);
 
-          return value.toLowerCase().includes(search.toLowerCase());
+          return value?.toLowerCase().includes(search.toLowerCase());
         });
       }
 


### PR DESCRIPTION
Fixes #2505
`formatValue` function can return a null value in some cases.