### PR TITLE
Feat: Added simple brand options

### DIFF
--- a/src/app/(main)/NavBar.tsx
+++ b/src/app/(main)/NavBar.tsx
@@ -71,7 +71,7 @@ export function NavBar() {
         <Icon size="lg">
           <Icons.Logo />
         </Icon>
-        <Text>umami</Text>
+        <Text>{process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}</Text>
       </div>
       <div className={styles.links}>
         {links.map(({ url, label }) => {

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -21,7 +21,7 @@ export default function ({ children }) {
 
 export const metadata: Metadata = {
   title: {
-    template: '%s | Umami',
-    default: 'Umami',
+    template: `%s | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
+    default: {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'},
   },
 };

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -22,6 +22,6 @@ export default function ({ children }) {
 export const metadata: Metadata = {
   title: {
     template: `%s | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
-    default: {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'},
+    default: process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami',
   },
 };

--- a/src/app/(main)/settings/layout.tsx
+++ b/src/app/(main)/settings/layout.tsx
@@ -11,7 +11,7 @@ export default function ({ children }) {
 
 export const metadata: Metadata = {
   title: {
-    template: '%s | Settings | Umami',
-    default: 'Settings | Umami',
+    template: `%s | Settings | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
+    default: `Settings | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,6 +34,6 @@ export default function ({ children }) {
 export const metadata: Metadata = {
   title: {
     template: `%s | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
-    default: {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'},
+    default: process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami',
   },
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default function ({ children }) {
 
 export const metadata: Metadata = {
   title: {
-    template: '%s | Umami',
-    default: 'Umami',
+    template: `%s | ${process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}`,
+    default: {process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'},
   },
 };

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -39,7 +39,7 @@ export function LoginForm() {
       <Icon className={styles.icon} size="xl">
         <Logo />
       </Icon>
-      <div className={styles.title}>umami</div>
+      <div className={styles.title}>{process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'umami'}</div>
       <Form className={styles.form} onSubmit={handleSubmit} error={getMessage(error)}>
         <FormRow label={formatMessage(labels.username)}>
           <FormInput name="username" rules={{ required: formatMessage(labels.required) }}>

--- a/src/app/share/[...shareId]/Header.tsx
+++ b/src/app/share/[...shareId]/Header.tsx
@@ -10,11 +10,11 @@ export function Header() {
   return (
     <header className={styles.header}>
       <div>
-        <Link href="https://umami.is" target="_blank" className={styles.title}>
+        <Link href={process.env.NEXT_PUBLIC_CUSTOM_HOMEPAGE_URL || 'https://umami.is'} target="_blank" className={styles.title}>
           <Icon size="lg">
             <Icons.Logo />
           </Icon>
-          <Text>umami</Text>
+          <Text>{process.env.NEXT_PUBLIC_CUSTOM_TITLE || 'Umami'}</Text>
         </Link>
       </div>
       <div className={styles.buttons}>


### PR DESCRIPTION
In this Feature I´ve added the ability to change the branding of umami. The "Powered by" branding is not affected by this config vars.

Added ENV-Vars:
- NEXT_PUBLIC_CUSTOM_HOMEPAGE_URL (Custom Homepage Url for the Shared-Pages)
-  NEXT_PUBLIC_CUSTOM_TITLE (Custom Website Title)