### PR TITLE
fix: Administrator label in users table (#2)

### DIFF
--- a/src/app/(main)/profile/ProfileSettings.tsx
+++ b/src/app/(main)/profile/ProfileSettings.tsx
@@ -23,7 +23,7 @@ export function ProfileSettings() {
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);

--- a/src/app/(main)/settings/users/UserAddForm.tsx
+++ b/src/app/(main)/settings/users/UserAddForm.tsx
@@ -34,7 +34,7 @@ export function UserAddForm({ onSave, onClose }) {
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);
@@ -58,7 +58,7 @@ export function UserAddForm({ onSave, onClose }) {
           <Dropdown renderValue={renderValue}>
             <Item key={ROLES.viewOnly}>{formatMessage(labels.viewOnly)}</Item>
             <Item key={ROLES.user}>{formatMessage(labels.user)}</Item>
-            <Item key={ROLES.admin}>{formatMessage(labels.administrator)}</Item>
+            <Item key={ROLES.admin}>{formatMessage(labels.admin)}</Item>
           </Dropdown>
         </FormInput>
       </FormRow>

--- a/src/app/(main)/settings/users/[userId]/UserEditForm.tsx
+++ b/src/app/(main)/settings/users/[userId]/UserEditForm.tsx
@@ -46,7 +46,7 @@ export function UserEditForm({ userId, onSave }: { userId: string; onSave?: () =
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);
@@ -76,7 +76,7 @@ export function UserEditForm({ userId, onSave }: { userId: string; onSave?: () =
             <Dropdown renderValue={renderValue}>
               <Item key={ROLES.viewOnly}>{formatMessage(labels.viewOnly)}</Item>
               <Item key={ROLES.user}>{formatMessage(labels.user)}</Item>
-              <Item key={ROLES.admin}>{formatMessage(labels.administrator)}</Item>
+              <Item key={ROLES.admin}>{formatMessage(labels.admin)}</Item>
             </Dropdown>
           </FormInput>
         </FormRow>

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -18,7 +18,7 @@ export const labels = defineMessages({
   user: { id: 'label.user', defaultMessage: 'User' },
   viewOnly: { id: 'label.view-only', defaultMessage: 'View only' },
   manage: { id: 'label.manage', defaultMessage: 'Manage' },
-  administrator: { id: 'label.administrator', defaultMessage: 'Administrator' },
+  admin: { id: 'label.administrator', defaultMessage: 'Administrator' },
   confirm: { id: 'label.confirm', defaultMessage: 'Confirm' },
   details: { id: 'label.details', defaultMessage: 'Details' },
   website: { id: 'label.website', defaultMessage: 'Website' },


### PR DESCRIPTION
## Headline
Fix admin label on user table.

## Details
In `src/app/(main)/settings/users/UsersTable.tsx:25` it expects to find a role `ROLES['admin']` based on the role name in the database, which doesn't exist. Everywhere else in the codebase it seems to use `ROLES.administrator`.

This is the easiest/most backwards compatible way I could think of to fix this, without requiring a migration to update the users' role fields in the database.

Before:
<img width="1136" alt="image" src="https://github.com/mhespenh/umami/assets/1562473/61e40706-757e-47c4-86fc-0b6a8d12f67b">

After:
<img width="1136" alt="image" src="https://github.com/mhespenh/umami/assets/1562473/d578da0d-1fc4-4382-b983-7fa5e168cea7">
