### PR TITLE
fix: Administrator label in /settings/users

### DIFF
--- a/public/intl/messages/am-ET.json
+++ b/public/intl/messages/am-ET.json
@@ -41,7 +41,7 @@
       "value": "Add website"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/ar-SA.json
+++ b/public/intl/messages/ar-SA.json
@@ -41,7 +41,7 @@
       "value": "إضافة موقع"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "مدير"

--- a/public/intl/messages/be-BY.json
+++ b/public/intl/messages/be-BY.json
@@ -41,7 +41,7 @@
       "value": "Дадаць сайт"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Адміністратар"

--- a/public/intl/messages/bn-BD.json
+++ b/public/intl/messages/bn-BD.json
@@ -41,7 +41,7 @@
       "value": "ওয়েবসাইট যুক্ত করুন"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "অ্যাডমিন"

--- a/public/intl/messages/ca-ES.json
+++ b/public/intl/messages/ca-ES.json
@@ -41,7 +41,7 @@
       "value": "Afegeix lloc web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrador"

--- a/public/intl/messages/cs-CZ.json
+++ b/public/intl/messages/cs-CZ.json
@@ -41,7 +41,7 @@
       "value": "Přidat web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrátor"

--- a/public/intl/messages/da-DK.json
+++ b/public/intl/messages/da-DK.json
@@ -41,7 +41,7 @@
       "value": "Tilføj hjemmeside"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/de-CH.json
+++ b/public/intl/messages/de-CH.json
@@ -41,7 +41,7 @@
       "value": "Websiite hinzuefüege"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/de-DE.json
+++ b/public/intl/messages/de-DE.json
@@ -41,7 +41,7 @@
       "value": "Website hinzufügen"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/el-GR.json
+++ b/public/intl/messages/el-GR.json
@@ -41,7 +41,7 @@
       "value": "Προσθήκη ιστότοπου"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Διαχειριστής"

--- a/public/intl/messages/en-GB.json
+++ b/public/intl/messages/en-GB.json
@@ -41,7 +41,7 @@
       "value": "Add website"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/en-US.json
+++ b/public/intl/messages/en-US.json
@@ -41,7 +41,7 @@
       "value": "Add website"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/es-ES.json
+++ b/public/intl/messages/es-ES.json
@@ -41,7 +41,7 @@
       "value": "Nuevo sitio web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrador"

--- a/public/intl/messages/fa-IR.json
+++ b/public/intl/messages/fa-IR.json
@@ -41,7 +41,7 @@
       "value": "افزودن وب‌سایت"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "مدیر"

--- a/public/intl/messages/fi-FI.json
+++ b/public/intl/messages/fi-FI.json
@@ -41,7 +41,7 @@
       "value": "Lisää verkkosivu"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Järjestelmänvalvoja"

--- a/public/intl/messages/fo-FO.json
+++ b/public/intl/messages/fo-FO.json
@@ -41,7 +41,7 @@
       "value": "Legg heimasíðu afturat"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Fyrisitari"

--- a/public/intl/messages/fr-FR.json
+++ b/public/intl/messages/fr-FR.json
@@ -41,7 +41,7 @@
       "value": "Ajouter un site"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrateur"

--- a/public/intl/messages/ga-ES.json
+++ b/public/intl/messages/ga-ES.json
@@ -41,7 +41,7 @@
       "value": "Engadir sitio web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administradora"

--- a/public/intl/messages/he-IL.json
+++ b/public/intl/messages/he-IL.json
@@ -41,7 +41,7 @@
       "value": "הוספת אתר"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "מנהל"

--- a/public/intl/messages/hi-IN.json
+++ b/public/intl/messages/hi-IN.json
@@ -41,7 +41,7 @@
       "value": "वेबसाइट"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "प्रशासक"

--- a/public/intl/messages/hr-HR.json
+++ b/public/intl/messages/hr-HR.json
@@ -41,7 +41,7 @@
       "value": "Dodaj web stranicu"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/hu-HU.json
+++ b/public/intl/messages/hu-HU.json
@@ -41,7 +41,7 @@
       "value": "Weboldal hozzáadása"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Adminisztrátor"

--- a/public/intl/messages/id-ID.json
+++ b/public/intl/messages/id-ID.json
@@ -41,7 +41,7 @@
       "value": "Tambah situs web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Pengelola"

--- a/public/intl/messages/it-IT.json
+++ b/public/intl/messages/it-IT.json
@@ -41,7 +41,7 @@
       "value": "Aggiungi sito"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Amministratore"

--- a/public/intl/messages/ja-JP.json
+++ b/public/intl/messages/ja-JP.json
@@ -41,7 +41,7 @@
       "value": "Webサイトの追加"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "管理者"

--- a/public/intl/messages/km-KH.json
+++ b/public/intl/messages/km-KH.json
@@ -41,7 +41,7 @@
       "value": "បន្ថែមគេហទំព័រ"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "អ្នកគ្រប់គ្រង"

--- a/public/intl/messages/ko-KR.json
+++ b/public/intl/messages/ko-KR.json
@@ -41,7 +41,7 @@
       "value": "웹사이트 추가"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "관리자"

--- a/public/intl/messages/lt-LT.json
+++ b/public/intl/messages/lt-LT.json
@@ -41,7 +41,7 @@
       "value": "Pridėti svetainę"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administratorius"

--- a/public/intl/messages/mn-MN.json
+++ b/public/intl/messages/mn-MN.json
@@ -41,7 +41,7 @@
       "value": "Веб нэмэх"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Админ"

--- a/public/intl/messages/ms-MY.json
+++ b/public/intl/messages/ms-MY.json
@@ -41,7 +41,7 @@
       "value": "Tambah laman web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Pentadbir"

--- a/public/intl/messages/my-MM.json
+++ b/public/intl/messages/my-MM.json
@@ -41,7 +41,7 @@
       "value": "ဝက်ဘ်ဆိုဒ်ထည့်မည်"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "အက်ဒမင်"

--- a/public/intl/messages/nb-NO.json
+++ b/public/intl/messages/nb-NO.json
@@ -41,7 +41,7 @@
       "value": "Legg til nettsted"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/nl-NL.json
+++ b/public/intl/messages/nl-NL.json
@@ -41,7 +41,7 @@
       "value": "Website koppelen"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Beheerder"

--- a/public/intl/messages/pl-PL.json
+++ b/public/intl/messages/pl-PL.json
@@ -41,7 +41,7 @@
       "value": "Dodaj witrynę"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/pt-BR.json
+++ b/public/intl/messages/pt-BR.json
@@ -41,7 +41,7 @@
       "value": "Adicionar site"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrador"

--- a/public/intl/messages/pt-PT.json
+++ b/public/intl/messages/pt-PT.json
@@ -41,7 +41,7 @@
       "value": "Adicionar website"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrador"

--- a/public/intl/messages/ro-RO.json
+++ b/public/intl/messages/ro-RO.json
@@ -41,7 +41,7 @@
       "value": "Adăugare site web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/ru-RU.json
+++ b/public/intl/messages/ru-RU.json
@@ -41,7 +41,7 @@
       "value": "Добавить сайт"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Администратор"

--- a/public/intl/messages/si-LK.json
+++ b/public/intl/messages/si-LK.json
@@ -41,7 +41,7 @@
       "value": "වෙබ් අඩවිය එක් කරන්න"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/sk-SK.json
+++ b/public/intl/messages/sk-SK.json
@@ -41,7 +41,7 @@
       "value": "Pridať web"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrátor"

--- a/public/intl/messages/sl-SI.json
+++ b/public/intl/messages/sl-SI.json
@@ -41,7 +41,7 @@
       "value": "Dodaj spletno mesto"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administrator"

--- a/public/intl/messages/sv-SE.json
+++ b/public/intl/messages/sv-SE.json
@@ -41,7 +41,7 @@
       "value": "Lägg till webbplats"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Administratör"

--- a/public/intl/messages/ta-IN.json
+++ b/public/intl/messages/ta-IN.json
@@ -41,7 +41,7 @@
       "value": "வலைத்தளத்தைச் சேர்க்க"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "நிர்வாகியைச் சேர்க்க"

--- a/public/intl/messages/th-TH.json
+++ b/public/intl/messages/th-TH.json
@@ -41,7 +41,7 @@
       "value": "เพิ่มเว็บไซต์"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "ผู้ดูแลระบบ"

--- a/public/intl/messages/tr-TR.json
+++ b/public/intl/messages/tr-TR.json
@@ -41,7 +41,7 @@
       "value": "Web sitesi ekle"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Yönetici"

--- a/public/intl/messages/uk-UA.json
+++ b/public/intl/messages/uk-UA.json
@@ -41,7 +41,7 @@
       "value": "Додати сайт"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Адміністратор"

--- a/public/intl/messages/ur-PK.json
+++ b/public/intl/messages/ur-PK.json
@@ -41,7 +41,7 @@
       "value": "ویب سائٹ کا اضافہ کریں"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "منتظم"

--- a/public/intl/messages/vi-VN.json
+++ b/public/intl/messages/vi-VN.json
@@ -41,7 +41,7 @@
       "value": "Thêm website"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "Quản trị"

--- a/public/intl/messages/zh-CN.json
+++ b/public/intl/messages/zh-CN.json
@@ -41,7 +41,7 @@
       "value": "添加网站"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "管理员"

--- a/public/intl/messages/zh-TW.json
+++ b/public/intl/messages/zh-TW.json
@@ -41,7 +41,7 @@
       "value": "新增網站"
     }
   ],
-  "label.administrator": [
+  "label.admin": [
     {
       "type": 0,
       "value": "管理員"

--- a/src/app/(main)/profile/ProfileSettings.tsx
+++ b/src/app/(main)/profile/ProfileSettings.tsx
@@ -23,7 +23,7 @@ export function ProfileSettings() {
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);

--- a/src/app/(main)/settings/users/UserAddForm.tsx
+++ b/src/app/(main)/settings/users/UserAddForm.tsx
@@ -34,7 +34,7 @@ export function UserAddForm({ onSave, onClose }) {
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);
@@ -58,7 +58,7 @@ export function UserAddForm({ onSave, onClose }) {
           <Dropdown renderValue={renderValue}>
             <Item key={ROLES.viewOnly}>{formatMessage(labels.viewOnly)}</Item>
             <Item key={ROLES.user}>{formatMessage(labels.user)}</Item>
-            <Item key={ROLES.admin}>{formatMessage(labels.administrator)}</Item>
+            <Item key={ROLES.admin}>{formatMessage(labels.admin)}</Item>
           </Dropdown>
         </FormInput>
       </FormRow>

--- a/src/app/(main)/settings/users/[userId]/UserEditForm.tsx
+++ b/src/app/(main)/settings/users/[userId]/UserEditForm.tsx
@@ -46,7 +46,7 @@ export function UserEditForm({ userId, onSave }: { userId: string; onSave?: () =
       return formatMessage(labels.user);
     }
     if (value === ROLES.admin) {
-      return formatMessage(labels.administrator);
+      return formatMessage(labels.admin);
     }
     if (value === ROLES.viewOnly) {
       return formatMessage(labels.viewOnly);
@@ -76,7 +76,7 @@ export function UserEditForm({ userId, onSave }: { userId: string; onSave?: () =
             <Dropdown renderValue={renderValue}>
               <Item key={ROLES.viewOnly}>{formatMessage(labels.viewOnly)}</Item>
               <Item key={ROLES.user}>{formatMessage(labels.user)}</Item>
-              <Item key={ROLES.admin}>{formatMessage(labels.administrator)}</Item>
+              <Item key={ROLES.admin}>{formatMessage(labels.admin)}</Item>
             </Dropdown>
           </FormInput>
         </FormRow>

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -18,7 +18,7 @@ export const labels = defineMessages({
   user: { id: 'label.user', defaultMessage: 'User' },
   viewOnly: { id: 'label.view-only', defaultMessage: 'View only' },
   manage: { id: 'label.manage', defaultMessage: 'Manage' },
-  admin: { id: 'label.administrator', defaultMessage: 'Administrator' },
+  admin: { id: 'label.admin', defaultMessage: 'Administrator' },
   confirm: { id: 'label.confirm', defaultMessage: 'Confirm' },
   details: { id: 'label.details', defaultMessage: 'Details' },
   website: { id: 'label.website', defaultMessage: 'Website' },

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -18,7 +18,7 @@ export const labels = defineMessages({
   user: { id: 'label.user', defaultMessage: 'User' },
   viewOnly: { id: 'label.view-only', defaultMessage: 'View only' },
   manage: { id: 'label.manage', defaultMessage: 'Manage' },
-  administrator: { id: 'label.administrator', defaultMessage: 'Administrator' },
+  admin: { id: 'label.administrator', defaultMessage: 'Administrator' },
   confirm: { id: 'label.confirm', defaultMessage: 'Confirm' },
   details: { id: 'label.details', defaultMessage: 'Details' },
   website: { id: 'label.website', defaultMessage: 'Website' },

--- a/src/lang/am-ET.json
+++ b/src/lang/am-ET.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Add website",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "All",
   "label.all-time": "All time",

--- a/src/lang/ar-SA.json
+++ b/src/lang/ar-SA.json
@@ -6,7 +6,7 @@
   "label.add-description": "أضِف وصف",
   "label.add-member": "أضِف عضو",
   "label.add-website": "إضافة موقع",
-  "label.administrator": "مدير",
+  "label.admin": "مدير",
   "label.after": "يعد",
   "label.all": "الكل",
   "label.all-time": "كل الوقت",

--- a/src/lang/be-BY.json
+++ b/src/lang/be-BY.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Дадаць сайт",
-  "label.administrator": "Адміністратар",
+  "label.admin": "Адміністратар",
   "label.after": "After",
   "label.all": "Усё",
   "label.all-time": "Увесь час",

--- a/src/lang/bn-BD.json
+++ b/src/lang/bn-BD.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "ওয়েবসাইট যুক্ত করুন",
-  "label.administrator": "অ্যাডমিন",
+  "label.admin": "অ্যাডমিন",
   "label.after": "After",
   "label.all": "সবগুলো",
   "label.all-time": "সব সময়",

--- a/src/lang/ca-ES.json
+++ b/src/lang/ca-ES.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Afegeix lloc web",
-  "label.administrator": "Administrador",
+  "label.admin": "Administrador",
   "label.after": "After",
   "label.all": "Tots",
   "label.all-time": "Sempre",

--- a/src/lang/cs-CZ.json
+++ b/src/lang/cs-CZ.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Přidat web",
-  "label.administrator": "Administrátor",
+  "label.admin": "Administrátor",
   "label.after": "After",
   "label.all": "Vše",
   "label.all-time": "All time",

--- a/src/lang/da-DK.json
+++ b/src/lang/da-DK.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Tilføj hjemmeside",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "Alle",
   "label.all-time": "Altid",

--- a/src/lang/de-CH.json
+++ b/src/lang/de-CH.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Websiite hinzuefüege",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "Alli",
   "label.all-time": "Gesamte Zitruum",

--- a/src/lang/de-DE.json
+++ b/src/lang/de-DE.json
@@ -6,7 +6,7 @@
   "label.add-description": "Beschreibung hinzufügen",
   "label.add-member": "Add member",
   "label.add-website": "Website hinzufügen",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "Nach",
   "label.all": "Alle",
   "label.all-time": "Gesamter Zeitraum",

--- a/src/lang/el-GR.json
+++ b/src/lang/el-GR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Προσθήκη ιστότοπου",
-  "label.administrator": "Διαχειριστής",
+  "label.admin": "Διαχειριστής",
   "label.after": "After",
   "label.all": "All",
   "label.all-time": "All time",

--- a/src/lang/en-GB.json
+++ b/src/lang/en-GB.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Add website",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "All",
   "label.all-time": "All time",

--- a/src/lang/en-US.json
+++ b/src/lang/en-US.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Add website",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "All",
   "label.all-time": "All time",

--- a/src/lang/es-ES.json
+++ b/src/lang/es-ES.json
@@ -6,7 +6,7 @@
   "label.add-description": "Añadir descripción",
   "label.add-member": "Añadir miembro",
   "label.add-website": "Nuevo sitio web",
-  "label.administrator": "Administrador",
+  "label.admin": "Administrador",
   "label.after": "Después",
   "label.all": "Todos",
   "label.all-time": "Todos los tiempos",

--- a/src/lang/fa-IR.json
+++ b/src/lang/fa-IR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "افزودن وب‌سایت",
-  "label.administrator": "مدیر",
+  "label.admin": "مدیر",
   "label.after": "After",
   "label.all": "همه",
   "label.all-time": "همه زمان",

--- a/src/lang/fi-FI.json
+++ b/src/lang/fi-FI.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Lisää verkkosivu",
-  "label.administrator": "Järjestelmänvalvoja",
+  "label.admin": "Järjestelmänvalvoja",
   "label.after": "After",
   "label.all": "Kaikki",
   "label.all-time": "Alusta lähtien",

--- a/src/lang/fo-FO.json
+++ b/src/lang/fo-FO.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Legg heimasíðu afturat",
-  "label.administrator": "Fyrisitari",
+  "label.admin": "Fyrisitari",
   "label.after": "After",
   "label.all": "Alt",
   "label.all-time": "All time",

--- a/src/lang/fr-FR.json
+++ b/src/lang/fr-FR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Ajouter une description",
   "label.add-member": "Ajouter un membre",
   "label.add-website": "Ajouter un site",
-  "label.administrator": "Administrateur",
+  "label.admin": "Administrateur",
   "label.after": "Après",
   "label.all": "Tout",
   "label.all-time": "Toutes les données",

--- a/src/lang/ga-ES.json
+++ b/src/lang/ga-ES.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Engadir sitio web",
-  "label.administrator": "Administradora",
+  "label.admin": "Administradora",
   "label.after": "After",
   "label.all": "Todo",
   "label.all-time": "Sempre",

--- a/src/lang/he-IL.json
+++ b/src/lang/he-IL.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "הוספת אתר",
-  "label.administrator": "מנהל",
+  "label.admin": "מנהל",
   "label.after": "After",
   "label.all": "הכל",
   "label.all-time": "All time",

--- a/src/lang/hi-IN.json
+++ b/src/lang/hi-IN.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "वेबसाइट",
-  "label.administrator": "प्रशासक",
+  "label.admin": "प्रशासक",
   "label.after": "After",
   "label.all": "सब",
   "label.all-time": "All time",

--- a/src/lang/hr-HR.json
+++ b/src/lang/hr-HR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Dodaj web stranicu",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "Sve",
   "label.all-time": "Svo vrijeme",

--- a/src/lang/hu-HU.json
+++ b/src/lang/hu-HU.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Weboldal hozzáadása",
-  "label.administrator": "Adminisztrátor",
+  "label.admin": "Adminisztrátor",
   "label.after": "After",
   "label.all": "Összes",
   "label.all-time": "All time",

--- a/src/lang/id-ID.json
+++ b/src/lang/id-ID.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Tambah situs web",
-  "label.administrator": "Pengelola",
+  "label.admin": "Pengelola",
   "label.after": "After",
   "label.all": "Semua",
   "label.all-time": "Semua waktu",

--- a/src/lang/it-IT.json
+++ b/src/lang/it-IT.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Aggiungi sito",
-  "label.administrator": "Amministratore",
+  "label.admin": "Amministratore",
   "label.after": "After",
   "label.all": "Tutto",
   "label.all-time": "Sempre",

--- a/src/lang/ja-JP.json
+++ b/src/lang/ja-JP.json
@@ -6,7 +6,7 @@
   "label.add-description": "説明を追加",
   "label.add-member": "メンバーの追加",
   "label.add-website": "Webサイトの追加",
-  "label.administrator": "管理者",
+  "label.admin": "管理者",
   "label.after": "直後",
   "label.all": "すべて",
   "label.all-time": "すべての時間帯",

--- a/src/lang/km-KH.json
+++ b/src/lang/km-KH.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "បន្ថែមគេហទំព័រ",
-  "label.administrator": "អ្នកគ្រប់គ្រង",
+  "label.admin": "អ្នកគ្រប់គ្រង",
   "label.after": "After",
   "label.all": "ទាំងអស់",
   "label.all-time": "គ្រប់ពេល",

--- a/src/lang/ko-KR.json
+++ b/src/lang/ko-KR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "웹사이트 추가",
-  "label.administrator": "관리자",
+  "label.admin": "관리자",
   "label.after": "After",
   "label.all": "전체",
   "label.all-time": "All time",

--- a/src/lang/lt-LT.json
+++ b/src/lang/lt-LT.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Pridėti svetainę",
-  "label.administrator": "Administratorius",
+  "label.admin": "Administratorius",
   "label.after": "After",
   "label.all": "Visi",
   "label.all-time": "Visas laikotarpis",

--- a/src/lang/mn-MN.json
+++ b/src/lang/mn-MN.json
@@ -6,7 +6,7 @@
   "label.add-description": "Тайлбар нэмэх",
   "label.add-member": "Add member",
   "label.add-website": "Веб нэмэх",
-  "label.administrator": "Админ",
+  "label.admin": "Админ",
   "label.after": "Хойно",
   "label.all": "Бүх",
   "label.all-time": "Бүх цаг үеийн",

--- a/src/lang/ms-MY.json
+++ b/src/lang/ms-MY.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Tambah laman web",
-  "label.administrator": "Pentadbir",
+  "label.admin": "Pentadbir",
   "label.after": "After",
   "label.all": "Semua",
   "label.all-time": "All time",

--- a/src/lang/my-MM.json
+++ b/src/lang/my-MM.json
@@ -6,7 +6,7 @@
   "label.add-description": "အကြောင်းအရာဖော်ပြချက် ထည့်မည်",
   "label.add-member": "Add member",
   "label.add-website": "ဝက်ဘ်ဆိုဒ်ထည့်မည်",
-  "label.administrator": "အက်ဒမင်",
+  "label.admin": "အက်ဒမင်",
   "label.after": "ပြီးနောက်",
   "label.all": "အားလုံး",
   "label.all-time": "အချိန်အစမှအခုထိ",

--- a/src/lang/nb-NO.json
+++ b/src/lang/nb-NO.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Legg til nettsted",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "Alle",
   "label.all-time": "Noensinne",

--- a/src/lang/nl-NL.json
+++ b/src/lang/nl-NL.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Website koppelen",
-  "label.administrator": "Beheerder",
+  "label.admin": "Beheerder",
   "label.after": "After",
   "label.all": "Alles",
   "label.all-time": "Onbeperkt",

--- a/src/lang/pl-PL.json
+++ b/src/lang/pl-PL.json
@@ -6,7 +6,7 @@
   "label.add-description": "Dodaj opis",
   "label.add-member": "Add member",
   "label.add-website": "Dodaj witrynę",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "Po",
   "label.all": "Wszystkie",
   "label.all-time": "Cały czas",

--- a/src/lang/pt-BR.json
+++ b/src/lang/pt-BR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Adicionar site",
-  "label.administrator": "Administrador",
+  "label.admin": "Administrador",
   "label.after": "Depois",
   "label.all": "Todos",
   "label.all-time": "Todo o período",

--- a/src/lang/pt-PT.json
+++ b/src/lang/pt-PT.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Adicionar website",
-  "label.administrator": "Administrador",
+  "label.admin": "Administrador",
   "label.after": "After",
   "label.all": "Todos",
   "label.all-time": "Todo o tempo",

--- a/src/lang/ro-RO.json
+++ b/src/lang/ro-RO.json
@@ -6,7 +6,7 @@
   "label.add-description": "Adaugă descriere",
   "label.add-member": "Adaugă membru",
   "label.add-website": "Adăugare site web",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "După",
   "label.all": "Toate",
   "label.all-time": "Pentru tot timpul",

--- a/src/lang/ru-RU.json
+++ b/src/lang/ru-RU.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Добавить сайт",
-  "label.administrator": "Администратор",
+  "label.admin": "Администратор",
   "label.after": "After",
   "label.all": "Все",
   "label.all-time": "Все время",

--- a/src/lang/si-LK.json
+++ b/src/lang/si-LK.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "වෙබ් අඩවිය එක් කරන්න",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "After",
   "label.all": "සියල්ල",
   "label.all-time": "හැම වෙලාවෙම",

--- a/src/lang/sk-SK.json
+++ b/src/lang/sk-SK.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Pridať web",
-  "label.administrator": "Administrátor",
+  "label.admin": "Administrátor",
   "label.after": "After",
   "label.all": "Všetko",
   "label.all-time": "All time",

--- a/src/lang/sl-SI.json
+++ b/src/lang/sl-SI.json
@@ -6,7 +6,7 @@
   "label.add-description": "Dodaj opis",
   "label.add-member": "Add member",
   "label.add-website": "Dodaj spletno mesto",
-  "label.administrator": "Administrator",
+  "label.admin": "Administrator",
   "label.after": "Po",
   "label.all": "Vsi",
   "label.all-time": "Ves čas",

--- a/src/lang/sv-SE.json
+++ b/src/lang/sv-SE.json
@@ -6,7 +6,7 @@
   "label.add-description": "Lägg till beskrivning",
   "label.add-member": "Add member",
   "label.add-website": "Lägg till webbplats",
-  "label.administrator": "Administratör",
+  "label.admin": "Administratör",
   "label.after": "Efter",
   "label.all": "Alla",
   "label.all-time": "Sedan början",

--- a/src/lang/ta-IN.json
+++ b/src/lang/ta-IN.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "வலைத்தளத்தைச் சேர்க்க",
-  "label.administrator": "நிர்வாகியைச் சேர்க்க",
+  "label.admin": "நிர்வாகியைச் சேர்க்க",
   "label.after": "After",
   "label.all": "எல்லாம்",
   "label.all-time": "All time",

--- a/src/lang/th-TH.json
+++ b/src/lang/th-TH.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "เพิ่มเว็บไซต์",
-  "label.administrator": "ผู้ดูแลระบบ",
+  "label.admin": "ผู้ดูแลระบบ",
   "label.after": "After",
   "label.all": "ทั้งหมด",
   "label.all-time": "ทุกช่วงเวลา",

--- a/src/lang/tr-TR.json
+++ b/src/lang/tr-TR.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Web sitesi ekle",
-  "label.administrator": "Yönetici",
+  "label.admin": "Yönetici",
   "label.after": "After",
   "label.all": "Tümü",
   "label.all-time": "All time",

--- a/src/lang/uk-UA.json
+++ b/src/lang/uk-UA.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Додати сайт",
-  "label.administrator": "Адміністратор",
+  "label.admin": "Адміністратор",
   "label.after": "After",
   "label.all": "Всі",
   "label.all-time": "Весь час",

--- a/src/lang/ur-PK.json
+++ b/src/lang/ur-PK.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "ویب سائٹ کا اضافہ کریں",
-  "label.administrator": "منتظم",
+  "label.admin": "منتظم",
   "label.after": "After",
   "label.all": "تمام",
   "label.all-time": "تمام وقت",

--- a/src/lang/vi-VN.json
+++ b/src/lang/vi-VN.json
@@ -6,7 +6,7 @@
   "label.add-description": "Add description",
   "label.add-member": "Add member",
   "label.add-website": "Thêm website",
-  "label.administrator": "Quản trị",
+  "label.admin": "Quản trị",
   "label.after": "After",
   "label.all": "Tất cả",
   "label.all-time": "Toàn thời gian",

--- a/src/lang/zh-CN.json
+++ b/src/lang/zh-CN.json
@@ -6,7 +6,7 @@
   "label.add-description": "添加描述",
   "label.add-member": "Add member",
   "label.add-website": "添加网站",
-  "label.administrator": "管理员",
+  "label.admin": "管理员",
   "label.after": "之后",
   "label.all": "所有",
   "label.all-time": "所有时间段",

--- a/src/lang/zh-TW.json
+++ b/src/lang/zh-TW.json
@@ -6,7 +6,7 @@
   "label.add-description": "新增描述",
   "label.add-member": "Add member",
   "label.add-website": "新增網站",
-  "label.administrator": "管理員",
+  "label.admin": "管理員",
   "label.after": "之後",
   "label.all": "全部",
   "label.all-time": "所有時間",


### PR DESCRIPTION
## Headline
Fix the admin label on `<UsersTable />` within `/settings/users`

## Details
In `src/app/(main)/settings/users/UsersTable.tsx:25` it expects to find a role `ROLES['admin']` based on the role name in the database, which doesn't exist. Everywhere else in the codebase it seems to use `ROLES.administrator`.

This is the easiest/most backwards compatible way I could think of to fix this, without requiring a migration to update the users' role fields in the database.

Before:
<img width="1136" alt="image" src="https://github.com/mhespenh/umami/assets/1562473/61e40706-757e-47c4-86fc-0b6a8d12f67b">

After:
<img width="1136" alt="image" src="https://github.com/mhespenh/umami/assets/1562473/d578da0d-1fc4-4382-b983-7fa5e168cea7">

I haven't worked with this translation lib before, so hopefully I updated things correctly- please check my work and let me know if there is a different/better way to do this with `react-intl`