### PR TITLE
Support prisma pattern matching to match URL in funnels

### DIFF
--- a/src/queries/analytics/reports/getFunnel.ts
+++ b/src/queries/analytics/reports/getFunnel.ts
@@ -81,8 +81,8 @@ async function relationalQuery(
                   `l.created_at `,
                   `${windowMinutes} minute`,
                 )}
-                and we.referrer_path = {{${i - 1}}}
-                and we.url_path = {{${i}}}
+                and we.referrer_path like {{${i - 1}}}
+                and we.url_path like {{${i}}}
                 and we.created_at <= {{endDate}}
           )`;
         }
@@ -105,7 +105,7 @@ async function relationalQuery(
       from website_event
       where website_id = {{websiteId::uuid}}
         and created_at between {{startDate}} and {{endDate}}
-        and url_path = {{0}}
+        and url_path like {{0}}
     )
     ${levelQuery}
     ${sumQuery}
@@ -165,8 +165,8 @@ async function clickhouseQuery(
             join level0 y
             on x.session_id = y.session_id
             where y.created_at between x.created_at and x.created_at + interval ${windowMinutes} minute
-                and y.referrer_path = {url${i - 1}:String}
-                and y.url_path = {url${i}:String}
+                and y.referrer_path like {url${i - 1}:String}
+                and y.url_path like {url${i}:String}
           )`;
         }
 
@@ -197,7 +197,7 @@ async function clickhouseQuery(
     level1 AS (
       select *
       from level0
-      where url_path = {url0:String}
+      where url_path like {url0:String}
     )
     ${levelQuery}
     select *


### PR DESCRIPTION
An example is a funnel from the homepage to a cart page

1. Home page `http://whatever.com/`
2. The user selects an item `http://whatever.com/item/3d606f61-7a1d-408e-bcb2-577d2a2725b7/`
3. The user adds the item to the cart and go to checkout `http://whatever.com/checkout/`
4. User completes the checkout `http://whatever.com/success/`

This change enables a funnel to be described like this sequence of URLs:

1. `/`
2. `/item/%/`
3. `/checkout/`
4. `/success/`
