### PR TITLE
Add minimum database versions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A detailed getting started guide can be found at [https://umami.is/docs/](https:
 ### Requirements
 
 - A server with Node.js version 16.13 or newer
-- A database. Umami supports [MySQL](https://www.mysql.com/) and [Postgresql](https://www.postgresql.org/) databases.
+- A database. Umami supports [MySQL](https://www.mysql.com/) (minimum v8.0) and [Postgresql](https://www.postgresql.org/) (minimum v12.14) databases.
 
 ### Install Yarn
 


### PR DESCRIPTION
Add minimum mysql/postgres versions to readme.

These are the same versions as used in the `umami-software/website` repository: https://github.com/umami-software/website/blob/master/src/content/docs/v2/install.mdx