### PR TITLE
Order event data in descending order by count

### DIFF
--- a/src/queries/analytics/eventData/getEventDataEvents.ts
+++ b/src/queries/analytics/eventData/getEventDataEvents.ts
@@ -33,7 +33,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
         and event_data.created_at between {{startDate}} and {{endDate}}
         and website_event.event_name = {{event}}
       group by website_event.event_name, event_data.data_key, event_data.data_type, event_data.string_value
-      order by 1 asc, 2 asc, 3 asc, 4 desc
+      order by 1 asc, 2 asc, 3 asc, 5 desc
       `,
       params,
     );
@@ -81,7 +81,7 @@ async function clickhouseQuery(
         and created_at between {startDate:DateTime64} and {endDate:DateTime64}
         and event_name = {event:String}
       group by data_key, data_type, string_value, event_name
-      order by 1 asc, 2 asc, 3 asc, 4 desc
+      order by 1 asc, 2 asc, 3 asc, 5 desc
       limit 500
       `,
       params,


### PR DESCRIPTION
Think this is a bug where `fieldValue` was being sorted in descending order (which doesn't make much sense) instead of `count`.

| Before | After |
| --- | --- |
| ![bef](https://github.com/umami-software/umami/assets/12485023/ac0a5fd8-ec3c-4124-9770-afad61342119) | ![aft](https://github.com/umami-software/umami/assets/12485023/6780899d-fd94-46eb-8c81-a2ed911638ce) |

