### PR TITLE
Adding one-click deployment buttons to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ docker compose pull
 docker compose up --force-recreate
 ```
 
+## One-Click Deployment
+
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/?app_id=67)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/umami-analytics)
+
 ## License
 
 MIT


### PR DESCRIPTION
This pull request adds one-click deployment buttons to the README.md of the Umami project. These buttons provide straightforward, direct deployment options for users and contributors, facilitating an effortless setup and launch of Umami on different platforms.

Key Benefits:
- **Ease of Use**: These buttons simplify the process for both new and existing users to deploy Umami quickly, reducing setup complexity and encouraging more widespread use.
- **Community Growth**: By lowering the barrier to entry for deployment, these buttons help attract a diverse range of contributors and users, fostering a larger and more active community.
- **Flexible Deployment Choices**: Offers users the freedom to choose their preferred deployment method from the outset, enhancing user satisfaction and broadening Umami's appeal.

This enhancement supports Umami's goal of being user-friendly and widely accessible, making it easier for the community to grow and thrive.