### PR TITLE
Add Cascade delete to event_data

### DIFF
--- a/db/mysql/migrations/07_event_data_cascade_delete/migration.sql
+++ b/db/mysql/migrations/07_event_data_cascade_delete/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE 
+  event_data 
+ADD 
+  CONSTRAINT fk_website_event FOREIGN KEY (website_event_id) REFERENCES website_event(event_id) ON DELETE CASCADE;

--- a/db/postgresql/migrations/07_event_data_cascade_delete/migration.sql
+++ b/db/postgresql/migrations/07_event_data_cascade_delete/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE 
+  event_data 
+ADD 
+  CONSTRAINT fk_website_event FOREIGN KEY (website_event_id) REFERENCES website_event(event_id) ON DELETE CASCADE;


### PR DESCRIPTION
Addition of cascading delete functionality to ensure that all data related to a specific period is correctly removed.
Update of database schemas and necessary migration scripts.

Discussion : https://github.com/umami-software/umami/discussions/2789
