### PR TITLE
fix: mobile dvh and dashboard website header breaking

### DIFF
--- a/src/app/(main)/layout.module.css
+++ b/src/app/(main)/layout.module.css
@@ -17,5 +17,6 @@
   grid-row: 2 / 3;
   min-height: 0;
   height: calc(100vh - 60px);
+  height: calc(100dvh - 60px);
   overflow-y: auto;
 }

--- a/src/app/(main)/websites/[websiteId]/WebsiteHeader.module.css
+++ b/src/app/(main)/websites/[websiteId]/WebsiteHeader.module.css
@@ -1,7 +1,9 @@
 .header {
-  display: grid;
-  grid-template-columns: 1fr max-content;
+  display: flex;
+  gap: 10px;
   align-items: center;
+  flex-wrap: wrap;
+  padding: 20px 0px;
 }
 
 .title {
@@ -12,7 +14,7 @@
   font-size: 24px;
   font-weight: 700;
   overflow: hidden;
-  height: 100px;
+  height: 60px;
 }
 
 .actions {
@@ -22,6 +24,7 @@
   justify-content: flex-end;
   gap: 30px;
   min-height: 0;
+  margin-left: auto;
 }
 
 .selected {

--- a/src/app/share/[...shareId]/SharePage.module.css
+++ b/src/app/share/[...shareId]/SharePage.module.css
@@ -1,4 +1,5 @@
 .container {
   flex: 1;
   min-height: calc(100vh - 200px);
+  min-height: calc(100dvh - 200px);
 }

--- a/src/components/layout/Page.module.css
+++ b/src/components/layout/Page.module.css
@@ -8,4 +8,5 @@
   margin: 0 auto;
   padding: 0 20px;
   min-height: calc(100vh - 60px);
+  min-height: calc(100dvh - 60px);
 }


### PR DESCRIPTION
This PR fixes some two style issues that appeared on mobile screen sizes.

The first thing is that the scroll container was set to a height of `calc(100vh - 60px)` which is the screen height minus the header height. For some browsers e.g. Safari on iOS this makes the whole page scrollable so you have two scroll containers and the header can be scrolled out of the viewport which is not wanted. I added another line that uses the dynamic virtual height dvh in addition to the fallback if the used browser does not support dvh. 

The other issue was that the website header on the dashboard page was using `display: grid` and wrapped even when it was not needed. In addition there was a missing space underneath the button which looked a bit squeezed together.

**Before**:
![IMG_0259](https://github.com/user-attachments/assets/02b4fec7-633c-42d9-b938-48c3e95662f7)

**After** this shows the fix: there is only one scroll container and the button in the website header is not breaking into the next line. Also there is some padding that makes the spacing more balanced.
![IMG_0260](https://github.com/user-attachments/assets/2bb3d4c2-a1d3-4109-99e6-8deaeff7e67d)

To replicate the issue just open the dashboard site on any mobile browser preferably one that supports dynamic heights like Safari.

