### PR TITLE
fix: Compatible with browsers that do not support ES2019

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -44,7 +44,7 @@
       if (result !== str) {
         return result;
       }
-    } catch {
+    } catch (e) {
       return str;
     }
 
@@ -55,7 +55,7 @@
     try {
       const { pathname, search } = new URL(url);
       url = pathname + search;
-    } catch {
+    } catch (e) {
       /* empty */
     }
     return excludeSearch ? url.split('?')[0] : url;
@@ -217,7 +217,7 @@
       const text = await res.text();
 
       return (cache = text);
-    } catch {
+    } catch (e) {
       /* empty */
     }
   };


### PR DESCRIPTION
In ES2019, we can omit the parameters in `catch`, and an error will be reported in the browser that does not support ES2019
```js
Uncaught SyntaxError: Unexpected token {
```
Compatible with browsers that do not support ES2019