### PR TITLE
Use init when running in Docker to avoid zombie process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       db:
         condition: service_healthy
+    init: true
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "curl http://localhost:3000/api/heartbeat"]


### PR DESCRIPTION
When the `start-docker` script is executed, some process is not properly cleaned up and ends up in a zombie state.

Using the `init` flag when launching the container runs an init process inside the container that will forward signals to node and reap processes.

Fixes: #1428