### PR TITLE
feat: Add support for hash-based routing tracking

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -53,8 +53,9 @@
 
   const parseURL = url => {
     try {
-      const { pathname, search } = new URL(url);
-      url = pathname + search;
+      // use location.origin as the base to handle cases where the url is a relative path
+      const { pathname, search, hash } = new URL(url, location.origin);
+      url = pathname + search + hash;
     } catch (e) {
       /* empty */
     }


### PR DESCRIPTION
Fix: #2954 

#### Changes
- Added support for hash-based routing to ensure proper URL parsing.
- Used `location.origin` as the base to ensure relative paths are correctly processed.

#### Before
![image](https://github.com/user-attachments/assets/db97a4d4-93f5-486d-9f5b-790316979120)

#### After
![image](https://github.com/user-attachments/assets/56525bf8-1f02-4af1-91f8-cddfb90c7968)

