### PR TITLE
fix tracker localStorage DOMException in data URLs

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -3,10 +3,10 @@
     screen: { width, height },
     navigator: { language },
     location,
-    localStorage,
     document,
     history,
   } = window;
+  const localStorage = location.href.startsWith('data:') ? undefined : window.localStorage
   const { hostname, href } = location;
   const { currentScript, referrer } = document;
 

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -63,7 +63,7 @@
 
   const getPayload = () => ({
     website,
-    hostname,
+    hostname || 'none',
     screen,
     language,
     title: encode(title),


### PR DESCRIPTION
The current tracker.js does not work on data URLs pages,

Because:

- Direct access to localStorage (will throw DOMException)
- hostname is empty (`""`)


What is a data URLs page:

Use HTML as data to write pages in the URL. It has many uses such as third-party plug-in systems, such as plug-ins in Figma.com

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/32e8241f-ceea-4c17-87b0-332ce533b11b">

Directly accessing localStorage in such a page will throw an exception:
`Uncaught DOMException: Failed to read the 'localStorage' property from 'Window': Storage is disabled inside 'data:' URLs.`

<img width="882" alt="image" src="https://github.com/user-attachments/assets/6a7353ef-fd53-4ad7-b9f7-117ea3a90046">



This PR makes tracker.js compatible with this case