### PR TITLE
fix: use the same id for event and event data for clickhouse

### DIFF
--- a/src/queries/analytics/events/saveEvent.ts
+++ b/src/queries/analytics/events/saveEvent.ts
@@ -145,7 +145,7 @@ async function clickhouseQuery(data: {
     website_id: websiteId,
     session_id: sessionId,
     visit_id: visitId,
-    event_id: uuid(),
+    event_id: eventId,
     country: country,
     subdivision1:
       country && subdivision1


### PR DESCRIPTION
The eventId for the event and event data for clickhouse is different, but in case of postgresql its the same.

Since the event ids on event and data are different there is no easy way to relate the event data with event and see the thing as one in case of clickhouse.

I am not sure if 2 different ID's was an intended or not, if it was intended then please ignore and close the PR