### PR TITLE
Update umami docker image url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '3'
 services:
   umami:
-    image: ghcr.io/umami-software/umami:postgresql-latest
+    image: docker.umami.is/umami-software/umami:postgresql-latest
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
The  umami docker image url  `ghcr.io/umami-software/umami:postgresql-latest` was not found, use `docker.umami.is/umami-software/umami:postgresql-latest` (copied form README.md) instead.

<img width="945" alt="image" src="https://github.com/user-attachments/assets/efa2ff2c-b478-42ba-9df7-674e496b03de">
