### PR TITLE
Set engine to InnoDB for MySQL

### DIFF
--- a/db/mysql/migrations/01_init/migration.sql
+++ b/db/mysql/migrations/01_init/migration.sql
@@ -11,7 +11,7 @@ CREATE TABLE `user` (
     UNIQUE INDEX `user_user_id_key`(`user_id`),
     UNIQUE INDEX `user_username_key`(`username`),
     PRIMARY KEY (`user_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `session` (
@@ -33,7 +33,7 @@ CREATE TABLE `session` (
     INDEX `session_created_at_idx`(`created_at`),
     INDEX `session_website_id_idx`(`website_id`),
     PRIMARY KEY (`session_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `website` (
@@ -53,7 +53,7 @@ CREATE TABLE `website` (
     INDEX `website_created_at_idx`(`created_at`),
     INDEX `website_share_id_idx`(`share_id`),
     PRIMARY KEY (`website_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `website_event` (
@@ -76,7 +76,7 @@ CREATE TABLE `website_event` (
     INDEX `website_event_website_id_created_at_idx`(`website_id`, `created_at`),
     INDEX `website_event_website_id_session_id_created_at_idx`(`website_id`, `session_id`, `created_at`),
     PRIMARY KEY (`event_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `event_data` (
@@ -95,7 +95,7 @@ CREATE TABLE `event_data` (
     INDEX `event_data_website_event_id_idx`(`website_event_id`),
     INDEX `event_data_website_id_website_event_id_created_at_idx`(`website_id`, `website_event_id`, `created_at`),
     PRIMARY KEY (`event_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `team` (
@@ -109,7 +109,7 @@ CREATE TABLE `team` (
     UNIQUE INDEX `team_access_code_key`(`access_code`),
     INDEX `team_access_code_idx`(`access_code`),
     PRIMARY KEY (`team_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `team_user` (
@@ -124,7 +124,7 @@ CREATE TABLE `team_user` (
     INDEX `team_user_team_id_idx`(`team_id`),
     INDEX `team_user_user_id_idx`(`user_id`),
     PRIMARY KEY (`team_user_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `team_website` (
@@ -137,7 +137,7 @@ CREATE TABLE `team_website` (
     INDEX `team_website_team_id_idx`(`team_id`),
     INDEX `team_website_website_id_idx`(`website_id`),
     PRIMARY KEY (`team_website_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AddSystemUser
 INSERT INTO user (user_id, username, role, password) VALUES ('41e2b680-648e-4b09-bcd7-3e2b10c06264' , 'admin', 'admin', '$2b$10$BUli0c.muyCW1ErNJc3jL.vFRFtFJWrT8/GcR4A.sUdCznaXiqFXa');

--- a/db/mysql/migrations/02_report_schema_session_data/migration.sql
+++ b/db/mysql/migrations/02_report_schema_session_data/migration.sql
@@ -21,7 +21,7 @@ CREATE TABLE `session_data` (
     INDEX `session_data_website_id_idx`(`website_id`),
     INDEX `session_data_session_id_idx`(`session_id`),
     PRIMARY KEY (`session_data_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- CreateTable
 CREATE TABLE `report` (
@@ -41,7 +41,7 @@ CREATE TABLE `report` (
     INDEX `report_type_idx`(`type`),
     INDEX `report_name_idx`(`name`),
     PRIMARY KEY (`report_id`)
-) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+) ENGINE=InnoDB DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- EventData migration
 UPDATE event_data


### PR DESCRIPTION
I've had trouble setting up Umami on a shared hosting where the default MySQL engine was MyISAM, and I didn't have the permissions to change it.

As per Prisma docs, _If you are using a version of MySQL where MyISAM is the default engine, you must specify ENGINE = InnoDB; when you create a table_. 

The changes in this MR fixed my issues.

Looks like they were previously removed here https://github.com/umami-software/umami/pull/1770/files . I'm not sure though if it was on purpose or were just considered redundant?