### PR TITLE
fix: respect filter in TableView

### DIFF
--- a/src/components/hooks/queries/useWebsiteMetrics.ts
+++ b/src/components/hooks/queries/useWebsiteMetrics.ts
@@ -20,12 +20,8 @@ export function useWebsiteMetrics(
       },
     ],
     queryFn: async () => {
-      const filters = { ...params };
-
-      filters[queryParams.type] = undefined;
-
       const data = await get(`/websites/${websiteId}/metrics`, {
-        ...filters,
+        ...params,
         ...queryParams,
       });
 

--- a/src/components/hooks/queries/useWebsiteMetrics.ts
+++ b/src/components/hooks/queries/useWebsiteMetrics.ts
@@ -22,15 +22,9 @@ export function useWebsiteMetrics(
       },
     ],
     queryFn: async () => {
-      const filters = { ...params };
-      const view = searchParams.get('view');
-
-      if (view && filters[view]) {
-        filters[view] = undefined;
-      }
-
       const data = await get(`/websites/${websiteId}/metrics`, {
-        ...filters,
+        ...params,
+        [searchParams.get('view')]: undefined,
         ...queryParams,
       });
 

--- a/src/components/hooks/queries/useWebsiteMetrics.ts
+++ b/src/components/hooks/queries/useWebsiteMetrics.ts
@@ -1,6 +1,7 @@
 import { UseQueryOptions } from '@tanstack/react-query';
 import useApi from './useApi';
 import { useFilterParams } from '../useFilterParams';
+import { useSearchParams } from 'next/navigation';
 
 export function useWebsiteMetrics(
   websiteId: string,
@@ -9,6 +10,7 @@ export function useWebsiteMetrics(
 ) {
   const { get, useQuery } = useApi();
   const params = useFilterParams(websiteId);
+  const searchParams = useSearchParams();
 
   return useQuery({
     queryKey: [
@@ -20,8 +22,15 @@ export function useWebsiteMetrics(
       },
     ],
     queryFn: async () => {
+      const filters = { ...params };
+      const view = searchParams.get('view');
+
+      if (view && filters[view]) {
+        filters[view] = undefined;
+      }
+
       const data = await get(`/websites/${websiteId}/metrics`, {
-        ...params,
+        ...filters,
         ...queryParams,
       });
 


### PR DESCRIPTION
By adjusting the filtering in the `useWebsiteMetrics` hook based on whether the table or expanded view is displayed, I ensured that the filters apply to the entire detail page, not just the `WebsiteMetricsBar`. However, in the expanded view, the filter is not respected, so the current flow of listing all entries remains unchanged.
Should fix #2769 