### PR TITLE
fix: add z-index to dropdown menu

### DIFF
--- a/src/app/(main)/websites/[websiteId]/WebsiteExpandedView.module.css
+++ b/src/app/(main)/websites/[websiteId]/WebsiteExpandedView.module.css
@@ -59,5 +59,6 @@
     align-items: center;
     justify-content: space-between;
     padding-inline-end: 0;
+    z-index: 10;
   }
 }


### PR DESCRIPTION
Fixes #3039

As in the issue described the dropdown menu was behind the content. By adding a z-index to that element, this problem can no longer be reproduced in Safari.
<details>
<summary>Before:</summary>
<img width="642" alt="Screenshot 2024-11-17 at 17 00 15" src="https://github.com/user-attachments/assets/a9eed194-6e5d-4709-aa1a-ddc780f70eff">
</details>
<details>
<summary>After:</summary>
<img width="686" alt="Screenshot 2024-11-17 at 17 00 26" src="https://github.com/user-attachments/assets/ae64d7a9-db73-4209-9b9f-40cf94752439">

</details>

