### PR TITLE
Use `unknown` label for `undefined` countries

### DIFF
--- a/src/components/metrics/WorldMap.tsx
+++ b/src/components/metrics/WorldMap.tsx
@@ -28,6 +28,7 @@ export function WorldMap({
   const { formatMessage, labels } = useMessages();
   const { countryNames } = useCountryNames(locale);
   const visitorsLabel = formatMessage(labels.visitors).toLocaleLowerCase(locale);
+  const unknownLabel = formatMessage(labels.unknown);
   const {
     dateRange: { startDate, endDate },
   } = useDateRange(websiteId);
@@ -62,7 +63,9 @@ export function WorldMap({
     if (code === 'AQ') return;
     const country = metrics?.find(({ x }) => x === code);
     setTooltipPopup(
-      `${countryNames[code]}: ${formatLongNumber(country?.y || 0)} ${visitorsLabel}` as any,
+      `${countryNames[code] || unknownLabel}: ${formatLongNumber(
+        country?.y || 0,
+      )} ${visitorsLabel}` as any,
     );
   };
 


### PR DESCRIPTION
**Improve handling of `unknown` countries in `WorldMap` component**

**Changes**
- Replace `undefined` text with localized `Unknown` label for countries that don't exist in `countryNames`
- Utilizes existing `labels.unknown` translation key, maintaining consistency across languages

**Before**
When hovering over an unmapped country code, the tooltip would show: `undefined: 0 visitors`
<img width="414" alt="before" src="https://github.com/user-attachments/assets/81d9699e-8829-4d92-be33-d0235f6c1451">


**After**
When hovering over an unmapped country code, the tooltip now shows: `Unknown: 0 visitors` (or equivalent in the user's selected language)
<img width="402" alt="after" src="https://github.com/user-attachments/assets/340cfb21-b34d-4729-bbc3-a4551526eff0">
<img width="325" alt="after-fi" src="https://github.com/user-attachments/assets/402242ef-226a-4644-aecc-b4c62e0f3944">


**Technical Details**
- Modified `handleHover` function in `WorldMap.tsx` to use fallback value
- Leverages existing translation infrastructure
- No new translation keys needed

**Testing**
- Hover over known countries: displays correct country name
- Hover over unknown country codes: displays localized `Unknown` text
- Tested with different language settings to ensure proper translation