### PR TITLE
fix #3083 improve the parseURL function to handle page-relative URLs

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -54,7 +54,7 @@
   const parseURL = url => {
     try {
       // use location.origin as the base to handle cases where the url is a relative path
-      const { pathname, search, hash } = new URL(url, origin);
+      const { pathname, search, hash } = new URL(url, href);
       url = pathname + search + hash;
     } catch (e) {
       /* empty */
@@ -79,6 +79,7 @@
     if (!url) return;
 
     currentRef = currentUrl;
+    
     currentUrl = parseURL(url.toString());
 
     if (currentUrl !== currentRef) {

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -54,7 +54,7 @@
   const parseURL = url => {
     try {
       // use location.origin as the base to handle cases where the url is a relative path
-      const { pathname, search, hash } = new URL(url, href);
+      const { pathname, search, hash } = new URL(url, location.href);
       url = pathname + search + hash;
     } catch (e) {
       /* empty */
@@ -79,7 +79,6 @@
     if (!url) return;
 
     currentRef = currentUrl;
-    
     currentUrl = parseURL(url.toString());
 
     if (currentUrl !== currentRef) {


### PR DESCRIPTION
In #3083 I noticed that some of my hash URLs were tracked without including the path. Upon inspection I found out that the `parseURL` implementation included a bug: it resolved against `origin` and not against `href`, which means that page-relative URLs coming from pushState are resolved incorrectly.

The following links all resolve to the same page:
- fully specified: `https://example.com/foo/bar`
- relative to the root: `/foo/bar`
- relative to the current page: `../bar` when you're on  `https://example.com/foo/baz`

When using `origin` the last one will resolve incorrectly (it will try to go a subfolder higher than the origin), as it should be compared to the current href.

This URL resolution is also why pushstate can contain just `#selector=foo` and resolve correctly against the current page. 

Fixes #3083.