### PR TITLE
Update ja-JP.json

### DIFF
--- a/src/lang/ja-JP.json
+++ b/src/lang/ja-JP.json
@@ -229,7 +229,7 @@
   "label.views-per-visit": "訪問あたりの閲覧数",
   "label.visit-duration": "平均滞在時間",
   "label.visitors": "訪問者",
-  "label.visits": "訪問者数",
+  "label.visits": "訪問数",
   "label.website": "Webサイト",
   "label.website-id": "WebサイトID",
   "label.websites": "Webサイト",


### PR DESCRIPTION
I think `訪問数` is a more appropriate Japanese translation of "visits".
The current translation `訪問者数` means "number of visitors" in Japanese.