### PR TITLE
add 28 days filter option

### DIFF
--- a/src/components/input/DateFilter.tsx
+++ b/src/components/input/DateFilter.tsx
@@ -54,6 +54,10 @@ export function DateFilter({
       divider: true,
     },
     {
+      label: formatMessage(labels.lastDays, { x: 28 }),
+      value: '28day',
+    },
+    {
       label: formatMessage(labels.lastDays, { x: 30 }),
       value: '30day',
     },


### PR DESCRIPTION
This fixes issue #3063

The 28 day view is, I think, important enough to make easily accessible.