### PR TITLE
Fix Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     strategy:
       matrix:
         include:
-        - node-version: 18.17
+        - node-version: 18.18
           db-type: postgresql
-        - node-version: 18.17
+        - node-version: 18.18
           db-type: mysql
 
     steps:

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A detailed getting started guide can be found at [umami.is/docs](https://umami.i
 
 ### Requirements
 
-- A server with Node.js version 16.13 or newer
+- A server with Node.js version 18.18 or newer
 - A database. Umami supports [MariaDB](https://www.mariadb.org/) (minimum v10.5), [MySQL](https://www.mysql.com/) (minimum v8.0) and [PostgreSQL](https://www.postgresql.org/) (minimum v12.14) databases.
 
 ### Install Yarn

--- a/src/lib/__tests__/detect.test.ts
+++ b/src/lib/__tests__/detect.test.ts
@@ -1,4 +1,5 @@
 import * as detect from '../detect';
+import { expect } from '@jest/globals';
 
 const IP = '127.0.0.1';
 

--- a/src/lib/__tests__/format.test.ts
+++ b/src/lib/__tests__/format.test.ts
@@ -1,4 +1,5 @@
 import * as format from '../format';
+import { expect } from '@jest/globals';
 
 test('parseTime', () => {
   expect(format.parseTime(86400 + 3600 + 60 + 1)).toEqual({


### PR DESCRIPTION
Hi there,

We are using a fork of umami for our own usage and I noticed the CI broke when I did the update an hour ago.

This should fix it (upgrade node to 18.18 and fix the tests).