### PR TITLE
Omit credentials in tracker fetch request

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -214,6 +214,7 @@
         method: 'POST',
         body: JSON.stringify({ type, payload }),
         headers,
+        credentials: 'omit',
       });
       const text = await res.text();
 


### PR DESCRIPTION
Adds `credentials: "omit"` to the fetch request options

Fixes CORS issues that may occur in at least the following scenario:

- Umami self-hosted on `umami.example.com`
- App with tracker script included on `app.example.com`

Tracker POST request may fail due to fetch sending credentials for same origin requests by default, but umami does not have a `Access-Control-Allow-Credentials` in its CORS options (and it shouldn't)