### PR TITLE
Fix issue with missing user role in Redis authentication

### DIFF
--- a/src/pages/api/auth/login.ts
+++ b/src/pages/api/auth/login.ts
@@ -50,7 +50,7 @@ export default async (
 
     if (user && checkPassword(password, user.password)) {
       if (redisEnabled) {
-        const token = await saveAuth({ userId: user.id });
+        const token = await saveAuth({ userId: user.id, role: user.role });
 
         return ok(res, { token, user });
       }


### PR DESCRIPTION
Hello,

There is an issue when using Redis for user authentication. The problem is that only the user ID is being saved in the Redis database. Consequently, when the `useAuth` function in `lib/middleware` attempts to check if the user is an admin, it fails because the `role` property is missing.

#### Issue Description
In the `useAuth` function in `lib/middleware`, the user admin is being checked by the `role` property:

```javascript
user.isAdmin = user.role === ROLES.admin;
```

However, when the user is authenticated using Redis, the `role` property is not present, leading to an incorrect admin status check.

#### The changes i made to fix this issue
To fix this issue, update the default export of `src/pages/api/auth/login.ts`. Currently, only the `userId` is saved in Redis:

```javascript
if (redisEnabled) {
  const token = await saveAuth({ userId: user.id });
  return ok(res, { token, user });
}
```

Update this to include the `role` property as well:

```javascript
if (redisEnabled) {
  const token = await saveAuth({ userId: user.id, role: user.role });
  return ok(res, { token, user });
}
```

This ensures that the `role` property is saved in Redis, allowing the `useAuth` function to accurately check the user's admin status.
