### PR TITLE
Consider hash as part of the path

### DIFF
--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -133,13 +133,15 @@ export async function POST(request: Request) {
       const base = hostname ? `https://${hostname}` : 'https://localhost';
       const currentUrl = new URL(url, base);
 
-      let urlPath = currentUrl.pathname + currentUrl.hash;
+      let urlPath = currentUrl.pathname;
       const urlQuery = currentUrl.search.substring(1);
       const urlDomain = currentUrl.hostname.replace(/^www./, '');
 
       if (process.env.REMOVE_TRAILING_SLASH) {
         urlPath = urlPath.replace(/(.+)\/$/, '$1');
       }
+
+      urlPath = urlPath + currentUrl.hash;
 
       let referrerPath: string;
       let referrerQuery: string;

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -133,7 +133,7 @@ export async function POST(request: Request) {
       const base = hostname ? `https://${hostname}` : 'https://localhost';
       const currentUrl = new URL(url, base);
 
-      let urlPath = currentUrl.pathname;
+      let urlPath = currentUrl.pathname + currentUrl.hash;
       const urlQuery = currentUrl.search.substring(1);
       const urlDomain = currentUrl.hostname.replace(/^www./, '');
 


### PR DESCRIPTION
The tracker script already sends paths correctly with their hash part, but the database does not store them yet in `url_path`. So the UI cannot show them.

This pull request implements the missing piece of what was already described in #2960:

<img width="669" alt="Untitled" src="https://github.com/user-attachments/assets/d3b58a08-dd6d-426b-8828-bde6740b79c4" />
