### PR TITLE
♻️ refactor(docker): remove versioning in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   umami:
     image: ghcr.io/umami-software/umami:postgresql-latest


### PR DESCRIPTION
Remove docker-compose versioning as it's deprecated.

This will also remove the warning message `the attribute version is obsolete, it will be ignored, please remove it to avoid potential confusion`.

Reference: https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete