### PR TITLE
Add `-d` flag to update commands to reflect docker install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ To update the Docker image, simply pull the new images and rebuild:
 
 ```bash
 docker compose pull
-docker compose up --force-recreate
+docker compose up --force-recreate -d
 ```
 
 ---


### PR DESCRIPTION
The intial installation instructions tell users to run `docker compose up -d`. The intent is to run the Docker stack in detached mode. Yet the update instructions doesn't add this flag. This commit simply adds that flag to the README