### PR TITLE
Fix duplicate key errors

### DIFF
--- a/src/app/(main)/websites/[websiteId]/realtime/RealtimeLog.tsx
+++ b/src/app/(main)/websites/[websiteId]/realtime/RealtimeLog.tsx
@@ -101,10 +101,10 @@ export function RealtimeLog({ data }: { data: RealtimeData }) {
 
     if (__type === TYPE_SESSION) {
       return formatMessage(messages.visitorLog, {
-        country: <b>{countryNames[country] || formatMessage(labels.unknown)}</b>,
-        browser: <b>{BROWSERS[browser]}</b>,
-        os: <b>{OS_NAMES[os] || os}</b>,
-        device: <b>{formatMessage(labels[device] || labels.unknown)}</b>,
+        country: <b key="country">{countryNames[country] || formatMessage(labels.unknown)}</b>,
+        browser: <b key="browser">{BROWSERS[browser]}</b>,
+        os: <b key="os">{OS_NAMES[os] || os}</b>,
+        device: <b key="device">{formatMessage(labels[device] || labels.unknown)}</b>,
       });
     }
   };

--- a/src/app/(main)/websites/[websiteId]/realtime/RealtimeLog.tsx
+++ b/src/app/(main)/websites/[websiteId]/realtime/RealtimeLog.tsx
@@ -71,9 +71,10 @@ export function RealtimeLog({ data }: { data: RealtimeData }) {
 
     if (__type === TYPE_EVENT) {
       return formatMessage(messages.eventLog, {
-        event: <b>{eventName || formatMessage(labels.unknown)}</b>,
+        event: <b key="b">{eventName || formatMessage(labels.unknown)}</b>,
         url: (
           <a
+            key="a"
             href={`//${website?.domain}${url}`}
             className={styles.link}
             target="_blank"

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionsWeekly.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionsWeekly.tsx
@@ -62,10 +62,10 @@ export function SessionsWeekly({ websiteId }: { websiteId: string }) {
                 <div className={styles.header}>
                   {format(getDayOfWeekAsDate(index), 'EEE', { locale: dateLocale })}
                 </div>
-                {day?.map((hour: number) => {
+                {day?.map((hour: number, j) => {
                   const pct = hour / max;
                   return (
-                    <div key={hour} className={classNames(styles.cell)}>
+                    <div key={j} className={classNames(styles.cell)}>
                       {hour > 0 && (
                         <TooltipPopup
                           label={`${formatMessage(labels.visitors)}: ${hour}`}


### PR DESCRIPTION
For SessionsWeekly, the number per hours was used as key, but this is not necessarily unique.
For RealtimeLog, apparently tags in the variables need a key as well.