### PR TITLE
add CORS headers to any value of COLLECT_API_ENDPOINT in addition to /api/* endpoints

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -59,15 +59,29 @@ const trackerHeaders = [
   },
 ];
 
+const apiHeaders = [
+  {
+    key: 'Access-Control-Allow-Origin',
+    value: '*'
+  },
+  {
+    key: 'Access-Control-Allow-Headers',
+    value: '*'
+  },
+  {
+    key: 'Access-Control-Allow-Methods',
+    value: 'GET, DELETE, POST, PUT'
+  },
+  {
+    key: 'Access-Control-Max-Age',
+    value: corsMaxAge || '86400'
+  },
+];
+
 const headers = [
   {
     source: '/api/:path*',
-    headers: [
-      { key: 'Access-Control-Allow-Origin', value: '*' },
-      { key: 'Access-Control-Allow-Headers', value: '*' },
-      { key: 'Access-Control-Allow-Methods', value: 'GET, DELETE, POST, PUT' },
-      { key: 'Access-Control-Max-Age', value: corsMaxAge || '86400' },
-    ],
+    headers: apiHeaders
   },
   {
     source: '/:path*',
@@ -89,6 +103,11 @@ if (trackerScriptURL) {
 }
 
 if (collectApiEndpoint) {
+  headers.push({
+    source: collectApiEndpoint,
+    headers: apiHeaders,
+  });
+
   rewrites.push({
     source: collectApiEndpoint,
     destination: '/api/send',


### PR DESCRIPTION
This pull request fixes #3281.

As per the [configuration guide](https://umami.is/docs/environment-variables), the `COLLECT_API_ENDPOINT` can be set to avoid using the default `/api/send` endpoint, which is blocked by default by ad-blockers and alike.

Before this PR, umami only sends the necessary CORS headers along `/api/*` endpoints. If the `COLLECT_API_ENDPOINT` environment variable is set to something not starting with `/api` (i.e. `/tracking`), then the needed headers are not set.

This PR adds these headers to `COLLECT_API_ENDPOINT` to mitigate the issue.

Please let me know if you have any question or concern, I'd be glad to help :smile: 
