### PR TITLE
Fix counting _other domain groups

### DIFF
--- a/src/components/metrics/ReferrersTable.tsx
+++ b/src/components/metrics/ReferrersTable.tsx
@@ -60,19 +60,24 @@ export function ReferrersTable({ allowFilter, ...props }: ReferrersTableProps) {
     );
   };
 
+  const getDomain = (x: string) => {
+    for (const { domain, match } of GROUPED_DOMAINS) {
+      if (Array.isArray(match) ? match.some(str => x.includes(str)) : x.includes(match)) {
+        return domain;
+      }
+    }
+    return '_other';
+  };
+
   const groupedFilter = (data: any[]) => {
     const groups = { _other: 0 };
 
     for (const { x, y } of data) {
-      for (const { domain, match } of GROUPED_DOMAINS) {
-        if (Array.isArray(match) ? match.some(str => x.includes(str)) : x.includes(match)) {
-          if (!groups[domain]) {
-            groups[domain] = 0;
-          }
-          groups[domain] += +y;
-        }
+      const domain = getDomain(x);
+      if (!groups[domain]) {
+        groups[domain] = 0;
       }
-      groups._other += +y;
+      groups[domain] += +y;
     }
 
     return Object.keys(groups)


### PR DESCRIPTION
`channels._other` was counting all domain names, even if they belong to a group already.
Now visitors are only added to `channels._other` if not in any other group