### PR TITLE
Match CORS config in Docker middleware

### DIFF
--- a/docker/middleware.js
+++ b/docker/middleware.js
@@ -3,24 +3,18 @@ import { NextResponse } from 'next/server';
 export const config = {
   matcher: '/:path*',
 };
-const apiHeaders = [
-  {
-    key: 'Access-Control-Allow-Origin',
-    value: '*',
-  },
-  {
-    key: 'Access-Control-Allow-Headers',
-    value: '*',
-  },
-  {
-    key: 'Access-Control-Allow-Methods',
-    value: 'GET, DELETE, POST, PUT',
-  },
-  {
-    key: 'Access-Control-Max-Age',
-    value: process.env.CORS_MAX_AGE || '86400',
-  },
-];
+
+const apiHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': '*',
+  'Access-Control-Allow-Methods': 'GET, DELETE, POST, PUT',
+  'Access-Control-Max-Age': process.env.CORS_MAX_AGE || '86400',
+};
+
+const trackerHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Cache-Control': 'public, max-age=86400, must-revalidate',
+};
 
 function customCollectEndpoint(req) {
   const collectEndpoint = process.env.COLLECT_API_ENDPOINT;
@@ -31,9 +25,7 @@ function customCollectEndpoint(req) {
 
     if (pathname.endsWith(collectEndpoint)) {
       url.pathname = '/api/send';
-      const resp = NextResponse.rewrite(url);
-      apiHeaders.forEach(({ key, value }) => resp.headers.append(key, value));
-      return resp;
+      return NextResponse.rewrite(url, { headers: apiHeaders });
     }
   }
 }
@@ -48,7 +40,7 @@ function customScriptName(req) {
 
     if (names.find(name => pathname.endsWith(name))) {
       url.pathname = '/script.js';
-      return NextResponse.rewrite(url);
+      return NextResponse.rewrite(url, { headers: trackerHeaders });
     }
   }
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/umami-software/umami/pull/3331:

it adds CORS headers to custom script names (matching what is done in non standalone https://github.com/umami-software/umami/pull/2965)
and leverages `NextResponse.rewrite` ability to set them.