### PR TITLE
Use the props passed to identify to determine sessions

### DIFF
--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -18,7 +18,7 @@ const schema = z.object({
   payload: z.object({
     website: z.string().uuid(),
     data: anyObjectParam.optional(),
-    identity: anyObjectParam.optional(),
+    id: z.string().optional(),
     hostname: z.string().max(100).optional(),
     language: z.string().max(35).optional(),
     referrer: urlOrPathParam.optional(),
@@ -60,7 +60,7 @@ export async function POST(request: Request) {
       title,
       tag,
       timestamp,
-      identity,
+      id,
     } = payload;
 
     // Cache check
@@ -99,13 +99,7 @@ export async function POST(request: Request) {
     const sessionSalt = hash(startOfMonth(createdAt).toUTCString());
     const visitSalt = hash(startOfHour(createdAt).toUTCString());
 
-    const sessionId = uuid(
-      websiteId,
-      ip,
-      userAgent,
-      sessionSalt,
-      identity ? JSON.stringify(identity) : '',
-    );
+    const sessionId = uuid(websiteId, ip, userAgent, sessionSalt, id ? id : '');
 
     // Find session
     if (!clickhouse.enabled && !cache?.sessionId) {

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -18,6 +18,7 @@ const schema = z.object({
   payload: z.object({
     website: z.string().uuid(),
     data: anyObjectParam.optional(),
+    identity: anyObjectParam.optional(),
     hostname: z.string().max(100).optional(),
     language: z.string().max(35).optional(),
     referrer: urlOrPathParam.optional(),
@@ -59,6 +60,7 @@ export async function POST(request: Request) {
       title,
       tag,
       timestamp,
+      identity,
     } = payload;
 
     // Cache check
@@ -97,7 +99,13 @@ export async function POST(request: Request) {
     const sessionSalt = hash(startOfMonth(createdAt).toUTCString());
     const visitSalt = hash(startOfHour(createdAt).toUTCString());
 
-    const sessionId = uuid(websiteId, ip, userAgent, sessionSalt);
+    const sessionId = uuid(
+      websiteId,
+      ip,
+      userAgent,
+      sessionSalt,
+      identity ? JSON.stringify(identity) : '',
+    );
 
     // Find session
     if (!clickhouse.enabled && !cache?.sessionId) {

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -235,23 +235,24 @@
   const track = (obj, data) => {
     let identity;
     try {
-      identity = JSON.parse(localStorage.getItem('umami.identity'));
+      const parsedIdentity = JSON.parse(localStorage.getItem('umami.identity'));
+      identity = parsedIdentity !== null ? parsedIdentity : undefined;
     } catch (error) {
-      identity = null;
+      identity = undefined;
     }
     if (typeof obj === 'string') {
       return send({
         ...getPayload(),
         name: obj,
         data: typeof data === 'object' ? data : undefined,
-        identity: identity !== null ? identity : undefined,
+        identity,
       });
     } else if (typeof obj === 'object') {
-      return send({ ...obj, identity: identity !== null ? identity : undefined });
+      return send({ ...obj, identity });
     } else if (typeof obj === 'function') {
-      return send({ ...obj(getPayload()), identity: identity !== null ? identity : undefined });
+      return send({ ...obj(getPayload()), identity });
     }
-    return send({ ...getPayload(), identity: identity !== null ? identity : undefined });
+    return send({ ...getPayload(), identity });
   };
 
   const identify = data => {

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -249,7 +249,7 @@
   };
 
   const identify = (data, id = undefined) => {
-    if (id) {
+    if (id && typeof id === 'string') {
       identity = id;
     }
     /* Clear cache since this will result in another session */

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -233,7 +233,12 @@
   };
 
   const track = (obj, data) => {
-    const identity = JSON.parse(localStorage.getItem('umami.identity'));
+    let identity;
+    try {
+      identity = JSON.parse(localStorage.getItem('umami.identity'));
+    } catch (error) {
+      identity = null;
+    }
     if (typeof obj === 'string') {
       return send({
         ...getPayload(),

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -46,6 +46,7 @@
     url: currentUrl,
     referrer: currentRef,
     tag: tag ? tag : undefined,
+    id: identity ? identity : undefined,
   });
 
   const hasDoNotTrack = () => {
@@ -233,33 +234,27 @@
   };
 
   const track = (obj, data) => {
-    let identity;
-    try {
-      const parsedIdentity = JSON.parse(localStorage.getItem('umami.identity'));
-      identity = parsedIdentity !== null ? parsedIdentity : undefined;
-    } catch (error) {
-      identity = undefined;
-    }
     if (typeof obj === 'string') {
       return send({
         ...getPayload(),
         name: obj,
         data: typeof data === 'object' ? data : undefined,
-        identity,
       });
     } else if (typeof obj === 'object') {
-      return send({ ...obj, identity });
+      return send({ ...obj, ...getPayload().id });
     } else if (typeof obj === 'function') {
-      return send({ ...obj(getPayload()), identity });
+      return send(obj(getPayload()));
     }
-    return send({ ...getPayload(), identity });
+    return send(getPayload());
   };
 
-  const identify = data => {
-    localStorage.setItem('umami.identity', JSON.stringify(data));
+  const identify = (data, id = undefined) => {
+    if (id) {
+      identity = id;
+    }
     /* Clear cache since this will result in another session */
     cache = '';
-    send({ ...getPayload(), data, identity: data }, 'identify');
+    send({ ...getPayload(), data }, 'identify');
   };
 
   /* Start */
@@ -277,6 +272,7 @@
   let cache;
   let initialized;
   let disabled = false;
+  let identity;
 
   if (autoTrack && !trackingDisabled()) {
     if (document.readyState === 'complete') {

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -233,21 +233,28 @@
   };
 
   const track = (obj, data) => {
+    const identity = JSON.parse(localStorage.getItem('umami.identity'));
     if (typeof obj === 'string') {
       return send({
         ...getPayload(),
         name: obj,
         data: typeof data === 'object' ? data : undefined,
+        identity: identity !== null ? identity : undefined,
       });
     } else if (typeof obj === 'object') {
-      return send(obj);
+      return send({ ...obj, identity: identity !== null ? identity : undefined });
     } else if (typeof obj === 'function') {
-      return send(obj(getPayload()));
+      return send({ ...obj(getPayload()), identity: identity !== null ? identity : undefined });
     }
-    return send(getPayload());
+    return send({ ...getPayload(), identity: identity !== null ? identity : undefined });
   };
 
-  const identify = data => send({ ...getPayload(), data }, 'identify');
+  const identify = data => {
+    localStorage.setItem('umami.identity', JSON.stringify(data));
+    /* Clear cache since this will result in another session */
+    cache = '';
+    send({ ...getPayload(), data, identity: data }, 'identify');
+  };
 
   /* Start */
 


### PR DESCRIPTION
Hey!

I added the custom props sent to umami.identify to also be used for defining the session. This way if the same PC visits a website that uses Umami, but different props has been passed to umami.identify, it will result in different sessions rather than one session with the properties of the last visit.
Fixes #3181

Not sure if saving the identity in localstorage is the way to go so let me know if this is not a reasonable solution.
