### PR TITLE
Fix Netlify and possible other cache issues

### DIFF
--- a/docker/middleware.js
+++ b/docker/middleware.js
@@ -9,6 +9,7 @@ const apiHeaders = {
   'Access-Control-Allow-Headers': '*',
   'Access-Control-Allow-Methods': 'GET, DELETE, POST, PUT',
   'Access-Control-Max-Age': process.env.CORS_MAX_AGE || '86400',
+  'Cache-Control': 'no-cache',
 };
 
 const trackerHeaders = {

--- a/next.config.js
+++ b/next.config.js
@@ -62,26 +62,30 @@ const trackerHeaders = [
 const apiHeaders = [
   {
     key: 'Access-Control-Allow-Origin',
-    value: '*'
+    value: '*',
   },
   {
     key: 'Access-Control-Allow-Headers',
-    value: '*'
+    value: '*',
   },
   {
     key: 'Access-Control-Allow-Methods',
-    value: 'GET, DELETE, POST, PUT'
+    value: 'GET, DELETE, POST, PUT',
   },
   {
     key: 'Access-Control-Max-Age',
-    value: corsMaxAge || '86400'
+    value: corsMaxAge || '86400',
+  },
+  {
+    key: 'Cache-Control',
+    value: 'no-cache',
   },
 ];
 
 const headers = [
   {
     source: '/api/:path*',
-    headers: apiHeaders
+    headers: apiHeaders,
   },
   {
     source: '/:path*',


### PR DESCRIPTION
This fixes https://github.com/umami-software/umami/issues/3284.

Netlify can serve cached responses from a a cache which doesn't take into account the query parameters in use.
All metrics requests would then return the same data, hence the same data in every table.

This also affects other places like website listing, and it might also affect other hosting setups.

This PR adds `Cache-Control: no-cache` header to all api responses to prevent all that and to ensure they are up to date.