### PR TITLE
[WIP] Support funnel by hosts

### DIFF
--- a/src/app/(main)/reports/funnel/FunnelStepAddForm.tsx
+++ b/src/app/(main)/reports/funnel/FunnelStepAddForm.tsx
@@ -20,6 +20,7 @@ export function FunnelStepAddForm({
   const items = [
     { label: formatMessage(labels.url), value: 'url' },
     { label: formatMessage(labels.event), value: 'event' },
+    { label: formatMessage(labels.hosts), value: 'hosts' },
   ];
   const isDisabled = !type || !value;
 


### PR DESCRIPTION
Addresses #3372 

- Add hosts input to funnel report form
- Adjust column query logic to use switch case
- Adjust query to support hostname filtering

The bulk of the change is in the query, in the first level I'm querying all the necessary field which is available for filtering which currently are `url_path`, `event_name`, and the newly added `hostname`.

The join query is done on the first level because we need the `hostname` value from `session` table, plus instead of performing more join down the levels, we are simply querying off of previous levels.