### PR TITLE
fix: Insights report can make an invalid API request

### DIFF
--- a/src/app/(main)/reports/insights/InsightsParameters.tsx
+++ b/src/app/(main)/reports/insights/InsightsParameters.tsx
@@ -10,10 +10,10 @@ export function InsightsParameters() {
   const { report, runReport, isRunning } = useContext(ReportContext);
   const { formatMessage, labels } = useMessages();
   const { id, parameters } = report || {};
-  const { websiteId, dateRange, fields, filters } = parameters || {};
+  const { websiteId, dateRange, fields } = parameters || {};
   const { startDate, endDate } = dateRange || {};
   const parametersSelected = websiteId && startDate && endDate;
-  const queryEnabled = websiteId && dateRange && (fields?.length || filters?.length);
+  const queryEnabled = websiteId && dateRange && fields?.length;
 
   const handleSubmit = (values: any) => {
     runReport(values);


### PR DESCRIPTION
# Details
Error returned: `fields: Array must contain at least 1 element(s)`

This error is caused because the following zod validation is performed on the server but the client just checks if either `fields` or `filters` is defined.
https://github.com/umami-software/umami/blob/8525188e421f7e0645b5f0be8a37dc9f38d5591c/src/app/api/reports/insights/route.ts#L27

# How to reproduce
1. Create a new Insights report
2. Define one or more filters but NOT any fields.
3. Run query
4. Observe how the button shows an infinite loading spinner and an error is thrown in console

# Screenshots
| Before | After |
| --- | --- |
| ![insights_not_working_filters](https://github.com/user-attachments/assets/f391c2fc-f1e8-4676-807c-c31d8936a466) | ![insights_working_filters](https://github.com/user-attachments/assets/1bc112be-c105-4cf3-8656-bcd587beee9a) |
