### PR TITLE
Feature: Batch‑delete websites  (FR #3320)

### DIFF
--- a/src/app/(main)/settings/users/[userId]/UserWebsites.tsx
+++ b/src/app/(main)/settings/users/[userId]/UserWebsites.tsx
@@ -1,14 +1,22 @@
 import WebsitesTable from '@/app/(main)/settings/websites/WebsitesTable';
 import DataTable from '@/components/common/DataTable';
-import { useWebsites } from '@/components/hooks';
+import { useWebsites, useModified } from '@/components/hooks';
 
 export function UserWebsites({ userId }) {
   const queryResult = useWebsites({ userId });
-
+  const { touch } = useModified('websites');
   return (
     <DataTable queryResult={queryResult}>
       {({ data }) => (
-        <WebsitesTable data={data} showActions={true} allowEdit={true} allowView={true} />
+        <WebsitesTable
+          data={data}
+          showActions={true}
+          allowEdit={true}
+          allowView={true}
+          updateChildren={() => {
+            touch();
+          }}
+        />
       )}
     </DataTable>
   );

--- a/src/app/(main)/settings/websites/WebsitesDataTable.tsx
+++ b/src/app/(main)/settings/websites/WebsitesDataTable.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from 'react';
 import WebsitesTable from '@/app/(main)/settings/websites/WebsitesTable';
 import DataTable from '@/components/common/DataTable';
-import { useWebsites } from '@/components/hooks';
-
+import { useWebsites, useModified } from '@/components/hooks';
 export function WebsitesDataTable({
   teamId,
   allowEdit = true,
@@ -17,7 +16,7 @@ export function WebsitesDataTable({
   children?: ReactNode;
 }) {
   const queryResult = useWebsites({ teamId });
-
+  const { touch } = useModified('websites');
   return (
     <DataTable queryResult={queryResult} renderEmpty={() => children}>
       {({ data }) => (
@@ -27,6 +26,7 @@ export function WebsitesDataTable({
           showActions={showActions}
           allowEdit={allowEdit}
           allowView={allowView}
+          updateChildren={() => touch()}
         />
       )}
     </DataTable>

--- a/src/app/(main)/settings/websites/WebsitesTable.tsx
+++ b/src/app/(main)/settings/websites/WebsitesTable.tsx
@@ -1,8 +1,8 @@
-import { ReactNode } from 'react';
-import { Text, Icon, Icons, GridTable, GridColumn } from 'react-basics';
+import { ReactNode, useState } from 'react';
+import { Text, Icon, Icons, GridTable, GridColumn, Checkbox, Modal } from 'react-basics';
 import { useMessages, useTeamUrl } from '@/components/hooks';
+import WebsiteDeleteForm from './[websiteId]/WebsiteDeleteForm';
 import LinkButton from '@/components/common/LinkButton';
-
 export interface WebsitesTableProps {
   data: any[];
   showActions?: boolean;
@@ -10,6 +10,7 @@ export interface WebsitesTableProps {
   allowView?: boolean;
   teamId?: string;
   children?: ReactNode;
+  updateChildren?: () => void;
 }
 
 export function WebsitesTable({
@@ -18,47 +19,106 @@ export function WebsitesTable({
   allowEdit,
   allowView,
   children,
+  updateChildren,
 }: WebsitesTableProps) {
   const { formatMessage, labels } = useMessages();
   const { renderTeamUrl } = useTeamUrl();
+  const [deleteIds, setDeleteIds] = useState([]);
+  const [showConf, setShowConf] = useState(false);
 
   if (!data?.length) {
     return children;
   }
+  const checked = (websiteId: string) => {
+    if (deleteIds.includes(websiteId)) {
+      setDeleteIds(deleteIds.filter(prev => prev != websiteId));
+    } else {
+      setDeleteIds(prev => [...prev, websiteId]);
+    }
+  };
 
   return (
-    <GridTable data={data}>
-      <GridColumn name="name" label={formatMessage(labels.name)} />
-      <GridColumn name="domain" label={formatMessage(labels.domain)} />
-      {showActions && (
-        <GridColumn name="action" label=" " alignment="end">
+    <>
+      <GridTable data={data}>
+        <GridColumn
+          width="40px"
+          name="delete"
+          label={
+            deleteIds.length != 0 ? (
+              <Icon
+                style={{ color: 'red' }}
+                onClick={() => {
+                  setShowConf(true);
+                }}
+                size={'lg'}
+              >
+                <Icons.Trash />
+              </Icon>
+            ) : (
+              ''
+            )
+          }
+        >
           {row => {
             const { id: websiteId } = row;
-
             return (
-              <>
-                {allowEdit && (
-                  <LinkButton href={renderTeamUrl(`/settings/websites/${websiteId}`)}>
-                    <Icon data-test="link-button-edit">
-                      <Icons.Edit />
-                    </Icon>
-                    <Text>{formatMessage(labels.edit)}</Text>
-                  </LinkButton>
-                )}
-                {allowView && (
-                  <LinkButton href={renderTeamUrl(`/websites/${websiteId}`)}>
-                    <Icon>
-                      <Icons.ArrowRight />
-                    </Icon>
-                    <Text>{formatMessage(labels.view)}</Text>
-                  </LinkButton>
-                )}
-              </>
+              <Checkbox
+                defaultChecked={false}
+                onChange={() => {
+                  checked(websiteId);
+                }}
+                value={websiteId}
+              />
             );
           }}
         </GridColumn>
+        <GridColumn name="name" label={formatMessage(labels.name)} />
+        <GridColumn name="domain" label={formatMessage(labels.domain)} />
+        {showActions && (
+          <GridColumn name="action" label=" " alignment="end">
+            {row => {
+              const { id: websiteId } = row;
+
+              return (
+                <>
+                  {allowEdit && (
+                    <LinkButton href={renderTeamUrl(`/settings/websites/${websiteId}`)}>
+                      <Icon data-test="link-button-edit">
+                        <Icons.Edit />
+                      </Icon>
+                      <Text>{formatMessage(labels.edit)}</Text>
+                    </LinkButton>
+                  )}
+                  {allowView && (
+                    <LinkButton href={renderTeamUrl(`/websites/${websiteId}`)}>
+                      <Icon>
+                        <Icons.ArrowRight />
+                      </Icon>
+                      <Text>{formatMessage(labels.view)}</Text>
+                    </LinkButton>
+                  )}
+                </>
+              );
+            }}
+          </GridColumn>
+        )}
+      </GridTable>
+      {showConf && (
+        <Modal title={formatMessage(labels.deleteWebsite)}>
+          {
+            <WebsiteDeleteForm
+              websiteId={deleteIds}
+              CONFIRM_VALUE={'DELETE MULTIPLE'}
+              onClose={() => {
+                setShowConf(false);
+                updateChildren();
+                setDeleteIds([]);
+              }}
+            />
+          }
+        </Modal>
       )}
-    </GridTable>
+    </>
   );
 }
 

--- a/src/app/(main)/settings/websites/WebsitesTable.tsx
+++ b/src/app/(main)/settings/websites/WebsitesTable.tsx
@@ -31,7 +31,7 @@ export function WebsitesTable({
   }
   const checked = (websiteId: string) => {
     if (deleteIds.includes(websiteId)) {
-      setDeleteIds(deleteIds.filter(prev => prev != websiteId));
+      setDeleteIds(deleteIds.filter(prev => prev !== websiteId));
     } else {
       setDeleteIds(prev => [...prev, websiteId]);
     }
@@ -44,7 +44,7 @@ export function WebsitesTable({
           width="40px"
           name="delete"
           label={
-            deleteIds.length != 0 ? (
+            deleteIds.length > 0 ? (
               <Icon
                 style={{ color: 'red' }}
                 onClick={() => {
@@ -64,6 +64,7 @@ export function WebsitesTable({
             return (
               <Checkbox
                 defaultChecked={false}
+                checked={deleteIds.includes(websiteId)}
                 onChange={() => {
                   checked(websiteId);
                 }}

--- a/src/app/(main)/settings/websites/[websiteId]/WebsiteData.tsx
+++ b/src/app/(main)/settings/websites/[websiteId]/WebsiteData.tsx
@@ -78,7 +78,12 @@ export function WebsiteData({ websiteId, onSave }: { websiteId: string; onSave?:
           </Button>
           <Modal title={formatMessage(labels.deleteWebsite)}>
             {(close: () => void) => (
-              <WebsiteDeleteForm websiteId={websiteId} onSave={handleSave} onClose={close} />
+              <WebsiteDeleteForm
+                CONFIRM_VALUE={'DELETE'}
+                websiteId={websiteId}
+                onSave={handleSave}
+                onClose={close}
+              />
             )}
           </Modal>
         </ModalTrigger>

--- a/src/app/(main)/settings/websites/[websiteId]/WebsiteDeleteForm.tsx
+++ b/src/app/(main)/settings/websites/[websiteId]/WebsiteDeleteForm.tsx
@@ -1,21 +1,28 @@
 import { useApi, useMessages } from '@/components/hooks';
 import TypeConfirmationForm from '@/components/common/TypeConfirmationForm';
 
-const CONFIRM_VALUE = 'DELETE';
-
 export function WebsiteDeleteForm({
   websiteId,
+  CONFIRM_VALUE,
   onSave,
   onClose,
 }: {
-  websiteId: string;
+  websiteId: string | string[];
+  CONFIRM_VALUE: string;
   onSave?: () => void;
   onClose?: () => void;
 }) {
   const { formatMessage, labels } = useMessages();
   const { del, useMutation } = useApi();
   const { mutate, isPending, error } = useMutation({
-    mutationFn: () => del(`/websites/${websiteId}`),
+    mutationFn: async () => {
+      if (typeof websiteId === 'string') {
+        return del(`/websites/${websiteId}`);
+      } else {
+        const ids = Array.isArray(websiteId) ? websiteId : [websiteId];
+        return Promise.all(ids.map(id => del(`/websites/${id}`)));
+      }
+    },
   });
 
   const handleConfirm = async () => {

--- a/src/app/(main)/settings/websites/[websiteId]/WebsiteDeleteForm.tsx
+++ b/src/app/(main)/settings/websites/[websiteId]/WebsiteDeleteForm.tsx
@@ -19,7 +19,7 @@ export function WebsiteDeleteForm({
       if (typeof websiteId === 'string') {
         return del(`/websites/${websiteId}`);
       } else {
-        const ids = Array.isArray(websiteId) ? websiteId : [websiteId];
+        const ids = typeof websiteId === 'string' ? [websiteId] : websiteId;
         return Promise.all(ids.map(id => del(`/websites/${id}`)));
       }
     },


### PR DESCRIPTION
**This PR adds the ability to select and delete multiple websites in one action refer #3320** 
- Why
    - Managing deletion of many test or stale sites one‑by‑one are slow and error‑prone. Bulk deletion streamlines it
- How it works
  - Checkboxes—a checkbox appears beside each website row,
  - Delete button—when ≥1 sites are selected, a Delete (selected) button becomes active.
   - Safety confirmation—clicking Delete opens a confirmation Page
 - Screen Shots:
   - Before Implementation 
   ![image](https://github.com/user-attachments/assets/d6fe0428-db56-4ac4-906f-a3cbd9e6726a)
   - After Implemetation
      - Before Selecting
![image](https://github.com/user-attachments/assets/8e622196-70d4-46e5-8d38-cca581c06d17)
     - After Selecting     
![image](https://github.com/user-attachments/assets/4297e990-9f29-40c2-af6f-421b84c379f8)
      -  Confirmation 
      
![image](https://github.com/user-attachments/assets/8c656b0f-82b9-4201-a070-cc651eb37ba5)



I have done the same for websites tab and websites tab under users in settings also
    

