### PR TITLE
improv: Improved performance of send

### DIFF
--- a/src/queries/sql/sessions/createSession.ts
+++ b/src/queries/sql/sessions/createSession.ts
@@ -1,7 +1,10 @@
 import { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 
-export async function createSession(data: Prisma.SessionCreateInput) {
+export async function createSession(
+  data: Prisma.SessionCreateInput,
+  options = { skipDuplicates: false },
+) {
   const {
     id,
     websiteId,
@@ -16,19 +19,31 @@ export async function createSession(data: Prisma.SessionCreateInput) {
     distinctId,
   } = data;
 
-  return prisma.client.session.create({
-    data: {
-      id,
-      websiteId,
-      browser,
-      os,
-      device,
-      screen,
-      language,
-      country,
-      region,
-      city,
-      distinctId,
-    },
-  });
+  try {
+    return await prisma.client.session.create({
+      data: {
+        id,
+        websiteId,
+        browser,
+        os,
+        device,
+        screen,
+        language,
+        country,
+        region,
+        city,
+        distinctId,
+      },
+    });
+  } catch (e: any) {
+    // With skipDuplicates flag: ignore unique constraint error and return null
+    if (
+      options.skipDuplicates &&
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === 'P2002'
+    ) {
+      return null;
+    }
+    throw e;
+  }
 }


### PR DESCRIPTION
Using the batch method to register a large number of events, we noticed that the inserts were extremely slow. This is not only because of how the batch insert works but due to the slowness of the individual send method itself within large sessions with many events.

The main issue is with how the session creation is unnecessarily retrieving the session with a complex SQL query every time in order to not insert it twice. Instead of this, it'd be better to insert and ignore duplicate entries.

Tested this change with a quick benchmark inserting 10000 events using the batch method and the results were the following:

# Before

     ✓ status is 200
     ✓ no errors in batch
     ✓ processed equals size
     ✓ processed size matches sent

     checks.........................: 100.00% 4 out of 4
     data_received..................: 655 B   1.0396771663668989 B/s
     data_sent......................: 7.8 MB  12 kB/s
     http_req_blocked...............: avg=816µs   min=816µs   med=816µs   max=816µs   p(90)=816µs   p(95)=816µs  
     http_req_connecting............: avg=230µs   min=230µs   med=230µs   max=230µs   p(90)=230µs   p(95)=230µs  
     http_req_duration..............: avg=5m10s   min=5m10s   med=5m10s   max=5m10s   p(90)=5m10s   p(95)=5m10s  
       { expected_response:true }...: avg=5m10s   min=5m10s   med=5m10s   max=5m10s   p(90)=5m10s   p(95)=5m10s  
     http_req_failed................: 0.00%   0 out of 1
     http_req_receiving.............: avg=723µs   min=723µs   med=723µs   max=723µs   p(90)=723µs   p(95)=723µs  
     http_req_sending...............: avg=22.12ms min=22.12ms med=22.12ms max=22.12ms p(90)=22.12ms p(95)=22.12ms
     http_req_tls_handshaking.......: avg=0s      min=0s      med=0s      max=0s      p(90)=0s      p(95)=0s     
     http_req_waiting...............: avg=5m10s   min=5m10s   med=5m10s   max=5m10s   p(90)=5m10s   p(95)=5m10s  
     http_reqs......................: 1       0.001587/s
     iteration_duration.............: avg=5m11s   min=5m11s   med=5m11s   max=5m11s   p(90)=5m11s   p(95)=5m11s  
     iterations.....................: 1       0.001587/s
     vus............................: 1       min=1                  max=1
     vus_max........................: 1       min=1                  max=1

# After

     ✓ status is 200
     ✓ no errors in batch
     ✓ processed equals size
     ✓ processed size matches sent

     checks.........................: 100.00% 8 out of 8
     data_received..................: 1.3 kB  17 B/s
     data_sent......................: 7.9 MB  104 kB/s
     http_req_blocked...............: avg=612µs   min=3µs     med=612µs   max=1.22ms  p(90)=1.09ms  p(95)=1.16ms  
     http_req_connecting............: avg=97µs    min=0s      med=97µs    max=194µs   p(90)=174.6µs p(95)=184.3µs 
     http_req_duration..............: avg=36.8s   min=35.77s  med=36.8s   max=37.82s  p(90)=37.62s  p(95)=37.72s  
       { expected_response:true }...: avg=36.8s   min=35.77s  med=36.8s   max=37.82s  p(90)=37.62s  p(95)=37.72s  
     http_req_failed................: 0.00%   0 out of 2
     http_req_receiving.............: avg=569µs   min=541µs   med=569µs   max=597µs   p(90)=591.4µs p(95)=594.19µs
     http_req_sending...............: avg=18.15ms min=14.14ms med=18.15ms max=22.15ms p(90)=21.35ms p(95)=21.75ms 
     http_req_tls_handshaking.......: avg=0s      min=0s      med=0s      max=0s      p(90)=0s      p(95)=0s      
     http_req_waiting...............: avg=36.78s  min=35.75s  med=36.78s  max=37.81s  p(90)=37.6s   p(95)=37.71s  
     http_reqs......................: 2       0.02638/s
     iteration_duration.............: avg=37.9s   min=36.86s  med=37.9s   max=38.94s  p(90)=38.73s  p(95)=38.84s  
     iterations.....................: 2       0.02638/s
     vus............................: 1       min=1      max=1
     vus_max........................: 1       min=1      max=1

