### PR TITLE
Feature: Add keepalive option to tracker fetch request

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -150,6 +150,7 @@
 
     try {
       const res = await fetch(endpoint, {
+        keepalive: true,
         method: 'POST',
         body: JSON.stringify({ type, payload }),
         headers: {


### PR DESCRIPTION
This solves #3354 

I need to report events to my Umami instance right before navigating to a new page. Currently, the fetch request gets terminated—as expected—when the page unloads and the request hasn't completed yet.

As of today, `keepalive` requests seems supported by all major browsers: https://developer.mozilla.org/en-US/docs/Web/API/Request/keepalive