### PR TITLE
Sanitize IP to remove port for geolocation lookup

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -127,7 +127,9 @@ export async function getLocation(ip: string = '', headers: Headers, hasPayloadI
     global[MAXMIND] = await maxmind.open(path.resolve(dir, 'GeoLite2-City.mmdb'));
   }
 
-  const result = global[MAXMIND].get(ip);
+  // When the client IP is extracted from headers, sometimes the value includes a port
+  const cleanIp = ip?.split(':')[0];
+  const result = global[MAXMIND].get(cleanIp);  
 
   if (result) {
     const country = result.country?.iso_code ?? result?.registered_country?.iso_code;


### PR DESCRIPTION
Sanitize IP address to remove port number before geolocation lookup. This ensures proper MaxMind database resolution in setups where IP:PORT is passed by the proxy.