### PR TITLE
`POST /api/websites/<id>`: Make name and domain optional in the validation schema

### DIFF
--- a/cypress/e2e/api-website.cy.ts
+++ b/cypress/e2e/api-website.cy.ts
@@ -149,6 +149,21 @@ describe('Website API tests', () => {
     });
   });
 
+  it('Updates a website with only shareId.', () => {
+    cy.request({
+      method: 'POST',
+      url: `/api/websites/${websiteId}`,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: Cypress.env('authorization'),
+      },
+      body: { shareId: 'ABCDEF' },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('shareId', 'ABCDEF');
+    });
+  });
+
   it('Resets a website by removing all data related to the website.', () => {
     cy.request({
       method: 'POST',

--- a/src/app/api/websites/[websiteId]/route.ts
+++ b/src/app/api/websites/[websiteId]/route.ts
@@ -31,8 +31,8 @@ export async function POST(
   { params }: { params: Promise<{ websiteId: string }> },
 ) {
   const schema = z.object({
-    name: z.string(),
-    domain: z.string(),
+    name: z.string().optional(),
+    domain: z.string().optional(),
     shareId: z.string().regex(SHARE_ID_REGEX).nullable().optional(),
   });
 


### PR DESCRIPTION
Fixes https://github.com/umami-software/umami/issues/3581