### PR TITLE
feat: Add AWS CloudFront geolocation headers support

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -15,6 +15,27 @@ import { safeDecodeURIComponent } from '@/lib/url';
 
 const MAXMIND = 'maxmind';
 
+const PROVIDER_HEADERS = [
+  // Cloudflare headers
+  {
+    countryHeader: 'cf-ipcountry',
+    regionHeader: 'cf-region-code',
+    cityHeader: 'cf-ipcity',
+  },
+  // Vercel headers
+  {
+    countryHeader: 'x-vercel-ip-country',
+    regionHeader: 'x-vercel-ip-country-region',
+    cityHeader: 'x-vercel-ip-city',
+  },
+  // CloudFront headers
+  {
+    countryHeader: 'cloudfront-viewer-country',
+    regionHeader: 'cloudfront-viewer-country-region',
+    cityHeader: 'cloudfront-viewer-city',
+  },
+];
+
 export function getIpAddress(headers: Headers) {
   const customHeader = process.env.CLIENT_IP_HEADER;
 
@@ -94,43 +115,19 @@ export async function getLocation(ip: string = '', headers: Headers, hasPayloadI
   }
 
   if (!hasPayloadIP && !process.env.SKIP_LOCATION_HEADERS) {
-    // Cloudflare headers
-    if (headers.get('cf-ipcountry')) {
-      const country = decodeHeader(headers.get('cf-ipcountry'));
-      const region = decodeHeader(headers.get('cf-region-code'));
-      const city = decodeHeader(headers.get('cf-ipcity'));
+    for (const provider of PROVIDER_HEADERS) {
+      const countryHeader = headers.get(provider.countryHeader);
+      if (countryHeader) {
+        const country = decodeHeader(countryHeader);
+        const region = decodeHeader(headers.get(provider.regionHeader));
+        const city = decodeHeader(headers.get(provider.cityHeader));
 
-      return {
-        country,
-        region: getRegionCode(country, region),
-        city,
-      };
-    }
-
-    // Vercel headers
-    if (headers.get('x-vercel-ip-country')) {
-      const country = decodeHeader(headers.get('x-vercel-ip-country'));
-      const region = decodeHeader(headers.get('x-vercel-ip-country-region'));
-      const city = decodeHeader(headers.get('x-vercel-ip-city'));
-
-      return {
-        country,
-        region: getRegionCode(country, region),
-        city,
-      };
-    }
-
-    // CloudFront headers
-    if (headers.get('cloudfront-viewer-country')) {
-      const country = decodeHeader(headers.get('cloudfront-viewer-country'));
-      const region = decodeHeader(headers.get('cloudfront-viewer-country-region'));
-      const city = decodeHeader(headers.get('cloudfront-viewer-city'));
-
-      return {
-        country,
-        region: getRegionCode(country, region),
-        city,
-      };
+        return {
+          country,
+          region: getRegionCode(country, region),
+          city,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Description
This PR adds support for AWS CloudFront geolocation headers in the `getLocation` function, enabling geographical detection when Umami is deployed behind CloudFront.

## Changes
- Added CloudFront header detection in `src/lib/detect.ts`
- Extracts location data from CloudFront-specific headers:
  - `cloudfront-viewer-country` - Viewer's country code
  - `cloudfront-viewer-country-region` - Viewer's region/state code  
  - `cloudfront-viewer-city` - Viewer's city name
- Follows the same pattern as existing Cloudflare and Vercel header support
- Maintains consistency with existing `getRegionCode` logic for region formatting

## Motivation
CloudFront provides built-in geolocation headers that can be enabled to identify the geographic location of viewers without requiring IP-based database lookups. This enhancement allows Umami deployments using CloudFront to leverage these headers for improved performance and accuracy.
