### PR TITLE
fix(hash): improve URL normalization and handling in tracking functions

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -38,6 +38,18 @@
 
   /* Helper functions */
 
+  const normalize = raw => {
+    if (!raw) return raw;
+    try {
+      const u = new URL(raw, location.href);
+      if (excludeSearch) u.search = '';
+      if (excludeHash) u.hash = '';
+      return u.toString();
+    } catch (e) {
+      return raw;
+    }
+  };
+
   const getPayload = () => ({
     website,
     screen,
@@ -61,11 +73,7 @@
     if (!url) return;
 
     currentRef = currentUrl;
-    currentUrl = new URL(url, location.href);
-
-    if (excludeSearch) currentUrl.search = '';
-    if (excludeHash) currentUrl.hash = '';
-    currentUrl = currentUrl.toString();
+    currentUrl = normalize(new URL(url, location.href).toString());
 
     if (currentUrl !== currentRef) {
       setTimeout(track, delayDuration);
@@ -210,8 +218,9 @@
     };
   }
 
-  let currentUrl = href;
-  let currentRef = referrer.startsWith(origin) ? '' : referrer;
+  let currentUrl = normalize(href);
+  let currentRef = normalize(referrer.startsWith(origin) ? '' : referrer);
+
   let initialized = false;
   let disabled = false;
   let cache;


### PR DESCRIPTION
## Problem
When `data-exclude-hash="true"` is set, hash fragments are only removed during navigation but NOT on the initial page load.
This can affect data collection in a production.

## Root Cause
Looking at the original code, there was inconsistent URL normalization. Especially for handle url with `hash`

```javascript
// Current code - Missing hash normalization on init
let currentUrl = href;
let currentRef = referrer.startsWith(origin) ? '' : referrer;

// only handlePush has normalization
const handlePush = (_state, _title, url) => {
  if (excludeHash) currentUrl.hash = ''; 
};
```

## Solution
Apply Consistent URL Normalization.
Use the same `normalize()` function that handlePush already uses for initial URL assignment:
```javascript
const normalize = raw => {
  if (!raw) return raw;
  try {
    const u = new URL(raw, location.href);
    if (excludeSearch) u.search = '';
    if (excludeHash) u.hash = '';
    return u.toString();
  } catch (e) {
    return raw;
  }
};

let currentUrl = normalize(href);
let currentRef = normalize(referrer.startsWith(origin) ? '' : referrer);
```
This ensures that both initial page loads and navigation events use the same URL normalization logic.