### PR TITLE
fix: wrong stats on event page

### DIFF
--- a/src/queries/sql/sessions/getWebsiteSessionStats.ts
+++ b/src/queries/sql/sessions/getWebsiteSessionStats.ts
@@ -29,11 +29,11 @@ async function relationalQuery(
   return rawQuery(
     `
     select
-      count(*) as "pageviews",
-      count(distinct website_event.session_id) as "visitors",
-      count(distinct website_event.visit_id) as "visits",
-      count(distinct session.country) as "countries",
-      sum(case when website_event.event_type = 2 then 1 else 0 end) as "events"
+      count(*) filter (where website_event.event_type = 1) as "pageviews",
+      count(distinct website_event.session_id) filter (where website_event.event_type = 1) as "visitors",
+      count(distinct visit_id) filter (where website_event.event_type = 1) as "visits",
+      count(distinct session.country) filter (where website_event.event_type = 1) as "countries",
+      count(*) filter (where website_event.event_type = 2) as "events"
     from website_event
     ${cohortQuery}
     join session on website_event.session_id = session.session_id

--- a/src/queries/sql/sessions/getWebsiteSessionStats.ts
+++ b/src/queries/sql/sessions/getWebsiteSessionStats.ts
@@ -62,30 +62,30 @@ async function clickhouseQuery(
     sql = `
     select
       sumIf(1, event_type = 1) as "pageviews",
-      uniq(session_id) as "visitors",
-      uniq(visit_id) as "visits",
-      uniq(country) as "countries",
-      sum(length(event_name)) as "events"
+      uniqIf(session_id, event_type = 1) as "visitors",
+      uniqIf(visit_id, event_type = 1) as "visits",
+      uniqIf(country, event_type = 1) as "countries",
+      sumIf(1, event_type = 2) as "events"
     from website_event
     ${cohortQuery}
     where website_id = {websiteId:UUID}
-        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-        ${filterQuery}
-    `;
+      and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+      ${filterQuery}
+  `;
   } else {
     sql = `
     select
-      sum(views) as "pageviews",
-      uniq(session_id) as "visitors",
-      uniq(visit_id) as "visits",
-      uniq(country) as "countries",
-      sum(length(event_name)) as "events"
+      sumIf(views, event_type = 1) as "pageviews",
+      uniqIf(session_id, event_type = 1) as "visitors",
+      uniqIf(visit_id, event_type = 1) as "visits",
+      uniqIf(country, event_type = 1) as "countries",
+      sumIf(1, event_type = 2) as "events"
     from website_event_stats_hourly website_event
     ${cohortQuery}
     where website_id = {websiteId:UUID}
-        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-        ${filterQuery}
-    `;
+      and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+      ${filterQuery}
+  `;
   }
 
   return rawQuery(sql, params);

--- a/src/queries/sql/sessions/getWebsiteSessionStats.ts
+++ b/src/queries/sql/sessions/getWebsiteSessionStats.ts
@@ -31,7 +31,7 @@ async function relationalQuery(
     select
       count(*) filter (where website_event.event_type = 1) as "pageviews",
       count(distinct website_event.session_id) filter (where website_event.event_type = 1) as "visitors",
-      count(distinct visit_id) filter (where website_event.event_type = 1) as "visits",
+      count(distinct website_event.visit_id) filter (where website_event.event_type = 1) as "visits",
       count(distinct session.country) filter (where website_event.event_type = 1) as "countries",
       count(*) filter (where website_event.event_type = 2) as "events"
     from website_event


### PR DESCRIPTION
## Problem
The numbers for Views, Visitors and Visits on the Events and Sessions page are different from those on the Overview page.

## Root Cause
On the Events and Sessions page all website_event are counted, both  pageViews and customEvents. So if in 1 session 1 user visits 1 page and triggers on that page 1 event, 2 views are counted. See image below.

## Solution
Ignore customEvents when calculating pageviews, visitors and visits.

## Example
<img width="964" height="688" alt="umami-wrong-stats" src="https://github.com/user-attachments/assets/2ea8e007-8a8f-4787-a2c3-1bc4c8f61993" />
