### PR TITLE
fix(geo): parse netlify ip header by default: `x-nf-client-connection-ip`

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -344,6 +344,7 @@ export const IP_ADDRESS_HEADERS = [
   'x-cluster-client-ip',
   'x-forwarded',
   'x-forwarded-for',
+  'x-nf-client-connection-ip',
   'x-real-ip',
 ];
 


### PR DESCRIPTION
This header is not clearly documented, but it is mentioned in semi-official sources, and I have tested it to ensure it's working properly.

Without this, Umami is unable to detect geolocation by default if deployed on Netlify.

* https://answers.netlify.com/t/is-the-client-ip-header-going-to-be-supported-long-term/11203/2
* https://httptoolkit.com/blog/what-is-x-forwarded-for/#and-others