### PR TITLE
Add setup-pnpm to hopefully fix CI tests etc.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,18 @@ jobs:
       matrix:
         include:
         - node-version: 18.18
+          pnpm-version: 10
           db-type: postgresql
         - node-version: 18.18
+          pnpm-version: 10
           db-type: mysql
 
     steps:
     - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4 # required so that setup-node will work
+      with:
+        version: ${{ matrix.pnpm-version }}
+        run_install: false
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
I have noticed that CI has been broken for some time.  It seems this is down to the setup-node job failing inside the workflow.  This PR adds a step to the workflow that installs pnpm beforehand, so that setup-node can successfully find it.