### PR TITLE
URGENT! Resolve IPv6 address destruction on GeoIP query

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -108,6 +108,14 @@ function decodeHeader(s: string | undefined | null): string | undefined | null {
   return Buffer.from(s, 'latin1').toString('utf-8');
 }
 
+function removePortFromIP(ip: string = "") {
+  const split = ip.split(":");
+
+  // Assuming ip is a valid IPv4/IPv6 address, 3 colons is the minumum for IPv6
+  const ipv4 = split.length - 1 < 3;
+  return ipv4 ? split[0] : ip;
+}
+
 export async function getLocation(ip: string = '', headers: Headers, hasPayloadIP: boolean) {
   // Ignore local ips
   if (await isLocalhost(ip)) {
@@ -141,7 +149,7 @@ export async function getLocation(ip: string = '', headers: Headers, hasPayloadI
   }
 
   // When the client IP is extracted from headers, sometimes the value includes a port
-  const cleanIp = ip?.split(':')[0];
+  const cleanIp = removePortFromIP(ip);
   const result = global[MAXMIND].get(cleanIp);
 
   if (result) {


### PR DESCRIPTION
I recently switched to Umami and noticed my IPv6 devices reporting incorrect countries. I traced it back to a piece of code which was supposed to remove arbitrary port numbers from an IP address inside `X-Forwarded-For` headers and whatnot, which was my exact use case. **This has certainly impacted a lot of people and the credibility of their data is questionable, since IPv6 enabled devices make up almost 50% of today's market.**

The old code in action on an unassigned IPv6 address:
> \> "f792:0025:408f:0efe:3b78:d261:6742:9ff3"?.split(':')[0]
> 'f792'

Note: This PR purposefully avoids Regex or other more "correct" ways of separating IPv4 addresses v. IPv6 ones as it is assumed those are passed from a safe context (such as Next.JS) with loopbacks disallowed. This is purposeful and avoids wasting resources.

I'm up for whatever help is needed regarding this matter, as the issue in question directly impacts me. Thanks for your time.