### PR TITLE
Incomplete ISO Countries Constants

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -448,8 +448,10 @@ export const MAP_FILE = '/datamaps.world.json';
 export const ISO_COUNTRIES = {
   ANT: 'AN',
   ARE: 'AE',
+  AUT: 'AT',
   BLM: 'BL',
   CHE: 'CH',
+  DEU: 'DE',
   ESH: 'EH',
   ESP: 'ES',
   FSM: 'FM',


### PR DESCRIPTION
I've noticed that a lot of countries in the map are missing their labels and coloring.
I've at least added it for the DA(CH was already there) region.

<img width="173" height="119" alt="image" src="https://github.com/user-attachments/assets/37664729-2ae9-4279-98b5-e8216a0f78f2" />
