### PR TITLE
feat (timezone): normalization function for handling legacy timezone identifiers

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -104,9 +104,18 @@ const DATE_FUNCTIONS = {
   },
 };
 
+const TIMEZONE_MAPPINGS: Record<string, string> = {
+  'Asia/Calcutta': 'Asia/Kolkata',
+};
+
+export function normalizeTimezone(timezone: string): string {
+  return TIMEZONE_MAPPINGS[timezone] || timezone;
+}
+
 export function isValidTimezone(timezone: string) {
   try {
-    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    const normalizedTimezone = normalizeTimezone(timezone);
+    Intl.DateTimeFormat(undefined, { timeZone: normalizedTimezone });
     return true;
   } catch (error) {
     return false;

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { isValidTimezone } from '@/lib/date';
+import { isValidTimezone, normalizeTimezone } from '@/lib/date';
 import { UNIT_TYPES } from './constants';
 
 export const filterParams = {
@@ -28,9 +28,9 @@ export const pagingParams = {
   search: z.string().optional(),
 };
 
-export const timezoneParam = z.string().refine(value => isValidTimezone(value), {
+export const timezoneParam = z.string().refine((value: string) => isValidTimezone(value), {
   message: 'Invalid timezone',
-});
+}).transform((value: string) => normalizeTimezone(value));
 
 export const unitParam = z.string().refine(value => UNIT_TYPES.includes(value), {
   message: 'Invalid unit',


### PR DESCRIPTION
Enhance timezone handling by adding normalization for 'Asia/Calcutta' to 'Asia/Kolkata' and updating validation schema to use normalized timezones.

Closes: https://github.com/umami-software/umami/issues/3632