### PR TITLE
fix(postgres): canonicalize legacy timezone names (Asia/Calcutta → Asia/Kolkata) to prevent 22023 errors

### DIFF
--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,12 @@
+const ALIASES: Record<string, string> = {
+  'asia/calcutta': 'Asia/Kolkata',
+  'utc': 'UTC',
+  'gmt': 'UTC',
+  'greenwich': 'UTC',
+};
+
+export function canonicalizeTimeZone(tz?: string | null): string {
+  if (!tz) return 'UTC';
+  const key = tz.trim().toLowerCase();
+  return ALIASES[key] ?? tz.trim();
+}


### PR DESCRIPTION
This PR fixes a Postgres error that occurs when users select legacy or deprecated timezone names (e.g. Asia/Calcutta) that are no longer recognized by minimal tzdata installations.

Fixes #3660 

Changes Introduced

- Added canonicalizeTimeZone() helper in src/lib/timezone.ts
- Maps legacy aliases → canonical IANA names.
- Example: 'Asia/Calcutta' → 'Asia/Kolkata'.
- Normalized timezones in API routes
- Wrapped request timezone in canonicalizeTimeZone() before calling getPageviewStats() and getSessionStats().
- Default fallback → UTC.