### PR TITLE
Add Kagi to the list of search engines

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -381,7 +381,6 @@ export const SEARCH_DOMAINS = [
   'perplexity.ai',
   'search.brave.com',
   'yandex.',
-  
 ];
 
 export const SHOPPING_DOMAINS = [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -376,10 +376,12 @@ export const SEARCH_DOMAINS = [
   'duckduckgo.com',
   'ecosia.org',
   'google.',
+  'kagi.com',
   'msn.com',
   'perplexity.ai',
   'search.brave.com',
   'yandex.',
+  
 ];
 
 export const SHOPPING_DOMAINS = [


### PR DESCRIPTION
This simple PR add `kagi` as search engine. It is simple adding `kagi.com` to the `SEARCH_DOMAINS` list in `src/lib/constants.ts`. 

Kagi is a paid search engine that got traction in the developer community last couple of years. It would be useful to have it added to umami.  