### PR TITLE
feat: make website table rows clickable

### DIFF
--- a/src/app/(main)/settings/websites/WebsitesTable.module.css
+++ b/src/app/(main)/settings/websites/WebsitesTable.module.css
@@ -1,0 +1,11 @@
+.row {
+  color: inherit;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.row:visited {
+  color: inherit;
+}

--- a/src/app/(main)/settings/websites/WebsitesTable.tsx
+++ b/src/app/(main)/settings/websites/WebsitesTable.tsx
@@ -2,6 +2,8 @@ import { ReactNode } from 'react';
 import { Text, Icon, Icons, GridTable, GridColumn } from 'react-basics';
 import { useMessages, useTeamUrl } from '@/components/hooks';
 import LinkButton from '@/components/common/LinkButton';
+import Link from 'next/link';
+import styles from './WebsitesTable.module.css';
 
 export interface WebsitesTableProps {
   data: any[];
@@ -28,8 +30,28 @@ export function WebsitesTable({
 
   return (
     <GridTable data={data}>
-      <GridColumn name="name" label={formatMessage(labels.name)} />
-      <GridColumn name="domain" label={formatMessage(labels.domain)} />
+      <GridColumn name="name" label={formatMessage(labels.name)}>
+        {row =>
+          allowView ? (
+            <Link href={renderTeamUrl(`/websites/${row.id}`)} className={styles.row}>
+              {row.name}
+            </Link>
+          ) : (
+            row.name
+          )
+        }
+      </GridColumn>
+      <GridColumn name="domain" label={formatMessage(labels.domain)}>
+        {row =>
+          allowView ? (
+            <Link href={renderTeamUrl(`/websites/${row.id}`)} className={styles.row}>
+              {row.domain}
+            </Link>
+          ) : (
+            row.domain
+          )
+        }
+      </GridColumn>
       {showActions && (
         <GridColumn name="action" label=" " alignment="end">
           {row => {


### PR DESCRIPTION
After getting started with Umami I noticed a small, but annoying UX issue I want to fix with this PR.

**Problem**
When navigating between the projects on `/websites` or `settings/websites` it is more intuitive to click on the row, the name or the domain to open the dashboard vs only being able to click on the "View" button.

**Solution**
Wrapped the name and domain in Link to make the cell clickable.