### PR TITLE
Fixing docker image name

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ docker pull docker.umami.is/umami-software/umami:latest
 ## 🔄 Getting Updates
 > [!WARNING]  
 > If you are updating from Umami V2, image "postgresql-latest" is deprecated. You must change it to "latest".
-> Ex : rename "docker.umami.is/umami-software/umami:postgresql-latest" to "docker.umami.is/umami-software/umami:latest".
+> e.g., rename `docker.umami.is/umami-software/umami:postgresql-latest` to `docker.umami.is/umami-software/umami:latest`.
 
 To get the latest features, simply do a pull, install any new dependencies, and rebuild:
 


### PR DESCRIPTION
Fixing in README.md the docker image name and adding a deprecation message warning in section "update"