### PR TITLE
docs: document NEXT_SERVER_ACTIONS_ENCRYPTION_KEY requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,22 @@ Create an `.env` file with the following:
 DATABASE_URL=connection-url
 ```
 
+If you are running Umami v3 or newer you must also set the encryption key required by Next.js Server Actions:
+
+```bash
+NEXT_SERVER_ACTIONS_ENCRYPTION_KEY=your-64-character-hex-string
+```
+
 The connection URL format:
 
 ```bash
 postgresql://username:mypassword@localhost:5432/mydb
+```
+
+You can generate a secure 64-character hex encryption key (32 random bytes) with:
+
+```bash
+openssl rand -hex 32
 ```
 
 ### Build the Application

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       DATABASE_URL: postgresql://umami:umami@db:5432/umami
       DATABASE_TYPE: postgresql
       APP_SECRET: replace-me-with-a-random-string
+      NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: replace-me-with-a-64-character-hex-string
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
## Summary
- add missing NEXT_SERVER_ACTIONS_ENCRYPTION_KEY to the self-hosting README instructions
- document how to generate a secure key so installs don't fail on v3

## Testing
- documentation only

Fixes #3695