### PR TITLE
Prevent duplicate key db errors on session creation

### DIFF
--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -146,6 +146,7 @@ export async function POST(request: Request) {
         region,
         city,
         distinctId: id,
+        createdAt,
       });
     }
 

--- a/src/queries/sql/sessions/createSession.ts
+++ b/src/queries/sql/sessions/createSession.ts
@@ -1,41 +1,44 @@
 import { Prisma } from '@/generated/prisma/client';
 import prisma from '@/lib/prisma';
 
-export async function createSession(data: Prisma.SessionCreateInput) {
-  const {
-    id,
-    websiteId,
-    browser,
-    os,
-    device,
-    screen,
-    language,
-    country,
-    region,
-    city,
-    distinctId,
-  } = data;
+const FUNCTION_NAME = 'createSession';
 
-  try {
-    return await prisma.client.session.create({
-      data: {
-        id,
-        websiteId,
-        browser,
-        os,
-        device,
-        screen,
-        language,
-        country,
-        region,
-        city,
-        distinctId,
-      },
-    });
-  } catch (e: any) {
-    if (e.message.toLowerCase().includes('unique constraint')) {
-      return null;
-    }
-    throw e;
-  }
+export async function createSession(data: Prisma.SessionCreateInput) {
+  const { rawQuery } = prisma;
+
+  await rawQuery(
+    `
+    insert into session (
+      session_id,
+      website_id,
+      browser,
+      os,
+      device,
+      screen,
+      language,
+      country,
+      region,
+      city,
+      distinct_id,
+      created_at
+    )
+    values (
+      {{id}},
+      {{websiteId}},
+      {{browser}},
+      {{os}},
+      {{device}},
+      {{screen}},
+      {{language}},
+      {{country}},
+      {{region}},
+      {{city}},
+      {{distinctId}},
+      {{createdAt}}
+    )
+    on conflict (session_id) do nothing
+    `,
+    data,
+    FUNCTION_NAME,
+  );
 }


### PR DESCRIPTION
Closes #3709, closes #3551.

Since a previous performance improvement (#3469), duplicate key errors are expected to happen a lot more.
This is handled but db log can become cluttered by these.

Following Francis message in one of the issues:
> I think ON CONFLICT DO NOTHING makes the most sense. Need to see if this option is available in prisma or we can potentially convert it to a raw query.

Prisma does have `upsert` which translates to an ON CONFLICT query on certains conditions, but it doesn't handle the DO NOTHING part (which could be expected with an empty update https://github.com/prisma/prisma/issues/21853).

Raw query looks like the best bet for now.

Some details:
-Return value isn't needed/used.
-No need to catch "unique constraint" error because this won't happen.
-Previous prisma query generated `createdAt` before sending the query to db. Raw query won't do that.
=> `createdAt` is added so that it remains generated on JS land. And it's actually better in case timestamp is provided in send request.