### PR TITLE
feat(geo): add redirect support for direct .mmdb downloads

### DIFF
--- a/scripts/build-geo.js
+++ b/scripts/build-geo.js
@@ -45,10 +45,16 @@ const downloadCompressed = url =>
   });
 
 // Download handler for direct .mmdb files
-const downloadDirect = url =>
+const downloadDirect = (url, originalUrl) =>
   new Promise((resolve, reject) => {
     https.get(url, res => {
-      const filename = path.join(dest, path.basename(url));
+      // Follow redirects
+      if (res.statusCode === 301 || res.statusCode === 302) {
+        downloadDirect(res.headers.location, originalUrl || url).then(resolve).catch(reject);
+        return;
+      }
+      
+      const filename = path.join(dest, path.basename(originalUrl || url));
       const fileStream = fs.createWriteStream(filename);
       
       res.pipe(fileStream);


### PR DESCRIPTION
- Support GEO_DATABASE_URL environment variable for custom database sources
- Auto-detect .mmdb files and skip decompression step
- Handle HTTP 301/302 redirects while preserving original filename
- Maintain backward compatibility with tar.gz archives