### PR TITLE
Restore OS formatting in tables

### DIFF
--- a/src/components/metrics/MetricLabel.tsx
+++ b/src/components/metrics/MetricLabel.tsx
@@ -25,16 +25,16 @@ export function MetricLabel({ type, data }: MetricLabelProps) {
   const { getRegionName } = useRegionNames(locale);
 
   const { label, country, domain } = data;
-  const isType = ['browser', 'country', 'device', 'os'].includes(type);
 
   switch (type) {
     case 'browser':
+    case 'os':
       return (
         <FilterLink
-          type="browser"
+          type={type}
           value={label}
-          label={formatValue(label, 'browser')}
-          icon={<TypeIcon type="browser" value={label} />}
+          label={formatValue(label, type)}
+          icon={<TypeIcon type={type} value={label} />}
         />
       );
 
@@ -100,7 +100,7 @@ export function MetricLabel({ type, data }: MetricLabelProps) {
           type="device"
           value={labels[label] && label}
           label={formatValue(label, 'device')}
-          icon={<TypeIcon type="device" value={label?.toLowerCase()} />}
+          icon={<TypeIcon type="device" value={label} />}
         />
       );
 
@@ -141,14 +141,6 @@ export function MetricLabel({ type, data }: MetricLabelProps) {
         <FilterLink
           type={type}
           value={label}
-          icon={
-            isType && (
-              <TypeIcon
-                type={type as 'browser' | 'country' | 'device' | 'os'}
-                value={label?.toLowerCase()?.replaceAll(/\W/g, '-')}
-              />
-            )
-          }
         />
       );
   }


### PR DESCRIPTION
OS proper names (Mac OS => macOS, Windows 10 => Windows 10/11, ...) got lost in v3 tables.

This PR restores the needed formatting, and does a small cleanup:
-`toLowerCase` is already done in `TypeIcon`
-`isType` is only used in default case, but it would always be false, so it's removed, as well as the icon prop where it was used.

Cleanup could be pushed further but I wanted to keep the logic intact, even if some checks are redundant like
`value={(countryNames[label] && label) || label}` (resolves to `value={label}` anyway), but it might have been intentional for another reason.