### PR TITLE
fix(sessions): add defensive null checks for dates to prevent crashes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,8 +364,6 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  dist: {}
-
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionActivity.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionActivity.tsx
@@ -42,6 +42,19 @@ export function SessionActivity({
     <LoadingPanel data={data} isLoading={isLoading} error={error}>
       <Column gap>
         {data?.map(({ eventId, createdAt, urlPath, eventName, visitId, hasData }) => {
+          if (!createdAt) {
+            if (process.env.NODE_ENV !== 'production') {
+              // eslint-disable-next-line no-console
+              console.error('[SessionActivity] Event missing createdAt', {
+                eventId,
+                visitId,
+                urlPath,
+                eventName,
+              });
+            }
+            return null;
+          }
+
           const showHeader = !lastDay || !isSameDay(new Date(lastDay), new Date(createdAt));
           lastDay = createdAt;
 

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
@@ -11,6 +11,18 @@ export function SessionInfo({ data }) {
   const { formatValue } = useFormat();
   const { getRegionName } = useRegionNames(locale);
 
+  if (process.env.NODE_ENV !== 'production') {
+    if (!data.lastAt || !data.firstAt) {
+      // eslint-disable-next-line no-console
+      console.error('[SessionInfo] Session missing date fields', {
+        sessionId: data.id,
+        hasLastAt: !!data.lastAt,
+        hasFirstAt: !!data.firstAt,
+        distinctId: data.distinctId,
+      });
+    }
+  }
+
   return (
     <Grid columns="repeat(auto-fit, minmax(200px, 1fr)" gap>
       <Info label={formatMessage(labels.distinctId)} icon={<KeyRound />}>
@@ -18,11 +30,11 @@ export function SessionInfo({ data }) {
       </Info>
 
       <Info label={formatMessage(labels.lastSeen)} icon={<Calendar />}>
-        <DateDistance date={new Date(data.lastAt)} />
+        {data.lastAt ? <DateDistance date={new Date(data.lastAt)} /> : '—'}
       </Info>
 
       <Info label={formatMessage(labels.firstSeen)} icon={<Calendar />}>
-        <DateDistance date={new Date(data.firstAt)} />
+        {data.firstAt ? <DateDistance date={new Date(data.firstAt)} /> : '—'}
       </Info>
 
       <Info

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
@@ -51,7 +51,20 @@ export function SessionsTable(props: DataTableProps) {
         )}
       </DataColumn>
       <DataColumn id="lastAt" label={formatMessage(labels.lastSeen)}>
-        {(row: any) => <DateDistance date={new Date(row.createdAt)} />}
+        {(row: any) => {
+          if (!row.createdAt) {
+            if (process.env.NODE_ENV !== 'production') {
+              // eslint-disable-next-line no-console
+              console.error('[SessionsTable] Session missing createdAt', {
+                sessionId: row.id,
+                visits: row.visits,
+                views: row.views,
+              });
+            }
+            return '—';
+          }
+          return <DateDistance date={new Date(row.createdAt)} />;
+        }}
       </DataColumn>
     </DataTable>
   );

--- a/src/components/common/DateDistance.tsx
+++ b/src/components/common/DateDistance.tsx
@@ -6,6 +6,14 @@ export function DateDistance({ date }: { date: Date }) {
   const { formatTimezoneDate } = useTimezone();
   const { dateLocale } = useLocale();
 
+  if (!date || isNaN(date.getTime())) {
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.error('[DateDistance] Invalid date received', { date });
+    }
+    return <Text>—</Text>;
+  }
+
   return (
     <Text title={formatTimezoneDate(date.toISOString(), 'PPPpp')}>
       {formatDistanceToNow(date, { addSuffix: true, locale: dateLocale })}


### PR DESCRIPTION
⚠️ **Critical: This is a defensive fix for a deeper data integrity issue**

## Problem
Starting around November 14, 2025, users began experiencing crashes on the Sessions tab with `RangeError: Invalid time value at Date.toISOString()`. This appears to be a data integrity issue, not a code regression - sessions are returning null values for date fields.

## Solution
Adds defensive null checks across session components to prevent crashes and includes development-mode observability logging to track the scope of the problem.

## Changes
- Added null validation in SessionsTable, SessionInfo, SessionActivity, and DateDistance components
- Development-only console.error logs when null dates are encountered (with context like sessionId, eventId)
- Display "—" placeholder when dates are missing instead of crashing

## What Needs Investigation
This PR prevents crashes but does NOT fix the underlying data corruption. Immediate actions needed:
1. Database audit for sessions/events with null date fields
2. Check for changes around Nov 14 (migrations, deployments, imports)
3. Consider adding React Error Boundaries, API response validation, and user-visible warnings