### PR TITLE
Permit Docker use in read-only mode and/or offline env.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,10 +42,7 @@ RUN set -x \
     && apk add --no-cache curl
 
 # Script dependencies
-RUN pnpm add npm-run-all dotenv chalk semver prisma@6.18.0 @prisma/adapter-pg@6.18.0
-
-# Permissions for prisma
-RUN chown -R nextjs:nodejs node_modules/.pnpm/
+RUN pnpm --allow-build='@prisma/engines' add npm-run-all dotenv chalk semver prisma@6.18.0 @prisma/adapter-pg@6.18.0
 
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder /app/prisma ./prisma


### PR DESCRIPTION
Since the pnpm switch, a few users complained about filesystem or download errors using docker image.
Indeed, prisma engines were not included anymore in the image (because of the pnpm lifecycle scripts policy).

It moreover coincided with a change in custom route handling which required to have write permissions.

Now that the custom route logic has been abandoned, this PR adds the needed prisma engines back in the image so that it would be fully working in read-only mode and/or offline environment.

Details:
-Even with the new adapter method, specific engine is still needed for `prisma migrate deploy` in check-db script.
-`chown` step was there to handle the prisma engine download at first execution, so not needed anymore.
-Image size will be slightly increased, my local test shows a 25 MB difference.