### PR TITLE
Fixed `/api/batch` request recreation failure

### DIFF
--- a/src/app/api/batch/route.ts
+++ b/src/app/api/batch/route.ts
@@ -18,7 +18,20 @@ export async function POST(request: Request) {
 
     let index = 0;
     for (const data of body) {
-      const newRequest = new Request(request, { body: JSON.stringify(data) });
+      // Recreate a fresh Request since `new Request(request)` will have the following error:
+      // > Cannot read private member #state from an object whose class did not declare it
+
+      // Copy headers we received, ensure JSON content type, and avoid conflicting content-length
+      const headers = new Headers(request.headers);
+      headers.set('content-type', 'application/json');
+      headers.delete('content-length');
+
+      const newRequest = new Request(request.url, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(data),
+      });
+
       const response = await send.POST(newRequest);
 
       if (!response.ok) {


### PR DESCRIPTION
The original implementation would show `Cannot read private member #state from an object whose class did not declare it` error.

Production shows nothing (only return 500).

The app was built and ran on Windows.