### PR TITLE
fix: fix SQL syntax error in getPageviewExpandedMetrics query

### DIFF
--- a/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
+++ b/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
@@ -86,7 +86,7 @@ async function relationalQuery(
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime"
     from (
       select
-        ${column} name,
+        ${column} as name,
         website_event.session_id,
         website_event.visit_id,
         count(*) as "c",
@@ -101,7 +101,7 @@ async function relationalQuery(
       and website_event.event_type != 2
         ${excludeDomain}
         ${filterQuery}
-      group by name, website_event.session_id, website_event.visit_id
+      group by ${column}, website_event.session_id, website_event.visit_id
     ) as t
     where name != ''
     group by name 


### PR DESCRIPTION
reproduce the route: /websites/3638e7d2-7433-41b8-a2b6-2ec937faaecf?view=path
database version: PostgreSQL 13.22 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 11.5.0 20240719 (Red Hat 11.5.0-5), 64-bit

<img width="853" height="468" alt="截屏2025-11-25 21 10 25" src="https://github.com/user-attachments/assets/6339ad4e-068f-48bd-b465-a57656d2e0a0" />
