### PR TITLE
feat(sessions): add referrer to session modal

### DIFF
--- a/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { Icon, Grid, Column, Row, Label } from '@umami/react-zen';
 import { useFormat, useLocale, useMessages, useRegionNames } from '@/components/hooks';
 import { TypeIcon } from '@/components/common/TypeIcon';
+import { Favicon } from '@/components/common/Favicon';
 import { KeyRound, Calendar, MapPin, Landmark } from '@/components/icons';
 import { DateDistance } from '@/components/common/DateDistance';
 
@@ -59,6 +60,10 @@ export function SessionInfo({ data }) {
         icon={<TypeIcon type="device" value={data?.device} />}
       >
         {formatValue(data?.device, 'device')}
+      </Info>
+
+      <Info label={formatMessage(labels.referrer)} icon={<Favicon domain={data?.referrerDomain} />}>
+        {data?.referrerDomain}
       </Info>
     </Grid>
   );

--- a/src/queries/sql/sessions/getWebsiteSession.ts
+++ b/src/queries/sql/sessions/getWebsiteSession.ts
@@ -32,7 +32,13 @@ async function relationalQuery(websiteId: string, sessionId: string) {
       count(distinct visit_id) as visits,
       sum(views) as views,
       sum(events) as events,
-      sum(${getTimestampDiffSQL('min_time', 'max_time')}) as "totaltime" 
+      sum(${getTimestampDiffSQL('min_time', 'max_time')}) as "totaltime",
+      (select referrer_domain
+       from website_event
+       where website_id = {{websiteId::uuid}}
+         and session_id = {{sessionId::uuid}}
+       order by created_at asc
+       limit 1) as "referrerDomain"
     from (select
           session.session_id as id,
           session.distinct_id,
@@ -83,7 +89,13 @@ async function clickhouseQuery(websiteId: string, sessionId: string) {
       uniq(visit_id) visits,
       sum(views) as views,
       sum(events) as events,
-      sum(max_time-min_time) as totaltime
+      sum(max_time-min_time) as totaltime,
+      (select referrer_domain
+       from website_event
+       where website_id = {websiteId:UUID}
+         and session_id = {sessionId:UUID}
+       order by created_at asc
+       limit 1) as referrerDomain
     from (select
               session_id as id,
               distinct_id as distinctId,


### PR DESCRIPTION
### Summary
Display the initial referrer in the Session modal properties grid, after Device.

### Changes
- **Backend**: Modified `getWebsiteSession.ts` to fetch the referrer from the session's first event (both PostgreSQL and ClickHouse queries)
- **Frontend**: Added referrer display with favicon icon to `SessionInfo.tsx`

### How to Test
1. Go to Sessions page
2. Click on any session to open the modal
3. Verify "Referrer" appears as the last item in the properties grid
4. If the session has a referrer, it displays with a favicon; otherwise shows "—"