### PR TITLE
fix: disable prefetch for Links view button

### DIFF
--- a/src/app/(main)/links/[linkId]/LinkHeader.tsx
+++ b/src/app/(main)/links/[linkId]/LinkHeader.tsx
@@ -11,7 +11,7 @@ export function LinkHeader() {
 
   return (
     <PageHeader title={link.name} description={link.url} icon={<Link />} marginBottom="3">
-      <LinkButton href={getSlugUrl(link.slug)} target="_blank">
+      <LinkButton href={getSlugUrl(link.slug)} target="_blank" prefetch={false}>
         <Icon>
           <ExternalLink />
         </Icon>


### PR DESCRIPTION
Closes #3814 

Pixel `View` button has the prefetch props https://github.com/umami-software/umami/commit/b08a6e11138c41956836015e4de4caa74331c46e#diff-2e60e8392a1477697f19b74589ccb86f328023c61c66ca53154f0308d363c131