### PR TITLE
feat: Unique Visitors Count on Events Page

### DIFF
--- a/src/app/(main)/websites/[websiteId]/WebsiteControls.tsx
+++ b/src/app/(main)/websites/[websiteId]/WebsiteControls.tsx
@@ -4,7 +4,7 @@ import { FilterBar } from '@/components/input/FilterBar';
 import { MonthFilter } from '@/components/input/MonthFilter';
 import { WebsiteDateFilter } from '@/components/input/WebsiteDateFilter';
 import { WebsiteFilterButton } from '@/components/input/WebsiteFilterButton';
-import UniqueSessions from '@/components/metrics/UniqueSessions';
+import UniqueVisitors from '@/components/metrics/UniqueVisitors';
 
 export function WebsiteControls({
   websiteId,
@@ -26,7 +26,7 @@ export function WebsiteControls({
       <Grid columns={{ xs: '1fr', md: 'auto 1fr' }} gap>
         <Row alignItems="center" justifyContent="flex-start" gap="4">
           {allowFilter ? <WebsiteFilterButton websiteId={websiteId} /> : <div />}
-          <UniqueSessions websiteId={websiteId} />
+          <UniqueVisitors websiteId={websiteId} />
         </Row>
         <Row alignItems="center" justifyContent={{ xs: 'flex-start', md: 'flex-end' }}>
           {allowDateFilter && (

--- a/src/app/(main)/websites/[websiteId]/WebsiteControls.tsx
+++ b/src/app/(main)/websites/[websiteId]/WebsiteControls.tsx
@@ -4,6 +4,7 @@ import { FilterBar } from '@/components/input/FilterBar';
 import { MonthFilter } from '@/components/input/MonthFilter';
 import { WebsiteDateFilter } from '@/components/input/WebsiteDateFilter';
 import { WebsiteFilterButton } from '@/components/input/WebsiteFilterButton';
+import UniqueSessions from '@/components/metrics/UniqueSessions';
 
 export function WebsiteControls({
   websiteId,
@@ -23,8 +24,9 @@ export function WebsiteControls({
   return (
     <Column gap>
       <Grid columns={{ xs: '1fr', md: 'auto 1fr' }} gap>
-        <Row alignItems="center" justifyContent="flex-start">
+        <Row alignItems="center" justifyContent="flex-start" gap="4">
           {allowFilter ? <WebsiteFilterButton websiteId={websiteId} /> : <div />}
+          <UniqueSessions websiteId={websiteId} />
         </Row>
         <Row alignItems="center" justifyContent={{ xs: 'flex-start', md: 'flex-end' }}>
           {allowDateFilter && (

--- a/src/components/metrics/UniqueSessions.tsx
+++ b/src/components/metrics/UniqueSessions.tsx
@@ -16,12 +16,11 @@ const UniqueSessions = ({ websiteId }) => {
   return (
     <Container className="flex items-center gap-8">
       <Text size="5" color="gray">
-        {' '}
-        Unique Sessions:{' '}
+        Unique Sessions:
       </Text>
-      <Text size="5" className="text-white" weight="bold">
+      <Text size="5" className="text-white mr-3" weight="bold">
         {' '}
-        {uniqueSessionCount}{' '}
+        {uniqueSessionCount}
       </Text>
     </Container>
   );

--- a/src/components/metrics/UniqueSessions.tsx
+++ b/src/components/metrics/UniqueSessions.tsx
@@ -1,4 +1,4 @@
-import { Container, Loading, Text } from '@umami/react-zen';
+import { Loading, Row, Text } from '@umami/react-zen';
 import { useWebsiteStatsQuery } from '@/components/hooks';
 
 interface UniqueSessionsProps {
@@ -22,19 +22,19 @@ const UniqueSessions = ({ websiteId }: UniqueSessionsProps) => {
     }
 
     return (
-      <Text size="5" className="text-white mr-3" weight="bold">
+      <Text size="5" weight="bold">
         {data?.visitors ?? 0}
       </Text>
     );
   };
 
   return (
-    <Container className="flex items-center gap-8">
+    <Row alignItems="center" gap="3">
       <Text size="5" color="gray">
         Unique Sessions:
       </Text>
       {renderContent()}
-    </Container>
+    </Row>
   );
 };
 

--- a/src/components/metrics/UniqueSessions.tsx
+++ b/src/components/metrics/UniqueSessions.tsx
@@ -1,27 +1,39 @@
-import { Container, Text } from '@umami/react-zen';
-import { useMemo } from 'react';
-import { useWebsiteEventsQuery } from '@/components/hooks';
+import { Container, Loading, Text } from '@umami/react-zen';
+import { useWebsiteStatsQuery } from '@/components/hooks';
 
-const UniqueSessions = ({ websiteId }) => {
-  const query = useWebsiteEventsQuery(websiteId, { view: 'all' });
+interface UniqueSessionsProps {
+  websiteId: string;
+}
 
-  const uniqueSessionCount = useMemo(() => {
-    if (!query?.data?.data) return 0;
+const UniqueSessions = ({ websiteId }: UniqueSessionsProps) => {
+  const { data, isLoading, error } = useWebsiteStatsQuery(websiteId);
 
-    const uniqueSessions = new Set(query.data.data.map((event: any) => event.sessionId));
+  const renderContent = () => {
+    if (isLoading) {
+      return <Loading icon="dots" />;
+    }
 
-    return uniqueSessions.size;
-  }, [query?.data?.data]);
+    if (error) {
+      return (
+        <Text size="5" color="red">
+          Error loading data
+        </Text>
+      );
+    }
+
+    return (
+      <Text size="5" className="text-white mr-3" weight="bold">
+        {data?.visitors ?? 0}
+      </Text>
+    );
+  };
 
   return (
     <Container className="flex items-center gap-8">
       <Text size="5" color="gray">
         Unique Sessions:
       </Text>
-      <Text size="5" className="text-white mr-3" weight="bold">
-        {' '}
-        {uniqueSessionCount}
-      </Text>
+      {renderContent()}
     </Container>
   );
 };

--- a/src/components/metrics/UniqueSessions.tsx
+++ b/src/components/metrics/UniqueSessions.tsx
@@ -1,0 +1,30 @@
+import { Container, Text } from '@umami/react-zen';
+import { useMemo } from 'react';
+import { useWebsiteEventsQuery } from '@/components/hooks';
+
+const UniqueSessions = ({ websiteId }) => {
+  const query = useWebsiteEventsQuery(websiteId, { view: 'all' });
+
+  const uniqueSessionCount = useMemo(() => {
+    if (!query?.data?.data) return 0;
+
+    const uniqueSessions = new Set(query.data.data.map((event: any) => event.sessionId));
+
+    return uniqueSessions.size;
+  }, [query?.data?.data]);
+
+  return (
+    <Container className="flex items-center gap-8">
+      <Text size="5" color="gray">
+        {' '}
+        Unique Sessions:{' '}
+      </Text>
+      <Text size="5" className="text-white" weight="bold">
+        {' '}
+        {uniqueSessionCount}{' '}
+      </Text>
+    </Container>
+  );
+};
+
+export default UniqueSessions;

--- a/src/components/metrics/UniqueSessions.tsx
+++ b/src/components/metrics/UniqueSessions.tsx
@@ -31,7 +31,7 @@ const UniqueSessions = ({ websiteId }: UniqueSessionsProps) => {
   return (
     <Row alignItems="center" gap="3">
       <Text size="5" color="gray">
-        Unique Sessions:
+        {formatMessage(labels.visitors)}:
       </Text>
       {renderContent()}
     </Row>

--- a/src/components/metrics/UniqueVisitors.tsx
+++ b/src/components/metrics/UniqueVisitors.tsx
@@ -1,12 +1,13 @@
 import { Loading, Row, Text } from '@umami/react-zen';
-import { useWebsiteStatsQuery } from '@/components/hooks';
+import { useMessages, useWebsiteStatsQuery } from '@/components/hooks';
 
-interface UniqueSessionsProps {
+interface UniqueVisitorsProps {
   websiteId: string;
 }
 
-const UniqueSessions = ({ websiteId }: UniqueSessionsProps) => {
+const UniqueVisitors = ({ websiteId }: UniqueVisitorsProps) => {
   const { data, isLoading, error } = useWebsiteStatsQuery(websiteId);
+  const { formatMessage, labels } = useMessages();
 
   const renderContent = () => {
     if (isLoading) {
@@ -38,4 +39,4 @@ const UniqueSessions = ({ websiteId }: UniqueSessionsProps) => {
   );
 };
 
-export default UniqueSessions;
+export default UniqueVisitors;


### PR DESCRIPTION
This pull request introduces a new `UniqueVisitors` component to display the count of unique website sessions, integrates it into the website controls UI and fixes #3830. The main changes are the creation of the new component and its addition to the controls row.


## Screenshots

<img width="720" height="720" alt="Events _ Umami - Brave 07-12-2025 17_02_01" src="https://github.com/user-attachments/assets/e768ad46-9b60-48e6-b645-d70044fc623c" />

---

<img width="720" height="720" alt="Events _ Umami - Brave 07-12-2025 17_02_31" src="https://github.com/user-attachments/assets/fbfa42c2-6e4c-4489-9761-04c49fffa3d3" />
