### PR TITLE
fix: handle denied storage access

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -12,7 +12,13 @@
   if (!currentScript) return;
 
   const { hostname, href, origin } = location;
-  const localStorage = href.startsWith('data:') ? undefined : window.localStorage;
+
+  let localStorage;
+  try {
+    localStorage = href.startsWith('data:') ? undefined : window.localStorage;
+  } catch {
+    /* (DOMException) SecurityError: Access is denied for this document. */
+  }
 
   const _data = 'data-';
   const _false = 'false';


### PR DESCRIPTION
In the case where the website is denied access to localStorage, the tracker would fail as a DOMException is thrown when accessing `window.localStorage`. This PR adds a simple fix of ignoring the error and moving on. This allows us to keep tracking.