### PR TITLE
fix(events): use correct key for event values

### DIFF
--- a/src/components/hooks/queries/useEventDataValuesQuery.ts
+++ b/src/components/hooks/queries/useEventDataValuesQuery.ts
@@ -16,7 +16,7 @@ export function useEventDataValuesQuery(
   return useQuery<any>({
     queryKey: [
       'websites:event-data:values',
-      { websiteId, event, propertyName, startAt, endAt, unit, timezone, ...filters },
+      { websiteId, startAt, endAt, unit, timezone, ...filters, event, propertyName },
     ],
     queryFn: () =>
       get(`/websites/${websiteId}/event-data/values`, {


### PR DESCRIPTION
I faced a bug when switching events that share property name.

Example: we have two events `test-first` and `test-second`, both with properties `property`, as on the screenshots below:
<img width="1282" height="624" alt="image" src="https://github.com/user-attachments/assets/22ba8297-7cbf-4112-9733-7a3e4b27cf12" />
<img width="1286" height="623" alt="image" src="https://github.com/user-attachments/assets/f9686517-8682-413c-a8de-92eeecec916e" />


Then, if we switch between them, it will not update the UI and we will have a situation like below: `test-second` with properties from previous event:
<img width="1288" height="624" alt="image" src="https://github.com/user-attachments/assets/f884207a-327d-4341-83ed-1cddbf508442" />

Turns out, the problem is that `filters` contain an `event: undefined` entry that resets `event` to undefined and causes it to misuse the cache. This PR fixes it by moving `event` and `propertyName` to the end of dict, as in `get` function below.
