### PR TITLE
feat: add EdgeOne CDN geolocation headers support

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -28,6 +28,12 @@ const PROVIDER_HEADERS = [
     regionHeader: 'cloudfront-viewer-country-region',
     cityHeader: 'cloudfront-viewer-city',
   },
+  // EdgeOne headers (requires custom request headers in Rule Priorities, see: https://edgeone.ai/document/46151)
+  {
+    countryHeader: 'eo-ipcountry',
+    regionHeader: 'eo-region-code',
+    cityHeader: 'eo-ipcity',
+  },
 ];
 
 export function getDevice(userAgent: string, screen: string = '') {


### PR DESCRIPTION
After feedback to Tencent Cloud EdgeOne team, the feature is now available:

- Add support for EdgeOne CDN geolocation headers (eo-ipcountry, eo-region-code, eo-ipcity)
- Align EdgeOne with existing CDN providers (Cloudflare, Vercel, CloudFront) 
- Requires custom request headers configuration in EdgeOne Rule Priorities