### PR TITLE
feat: Add default currency support and update currency handling in Revenue component

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const cloudMode = process.env.CLOUD_MODE || '';
 const cloudUrl = process.env.CLOUD_URL || '';
 const collectApiEndpoint = process.env.COLLECT_API_ENDPOINT || '';
 const corsMaxAge = process.env.CORS_MAX_AGE || '';
+const defaultCurrency = process.env.DEFAULT_CURRENCY || '';
 const defaultLocale = process.env.DEFAULT_LOCALE || '';
 const forceSSL = process.env.FORCE_SSL || '';
 const frameAncestors = process.env.ALLOWED_FRAME_URLS || '';
@@ -170,6 +171,7 @@ export default {
     cloudMode,
     cloudUrl,
     currentVersion: pkg.version,
+    defaultCurrency,
     defaultLocale,
   },
   basePath,

--- a/src/app/(main)/websites/[websiteId]/(reports)/revenue/Revenue.tsx
+++ b/src/app/(main)/websites/[websiteId]/(reports)/revenue/Revenue.tsx
@@ -12,9 +12,10 @@ import { ListTable } from '@/components/metrics/ListTable';
 import { MetricCard } from '@/components/metrics/MetricCard';
 import { MetricsBar } from '@/components/metrics/MetricsBar';
 import { renderDateLabels } from '@/lib/charts';
-import { CHART_COLORS } from '@/lib/constants';
+import { CHART_COLORS, CURRENCY_CONFIG, DEFAULT_CURRENCY } from '@/lib/constants';
 import { generateTimeSeries } from '@/lib/date';
 import { formatLongCurrency, formatLongNumber } from '@/lib/format';
+import { getItem, setItem } from '@/lib/storage';
 
 export interface RevenueProps {
   websiteId: string;
@@ -24,7 +25,15 @@ export interface RevenueProps {
 }
 
 export function Revenue({ websiteId, startDate, endDate, unit }: RevenueProps) {
-  const [currency, setCurrency] = useState('USD');
+  const [currency, setCurrency] = useState(
+    getItem(CURRENCY_CONFIG) || process.env.defaultCurrency || DEFAULT_CURRENCY,
+  );
+
+  const handleCurrencyChange = (value: string) => {
+    setCurrency(value);
+    setItem(CURRENCY_CONFIG, value);
+  };
+
   const { formatMessage, labels } = useMessages();
   const { locale, dateLocale } = useLocale();
   const { countryNames } = useCountryNames(locale);
@@ -107,7 +116,7 @@ export function Revenue({ websiteId, startDate, endDate, unit }: RevenueProps) {
   return (
     <Column gap>
       <Grid columns="280px" gap>
-        <CurrencySelect value={currency} onChange={setCurrency} />
+        <CurrencySelect value={currency} onChange={handleCurrencyChange} />
       </Grid>
       <LoadingPanel data={data} isLoading={isLoading} error={error}>
         {data && (

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const LOCALE_CONFIG = 'umami.locale';
 export const TIMEZONE_CONFIG = 'umami.timezone';
 export const DATE_RANGE_CONFIG = 'umami.date-range';
 export const THEME_CONFIG = 'umami.theme';
+export const CURRENCY_CONFIG = 'umami.currency';
 export const DASHBOARD_CONFIG = 'umami.dashboard';
 export const LAST_TEAM_CONFIG = 'umami.last-team';
 export const VERSION_CHECK = 'umami.version-check';
@@ -25,6 +26,7 @@ export const DEFAULT_WEBSITE_LIMIT = 10;
 export const DEFAULT_RESET_DATE = '2000-01-01';
 export const DEFAULT_PAGE_SIZE = 20;
 export const DEFAULT_DATE_COMPARE = 'prev';
+export const DEFAULT_CURRENCY = 'USD';
 
 export const REALTIME_RANGE = 30;
 export const REALTIME_INTERVAL = 10000;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_CURRENCY } from './constants';
+
 export function parseTime(val: number) {
   const days = ~~(val / 86400);
   const hours = ~~(val / 3600) - days * 24;
@@ -94,7 +96,7 @@ export function formatCurrency(value: number, currency: string, locale = 'en-US'
     // Fallback to default currency format if an error occurs
     formattedValue = new Intl.NumberFormat(locale, {
       style: 'currency',
-      currency: 'USD',
+      currency: DEFAULT_CURRENCY,
     });
   }
 


### PR DESCRIPTION
This pull request introduces support for a configurable default currency throughout the application. The changes add a new environment variable for the default currency, persist user currency preferences, and ensure consistent usage of the default currency in formatting and UI components.

Close: #3896

**Default currency configuration and usage:**

* Added a `DEFAULT_CURRENCY` environment variable to `next.config.ts` and exposed it to the frontend for consistent access. [[1]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR11) [[2]](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR174)
* Defined `DEFAULT_CURRENCY` and `CURRENCY_CONFIG` constants in `src/lib/constants.ts` for use across the application. [[1]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR7) [[2]](diffhunk://#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR29)

**Frontend currency selection and persistence:**

* Updated the `Revenue` report component to initialize currency from local storage, environment variable, or fallback default, and to persist user selection using `getItem` and `setItem`. ([src/app/(main)/websites/[websiteId]/(reports)/revenue/Revenue.tsxL15-R18](diffhunk://#diff-227a91449d0c6eba437a4973164c80285bb351f692345508a64b4440b96b2c28L15-R18), [src/app/(main)/websites/[websiteId]/(reports)/revenue/Revenue.tsxL27-R36](diffhunk://#diff-227a91449d0c6eba437a4973164c80285bb351f692345508a64b4440b96b2c28L27-R36))
* Modified the currency selection UI to use a new `handleCurrencyChange` function, ensuring changes are saved to local storage. ([src/app/(main)/websites/[websiteId]/(reports)/revenue/Revenue.tsxL110-R119](diffhunk://#diff-227a91449d0c6eba437a4973164c80285bb351f692345508a64b4440b96b2c28L110-R119))

**Consistent currency formatting:**

* Updated the currency formatting utility to use the `DEFAULT_CURRENCY` constant as a fallback instead of a hardcoded value. [[1]](diffhunk://#diff-769f3879f73f128cb8edff98945340a348a660d9d40644f5ee246217e90107c8R1-R2) [[2]](diffhunk://#diff-769f3879f73f128cb8edff98945340a348a660d9d40644f5ee246217e90107c8L97-R99)