### PR TITLE
Fixed PostgreSQL 12/13 syntax error in Journeys feature

### DIFF
--- a/src/queries/sql/reports/getJourney.ts
+++ b/src/queries/sql/reports/getJourney.ts
@@ -119,7 +119,7 @@ async function relationalQuery(
       select distinct
           website_event.visit_id,
           website_event.referrer_path,
-          coalesce(nullIf(website_event.event_name, ''), website_event.url_path) event,
+          coalesce(nullIf(website_event.event_name, ''), website_event.url_path) "event",
           row_number() OVER (PARTITION BY visit_id ORDER BY website_event.created_at) AS event_number
       from website_event
       ${cohortQuery}


### PR DESCRIPTION
## Summary

  Fixes #3909 - PostgreSQL 12/13 compatibility issue in Journeys feature

  The Journeys feature was failing on PostgreSQL 12 and 13 with the error: syntax error at or near 'event'

### Changes

  - Added quotes around the event column alias in the Journeys SQL query (line 122 in src/queries/sql/reports/getJourney.ts)
  - This ensures compatibility with PostgreSQL 12/13's stricter column aliasing rules for reserved keywords

### Technical Details

  PostgreSQL 12 and 13 require reserved keywords like event to be quoted when used as column aliases. The query was referencing "event" (with quotes) in CASE statements but declaring it as event (without quotes), causing a syntax error.

### Testing

Tested with PostgreSQL 13 using docker-compose to verify the Journeys feature now works without errors.