### PR TITLE
Fix double scrollbar in dropdown

### DIFF
--- a/src/components/input/WebsiteSelect.tsx
+++ b/src/components/input/WebsiteSelect.tsx
@@ -65,7 +65,7 @@ export function WebsiteSelect({
       renderValue={renderValue}
       listProps={{
         renderEmptyState: () => <Empty message={formatMessage(messages.noResultsFound)} />,
-        style: { maxHeight: '400px' },
+        style: { maxHeight: 'calc(42vh - 65px)' },
       }}
     >
       {({ id, name }: any) => <ListItem key={id}>{name}</ListItem>}


### PR DESCRIPTION
**Summary**
Fixes UI issue where the WebsiteSelect dropdown in the sidebar would show two scrollbars with a long list on shorter viewports.

**Before/After**
<img width="321" height="459" alt="Screenshot from 2026-01-03 00-47-02" src="https://github.com/user-attachments/assets/93c58f8d-16c0-4f88-af4f-9a3e1f0a7c13" /> <img width="333" height="468" alt="Screenshot from 2026-01-03 00-47-45" src="https://github.com/user-attachments/assets/0fb62db0-4dbf-45d3-8a8f-a0f6e261d0a9" />

Likely fixes #3913 although I was unable to replicate the exact situation seen in the issue's screenshot. (their issue only has one non-scrollable scrollbar)

**Cause**
The Select dropdown wrapper in [@umami/react-zen:/src/components/Select.module.css:25](https://github.com/umami-software/react-zen/blob/56fa00ecd38f2e0a92ebf5b2ae78f67b8c84b5aa/src/components/Select.module.css#L25) is scrollable and capped at 42vh.
The inner list is also scrollable, so increasing the inner list height beyond the wrapper cap creates nested scroll containers.

**Fix**
The maximum height of the dropdown list is now set relative to the viewport.