### PR TITLE
Fix autofill styling inconsistency in dark theme

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -41,3 +41,18 @@ a:hover {
   border: 4px solid rgba(0, 0, 0, 0);
   background-clip: padding-box;
 }
+
+/* Fix autofill background color to match dark theme */
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active,
+textarea:-webkit-autofill,
+textarea:-webkit-autofill:hover,
+textarea:-webkit-autofill:focus,
+select:-webkit-autofill,
+select:-webkit-autofill:hover,
+select:-webkit-autofill:focus {
+  -webkit-box-shadow: 0 0 0 1000px var(--background-color) inset !important;
+  transition: color 5000s ease-in-out 0s;
+}


### PR DESCRIPTION
## Fix autofill styling inconsistency in dark theme

### Solution
Applied CSS rules to override browser autofill styling:
- Used `-webkit-box-shadow` inset technique to replace the white background with the theme's `--background-color`
- Added `transition: color 5000s ease-in-out 0s` to prevent the browser from reverting the text color to its default after a few seconds

### Note
The 5000s transition is a well-known hack required to override Chromium's aggressive autofill styling. Unfortunately, despite researching alternatives (`animation` with `animation-fill-mode`, `-webkit-text-fill-color`, `color !important`, etc.), the transition delay remains the only reliable cross-browser solution that prevents the text from turning black after autofill completes.

### Tested on
- Chrome
- Brave
- Edge

Fixes #3953