### PR TITLE
Covering index for website_event and query optimization for pageview and session metrics

### DIFF
--- a/prisma/migrations/18_add_website_event_covering_index/migration.sql
+++ b/prisma/migrations/18_add_website_event_covering_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "website_event_website_id_created_at_event_type_session_id_idx" ON "website_event"("website_id", "created_at", "event_type", "session_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -136,6 +136,7 @@ model WebsiteEvent {
   @@index([websiteId, createdAt, eventName])
   @@index([websiteId, createdAt, tag])
   @@index([websiteId, sessionId, createdAt])
+  @@index([websiteId, createdAt, eventType, sessionId])
   @@index([websiteId, visitId, createdAt])
   @@index([websiteId, createdAt, hostname])
   @@map("website_event")


### PR DESCRIPTION
I've been using Umami for a website which started skyrocketing a few days ago. And as soon as it did, the performance of statistics generation severely degraded. I was able to track things down to database queries for pageview and session metrics. To optimize them, I did the following:

* Added a covering index on `WebsiteEvent`
* Rewrote the logic in `getPageviewMetrix.ts` and `getSessionMetrics.ts` to use a common table expression when there are no filters set. Instead of scanning events, join all to session, then group and count distinct, we now scan events (faster thanks to the covering index), then get distinct ids, then join once to session, then count.

With these changes, I get superb performance again.