### PR TITLE
fix inconsistent date format

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -20,14 +20,6 @@ const PRISMA_LOG_OPTIONS = {
 };
 
 const DATE_FORMATS = {
-  minute: 'YYYY-MM-DD HH24:MI:00',
-  hour: 'YYYY-MM-DD HH24:00:00',
-  day: 'YYYY-MM-DD HH24:00:00',
-  month: 'YYYY-MM-01 HH24:00:00',
-  year: 'YYYY-01-01 HH24:00:00',
-};
-
-const DATE_FORMATS_UTC = {
   minute: 'YYYY-MM-DD"T"HH24:MI:00"Z"',
   hour: 'YYYY-MM-DD"T"HH24:00:00"Z"',
   day: 'YYYY-MM-DD"T"HH24:00:00"Z"',
@@ -52,7 +44,7 @@ function getDateSQL(field: string, unit: string, timezone?: string): string {
     return `to_char(date_trunc('${unit}', ${field} at time zone '${timezone}'), '${DATE_FORMATS[unit]}')`;
   }
 
-  return `to_char(date_trunc('${unit}', ${field}), '${DATE_FORMATS_UTC[unit]}')`;
+  return `to_char(date_trunc('${unit}', ${field}), '${DATE_FORMATS[unit]}')`;
 }
 
 function getDateWeeklySQL(field: string, timezone?: string) {


### PR DESCRIPTION
Currently when requesting website pageview API with and without a `timezone` parameter return different date formats. 

This change is to standardize the datetime format to the same as what Umami cloud return