### PR TITLE
Update robots.txt fixes #3996

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,5 @@
 User-agent: *
+Allow: /q/
+
+User-agent: *
 Disallow: /

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,3 @@
 User-agent: *
 Allow: /q/
-
-User-agent: *
 Disallow: /


### PR DESCRIPTION
Allows bots to crawl the /q/ paths which is used for links.