### PR TITLE
fix(collect): Fix the issue where referer might be null

### DIFF
--- a/src/app/(collect)/p/[slug]/route.ts
+++ b/src/app/(collect)/p/[slug]/route.ts
@@ -42,13 +42,13 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     }
   }
 
-  const referer = request.headers.get('referer') || request.headers.get('referrer');
+  const referrer = request.headers.get('referer') || request.headers.get('referrer');
   const payload = {
     type: 'event',
     payload: {
       pixel: pixel.id,
       url: request.url,
-      ...(referer && { referer }), // avoid referrer is not a string
+      ...(referrer && { referrer }), // avoid referrer is not a string
     },
   };
 

--- a/src/app/(collect)/q/[slug]/route.ts
+++ b/src/app/(collect)/q/[slug]/route.ts
@@ -40,13 +40,13 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     }
   }
 
-  const referer = request.headers.get('referer') || request.headers.get('referrer');
+  const referrer = request.headers.get('referer') || request.headers.get('referrer');
   const payload = {
     type: 'event',
     payload: {
       link: link.id,
       url: request.url,
-      ...(referer && { referer }), // avoid referrer is not a string
+      ...(referrer && { referrer }), // avoid referrer is not a string
     },
   };
 


### PR DESCRIPTION
Handle the case where the referer header could be null, and uniformly use the value from either the referer or referrer header.

#4038 