### PR TITLE
feat: add cache control headers to GET response

### DIFF
--- a/src/app/(collect)/p/[slug]/route.ts
+++ b/src/app/(collect)/p/[slug]/route.ts
@@ -63,6 +63,9 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     headers: {
       'Content-Type': 'image/gif',
       'Content-Length': image.length.toString(),
+      'Cache-Control': 'no-cache, no-store, must-revalidate',
+      Pragma: 'no-cache',
+      Expires: '0',
     },
   });
 }


### PR DESCRIPTION
This pull request adds HTTP headers to prevent caching of image responses in the `GET` handler for `src/app/(collect)/p/[slug]/route.ts`. This ensures that clients and proxies always fetch the latest image rather than using a cached version. 

Caching control improvements:

* Added `Cache-Control: no-cache, no-store, must-revalidate`, `Pragma: no-cache`, and `Expires: 0` headers to the image response to prevent caching. ([src/app/(collect)/p/[slug]/route.tsR66-R68](diffhunk://#diff-8248f0ded416f3cf5ae142f2f2065f497ca0b34e8e9c120b5e41781905b51ce4R66-R68))

closes : #4011
