### PR TITLE
feat: add aggregated dashboard with sparklines and per-website stats

### DIFF
--- a/src/app/(main)/MobileNav.tsx
+++ b/src/app/(main)/MobileNav.tsx
@@ -2,7 +2,7 @@ import { Grid, IconLabel, NavMenu, NavMenuItem, Row, Text } from '@umami/react-z
 import Link from 'next/link';
 import { WebsiteNav } from '@/app/(main)/websites/[websiteId]/WebsiteNav';
 import { useMessages, useNavigation } from '@/components/hooks';
-import { Globe, Grid2x2, LinkIcon } from '@/components/icons';
+import { Globe, Grid2x2, LayoutDashboard, LinkIcon } from '@/components/icons';
 import { MobileMenuButton } from '@/components/input/MobileMenuButton';
 import { NavButton } from '@/components/input/NavButton';
 import { Logo } from '@/components/svg';
@@ -16,6 +16,12 @@ export function MobileNav() {
   const isSettings = pathname.includes('/settings');
 
   const links = [
+    {
+      id: 'dashboard',
+      label: formatMessage(labels.dashboard),
+      path: '/dashboard',
+      icon: <LayoutDashboard />,
+    },
     {
       id: 'websites',
       label: formatMessage(labels.websites),

--- a/src/app/(main)/SideNav.tsx
+++ b/src/app/(main)/SideNav.tsx
@@ -10,7 +10,7 @@ import {
 import Link from 'next/link';
 import type { Key } from 'react';
 import { useGlobalState, useMessages, useNavigation } from '@/components/hooks';
-import { Globe, Grid2x2, LinkIcon, PanelLeft } from '@/components/icons';
+import { Globe, Grid2x2, LayoutDashboard, LinkIcon, PanelLeft } from '@/components/icons';
 import { LanguageButton } from '@/components/input/LanguageButton';
 import { NavButton } from '@/components/input/NavButton';
 import { PanelButton } from '@/components/input/PanelButton';
@@ -24,6 +24,12 @@ export function SideNav(props: SidebarProps) {
   const hasNav = !!(websiteId || pathname.startsWith('/admin') || pathname.includes('/settings'));
 
   const links = [
+    {
+      id: 'dashboard',
+      label: formatMessage(labels.dashboard),
+      path: '/dashboard',
+      icon: <LayoutDashboard />,
+    },
     {
       id: 'websites',
       label: formatMessage(labels.websites),

--- a/src/app/(main)/dashboard/DashboardPage.tsx
+++ b/src/app/(main)/dashboard/DashboardPage.tsx
@@ -1,16 +1,45 @@
 'use client';
-import { Column } from '@umami/react-zen';
+import { Column, Row } from '@umami/react-zen';
+import { useMemo } from 'react';
 import { PageBody } from '@/components/common/PageBody';
 import { PageHeader } from '@/components/common/PageHeader';
-import { useMessages } from '@/components/hooks';
+import { useDateRange, useMessages, useNavigation } from '@/components/hooks';
+import { DateFilter } from '@/components/input/DateFilter';
+import { getDateRangeValue } from '@/lib/date';
+import { DashboardView } from './DashboardView';
+
+const DASHBOARD_DEFAULT_DATE = '30day';
 
 export function DashboardPage() {
   const { formatMessage, labels } = useMessages();
+  const { dateRange } = useDateRange();
+  const {
+    router,
+    updateParams,
+    query: { date = '', offset = 0 },
+  } = useNavigation();
+
+  const dateValue = useMemo(() => {
+    if (!date) return DASHBOARD_DEFAULT_DATE;
+    return offset !== 0
+      ? getDateRangeValue(dateRange.startDate, dateRange.endDate)
+      : dateRange.value;
+  }, [date, offset, dateRange]);
+
+  const handleDateChange = (value: string) => {
+    router.push(updateParams({ date: value, offset: undefined }));
+  };
 
   return (
     <PageBody>
-      <Column margin="2">
-        <PageHeader title={formatMessage(labels.dashboard)}></PageHeader>
+      <Column gap="6" margin="2">
+        <Row alignItems="center" justifyContent="space-between" wrap="wrap" gap>
+          <PageHeader title={formatMessage(labels.dashboard)} />
+          <Row minWidth="200px">
+            <DateFilter value={dateValue} onChange={handleDateChange} />
+          </Row>
+        </Row>
+        <DashboardView defaultDate={DASHBOARD_DEFAULT_DATE} />
       </Column>
     </PageBody>
   );

--- a/src/app/(main)/dashboard/DashboardView.tsx
+++ b/src/app/(main)/dashboard/DashboardView.tsx
@@ -1,0 +1,193 @@
+'use client';
+import { Column, Grid, Loading, Text } from '@umami/react-zen';
+import { useMemo } from 'react';
+import { useApi, useDateRange, useMessages, useNavigation, useTimezone } from '@/components/hooks';
+import { Panel } from '@/components/common/Panel';
+import { parseDateRange } from '@/lib/date';
+import { WebsiteStatsTable } from './WebsiteStatsTable';
+import { StatCard } from './StatCard';
+
+interface WebsiteItem {
+  id: string;
+  name: string;
+  domain: string;
+}
+
+interface StatsData {
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+}
+
+interface PageviewPoint {
+  x: string;
+  y: number;
+}
+
+interface PageviewsData {
+  pageviews: PageviewPoint[];
+  sessions: PageviewPoint[];
+}
+
+export interface WebsiteWithStats extends WebsiteItem {
+  stats: StatsData;
+  visitorSeries?: number[];
+  pageviewSeries?: number[];
+}
+
+export function DashboardView({ defaultDate = '30day' }: { defaultDate?: string }) {
+  const { get, useQuery } = useApi();
+  const { formatMessage, labels } = useMessages();
+  const {
+    query: { date = '' },
+  } = useNavigation();
+  const { dateRange } = useDateRange();
+  const { timezone, localToUtc, canonicalizeTimezone } = useTimezone();
+
+  const { startAt, endAt, unit } = useMemo(() => {
+    const range = date ? dateRange : parseDateRange(defaultDate);
+    return {
+      startAt: +localToUtc(range.startDate),
+      endAt: +localToUtc(range.endDate),
+      unit: range.unit,
+    };
+  }, [date, dateRange, defaultDate, localToUtc]);
+
+  const tz = canonicalizeTimezone(timezone);
+
+  const {
+    data: websitesData,
+    isLoading: isLoadingWebsites,
+    error: websitesError,
+  } = useQuery({
+    queryKey: ['dashboard:websites'],
+    queryFn: () => get('/me/websites', { pageSize: 100 }),
+  });
+
+  const websites: WebsiteItem[] = websitesData?.data || [];
+
+  const { data: allStats, isLoading: isLoadingStats } = useQuery({
+    queryKey: ['dashboard:stats', { websiteIds: websites.map(w => w.id), startAt, endAt }],
+    queryFn: async () => {
+      const results = await Promise.all(
+        websites.map(async website => {
+          const [stats, pageviews] = await Promise.all([
+            get(`/websites/${website.id}/stats`, {
+              startAt,
+              endAt,
+              unit,
+              timezone: tz,
+            }),
+            get(`/websites/${website.id}/pageviews`, {
+              startAt,
+              endAt,
+              unit,
+              timezone: tz,
+            }) as Promise<PageviewsData>,
+          ]);
+          return {
+            ...website,
+            stats,
+            visitorSeries: pageviews?.sessions?.map((p: PageviewPoint) => p.y) || [],
+            pageviewSeries: pageviews?.pageviews?.map((p: PageviewPoint) => p.y) || [],
+          } as WebsiteWithStats;
+        }),
+      );
+      return results;
+    },
+    enabled: websites.length > 0,
+  });
+
+  const websitesWithStats: WebsiteWithStats[] = allStats || [];
+
+  const { aggregateVisitorSeries, aggregatePageviewSeries } = useMemo(() => {
+    if (!websitesWithStats.length)
+      return { aggregateVisitorSeries: [], aggregatePageviewSeries: [] };
+    const maxLen = Math.max(...websitesWithStats.map(w => w.visitorSeries?.length || 0));
+    if (!maxLen) return { aggregateVisitorSeries: [], aggregatePageviewSeries: [] };
+    const visitors: number[] = new Array(maxLen).fill(0);
+    const pageviews: number[] = new Array(maxLen).fill(0);
+    websitesWithStats.forEach(w => {
+      w.visitorSeries?.forEach((v, i) => {
+        visitors[i] += v;
+      });
+      w.pageviewSeries?.forEach((v, i) => {
+        pageviews[i] += v;
+      });
+    });
+    return { aggregateVisitorSeries: visitors, aggregatePageviewSeries: pageviews };
+  }, [websitesWithStats]);
+
+  if (isLoadingWebsites) {
+    return <Loading placement="absolute" />;
+  }
+
+  if (websitesError) {
+    return <Text>Failed to load websites.</Text>;
+  }
+
+  if (websites.length === 0) {
+    return (
+      <Panel>
+        <Text color="muted">No websites found. Add a website to get started.</Text>
+      </Panel>
+    );
+  }
+
+  const isLoading = isLoadingStats;
+
+  const totals = websitesWithStats.reduce(
+    (acc, { stats }) => ({
+      visitors: acc.visitors + (stats?.visitors || 0),
+      pageviews: acc.pageviews + (stats?.pageviews || 0),
+      visits: acc.visits + (stats?.visits || 0),
+      bounces: acc.bounces + (stats?.bounces || 0),
+      totaltime: acc.totaltime + (stats?.totaltime || 0),
+    }),
+    { visitors: 0, pageviews: 0, visits: 0, bounces: 0, totaltime: 0 },
+  );
+
+  const bounceRate = totals.visits > 0 ? Math.round((totals.bounces / totals.visits) * 100) : 0;
+  const avgDuration = totals.visits > 0 ? Math.round(totals.totaltime / totals.visits) : 0;
+
+  return (
+    <Column gap="6">
+      <Grid columns={{ xs: '1fr 1fr', md: '1fr 1fr 1fr 1fr' }} gap="4">
+        <StatCard
+          label={formatMessage(labels.uniqueVisitors)}
+          value={totals.visitors}
+          isLoading={isLoading}
+          sparkData={aggregateVisitorSeries}
+        />
+        <StatCard
+          label={formatMessage(labels.pageViews)}
+          value={totals.pageviews}
+          isLoading={isLoading}
+          sparkData={aggregatePageviewSeries}
+        />
+        <StatCard
+          label={formatMessage(labels.bounceRate)}
+          value={`${bounceRate}%`}
+          isLoading={isLoading}
+        />
+        <StatCard
+          label={formatMessage(labels.visitDuration)}
+          value={formatDuration(avgDuration)}
+          isLoading={isLoading}
+        />
+      </Grid>
+      <Panel title={formatMessage(labels.websites)}>
+        <WebsiteStatsTable websites={websitesWithStats} isLoading={isLoading} />
+      </Panel>
+    </Column>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}

--- a/src/app/(main)/dashboard/SparkLine.tsx
+++ b/src/app/(main)/dashboard/SparkLine.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { Box } from '@umami/react-zen';
+import ChartJS from 'chart.js/auto';
+import { useEffect, useRef } from 'react';
+
+export interface SparkLineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  fillColor?: string;
+}
+
+export function SparkLine({
+  data,
+  width = 100,
+  height = 32,
+  color = 'rgba(80, 130, 255, 0.9)',
+  fillColor = 'rgba(80, 130, 255, 0.15)',
+}: SparkLineProps) {
+  const canvas = useRef<HTMLCanvasElement>(null);
+  const chart = useRef<ChartJS | null>(null);
+
+  useEffect(() => {
+    if (!canvas.current || !data?.length) return;
+
+    chart.current = new ChartJS(canvas.current, {
+      type: 'line',
+      data: {
+        labels: data.map((_, i) => i),
+        datasets: [
+          {
+            data,
+            borderColor: color,
+            backgroundColor: fillColor,
+            borderWidth: 1.5,
+            fill: true,
+            tension: 0.4,
+            pointRadius: 0,
+            pointHitRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: false,
+        maintainAspectRatio: false,
+        animation: { duration: 0 },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false },
+        },
+        scales: {
+          x: { display: false },
+          y: { display: false, beginAtZero: true },
+        },
+        elements: {
+          line: { borderJoinStyle: 'round' },
+        },
+      },
+    });
+
+    return () => {
+      chart.current?.destroy();
+    };
+  }, [data, color, fillColor]);
+
+  if (!data?.length) return null;
+
+  return (
+    <Box style={{ width, height, flexShrink: 0 }}>
+      <canvas ref={canvas} width={width} height={height} />
+    </Box>
+  );
+}

--- a/src/app/(main)/dashboard/StatCard.tsx
+++ b/src/app/(main)/dashboard/StatCard.tsx
@@ -24,7 +24,7 @@ export function StatCard({
           <Loading />
         ) : (
           <>
-            <Heading size="4">{value.toLocaleString()}</Heading>
+            <Heading size="4">{typeof value === 'number' ? value.toLocaleString() : value}</Heading>
             {sparkData && sparkData.length > 1 && <SparkLine data={sparkData} />}
           </>
         )}

--- a/src/app/(main)/dashboard/StatCard.tsx
+++ b/src/app/(main)/dashboard/StatCard.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { Column, Heading, Loading, Text } from '@umami/react-zen';
+import { Panel } from '@/components/common/Panel';
+import { SparkLine } from './SparkLine';
+
+export function StatCard({
+  label,
+  value,
+  isLoading,
+  sparkData,
+}: {
+  label: string;
+  value: string | number;
+  isLoading?: boolean;
+  sparkData?: number[];
+}) {
+  return (
+    <Panel>
+      <Column gap="2" alignItems="center" paddingY="2">
+        <Text size="2" color="muted">
+          {label}
+        </Text>
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <>
+            <Heading size="4">{value.toLocaleString()}</Heading>
+            {sparkData && sparkData.length > 1 && <SparkLine data={sparkData} />}
+          </>
+        )}
+      </Column>
+    </Panel>
+  );
+}

--- a/src/app/(main)/dashboard/WebsiteStatsTable.tsx
+++ b/src/app/(main)/dashboard/WebsiteStatsTable.tsx
@@ -1,0 +1,107 @@
+'use client';
+import { Column, Icon, Loading, Row, Text } from '@umami/react-zen';
+import Link from 'next/link';
+import { Favicon } from '@/components/common/Favicon';
+import { useMessages, useNavigation } from '@/components/hooks';
+import { SparkLine } from './SparkLine';
+import type { WebsiteWithStats } from './DashboardView';
+
+export function WebsiteStatsTable({
+  websites,
+  isLoading,
+}: {
+  websites: WebsiteWithStats[];
+  isLoading?: boolean;
+}) {
+  const { formatMessage, labels } = useMessages();
+  const { renderUrl } = useNavigation();
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!websites.length) {
+    return <Text color="muted">No data available.</Text>;
+  }
+
+  return (
+    <Column gap="0">
+      <Row
+        paddingY="3"
+        paddingX="4"
+        gap="4"
+        style={{
+          borderBottom: '1px solid var(--base300)',
+          fontWeight: 600,
+          fontSize: '0.85rem',
+        }}
+      >
+        <Text style={{ flex: 2 }}>{formatMessage(labels.name)}</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{formatMessage(labels.visitors)}</Text>
+        <Text style={{ width: 100, textAlign: 'center' }}>&nbsp;</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{formatMessage(labels.views)}</Text>
+        <Text style={{ width: 100, textAlign: 'center' }}>&nbsp;</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{formatMessage(labels.bounceRate)}</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{formatMessage(labels.visitDuration)}</Text>
+      </Row>
+      {websites.map(({ id, name, domain, stats, visitorSeries, pageviewSeries }) => {
+        const bounceRate =
+          stats?.visits > 0 ? Math.round((stats.bounces / stats.visits) * 100) : 0;
+        const avgDuration = stats?.visits > 0 ? Math.round(stats.totaltime / stats.visits) : 0;
+
+        return (
+          <Row
+            key={id}
+            paddingY="3"
+            paddingX="4"
+            gap="4"
+            alignItems="center"
+            style={{
+              borderBottom: '1px solid var(--base200)',
+              fontSize: '0.875rem',
+            }}
+          >
+            <Link href={renderUrl(`/websites/${id}`)} style={{ flex: 2, textDecoration: 'none', color: 'inherit' }}>
+              <Row alignItems="center" gap="3">
+                <Icon size="md" color="muted">
+                  <Favicon domain={domain} />
+                </Icon>
+                <Column>
+                  <Text>{name}</Text>
+                  <Text size="1" color="muted">
+                    {domain}
+                  </Text>
+                </Column>
+              </Row>
+            </Link>
+            <Text style={{ flex: 1, textAlign: 'right' }}>
+              {stats?.visitors?.toLocaleString() || '0'}
+            </Text>
+            <Row style={{ width: 100 }} justifyContent="center">
+              {visitorSeries && visitorSeries.length > 1 && (
+                <SparkLine data={visitorSeries} width={80} height={24} />
+              )}
+            </Row>
+            <Text style={{ flex: 1, textAlign: 'right' }}>
+              {stats?.pageviews?.toLocaleString() || '0'}
+            </Text>
+            <Row style={{ width: 100 }} justifyContent="center">
+              {pageviewSeries && pageviewSeries.length > 1 && (
+                <SparkLine data={pageviewSeries} width={80} height={24} />
+              )}
+            </Row>
+            <Text style={{ flex: 1, textAlign: 'right' }}>{bounceRate}%</Text>
+            <Text style={{ flex: 1, textAlign: 'right' }}>{formatDuration(avgDuration)}</Text>
+          </Row>
+        );
+      })}
+    </Column>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}


### PR DESCRIPTION
## Summary

Populates the existing empty `/dashboard` route with an aggregated multi-website dashboard, restoring the overview functionality from v2 that many users have been requesting.

- Aggregate stat cards (unique visitors, page views, bounce rate, visit duration) with sparkline trend charts
- Per-website stats table with favicon, visitor + pageview sparklines, bounce rate, and visit duration
- Clickable website names that drill down to individual website details
- Date range filter defaulting to last 30 days
- Dashboard link added to side and mobile navigation

<img width="1711" height="670" alt="image" src="https://github.com/user-attachments/assets/0a251080-e97b-41eb-ae72-682725837c5e" />


Closes #3362
Closes #3951

## Test plan

- [ ] Log in and navigate to `/dashboard` from sidebar
- [ ] Verify aggregate stat cards show correct totals across all websites
- [ ] Verify sparkline charts render for visitors and page views (both aggregate and per-website)
- [ ] Change date range filter and confirm stats update
- [ ] Click a website name in the table and confirm it navigates to `/websites/{id}`
- [ ] Test on mobile viewport — dashboard link appears in mobile nav
- [ ] Verify empty state when no websites exist