### PR TITLE
fix: redirect logged-in users from login page to dashboard

### DIFF
--- a/src/app/login/LoginPage.tsx
+++ b/src/app/login/LoginPage.tsx
@@ -1,8 +1,24 @@
 'use client';
-import { Column } from '@umami/react-zen';
+import { Column, Loading } from '@umami/react-zen';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { useLoginQuery } from '@/components/hooks';
 import { LoginForm } from './LoginForm';
 
 export function LoginPage() {
+  const { user, isLoading } = useLoginQuery();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (user) {
+      router.replace('/');
+    }
+  }, [user, router]);
+
+  if (isLoading || user) {
+    return <Loading placement="absolute" />;
+  }
+
   return (
     <Column alignItems="center" height="100vh" backgroundColor="2" paddingTop="12">
       <LoginForm />


### PR DESCRIPTION
## Summary

When a user with an active session navigates to `/login` (e.g., by clicking "Get Started" on the homepage), they currently see the login form even though they're already authenticated. This is confusing since their session is valid.

## Changes

**`src/app/login/LoginPage.tsx`**: Added auth check using the existing `useLoginQuery` hook. If the user is already logged in, they are redirected to `/` (which routes to their dashboard). While loading/redirecting, a loading indicator is shown instead of the login form.

## How it works

1. `useLoginQuery` calls `POST /auth/verify` — this validates the token server-side
2. If valid → `router.replace('/')` redirects to dashboard
3. If invalid/expired → login form renders as before (no behavior change)

Fixes #4094