### PR TITLE
Feat/sortable sessions table headers (Visits, Views, and Last Seen Columns)

### DIFF
--- a/cypress/e2e/api-sessions-sort.cy.ts
+++ b/cypress/e2e/api-sessions-sort.cy.ts
@@ -1,0 +1,210 @@
+describe('Sessions sorting API tests', () => {
+  Cypress.session.clearAllSavedSessions();
+
+  let websiteId;
+
+  before(() => {
+    cy.login(Cypress.env('umami_user'), Cypress.env('umami_password'));
+    cy.fixture('websites').then(data => {
+      cy.request({
+        method: 'POST',
+        url: '/api/websites',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: Cypress.env('authorization'),
+        },
+        body: data.websiteCreate,
+      }).then(response => {
+        websiteId = response.body.id;
+        expect(response.status).to.eq(200);
+      });
+    });
+  });
+
+  it('Returns sessions with default sort (no sort params).', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+      expect(response.body).to.have.property('count');
+      expect(response.body).to.have.property('page');
+      expect(response.body).to.have.property('pageSize');
+    });
+  });
+
+  it('Accepts orderBy=visits with sortDescending=true.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'visits',
+        sortDescending: 'true',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+      expect(response.body).to.have.property('orderBy');
+    });
+  });
+
+  it('Accepts orderBy=views with sortDescending=false.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'views',
+        sortDescending: 'false',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+    });
+  });
+
+  it('Accepts orderBy=createdAt.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'createdAt',
+        sortDescending: 'true',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+    });
+  });
+
+  it('Accepts orderBy=firstAt.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'firstAt',
+        sortDescending: 'false',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+    });
+  });
+
+  it('Falls back gracefully with invalid orderBy value.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'invalid_column',
+        sortDescending: 'true',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+    });
+  });
+
+  it('Works with sorting combined with search.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'views',
+        sortDescending: 'true',
+        search: 'Chrome',
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+    });
+  });
+
+  it('Works with sorting combined with pagination.', () => {
+    const now = Date.now();
+    const oneDayAgo = now - 86400000;
+
+    cy.request({
+      method: 'GET',
+      url: `/api/websites/${websiteId}/sessions`,
+      headers: {
+        Authorization: Cypress.env('authorization'),
+      },
+      qs: {
+        startAt: oneDayAgo,
+        endAt: now,
+        orderBy: 'visits',
+        sortDescending: 'true',
+        page: 1,
+        pageSize: 5,
+      },
+    }).then(response => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.have.property('data');
+      expect(response.body).to.have.property('page', 1);
+      expect(response.body).to.have.property('pageSize', 5);
+    });
+  });
+
+  after(() => {
+    cy.deleteWebsite(websiteId);
+  });
+});

--- a/cypress/e2e/sessions-sort.cy.ts
+++ b/cypress/e2e/sessions-sort.cy.ts
@@ -1,0 +1,74 @@
+describe('Sessions sorting UI tests', () => {
+  Cypress.session.clearAllSavedSessions();
+
+  let websiteId;
+
+  before(() => {
+    cy.login(Cypress.env('umami_user'), Cypress.env('umami_password'));
+    cy.request({
+      method: 'POST',
+      url: '/api/websites',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: Cypress.env('authorization'),
+      },
+      body: { name: 'Sort Test Site', domain: 'sorttest.com' },
+    }).then(response => {
+      websiteId = response.body.id;
+      expect(response.status).to.eq(200);
+    });
+  });
+
+  beforeEach(() => {
+    cy.login(Cypress.env('umami_user'), Cypress.env('umami_password'));
+    cy.visit(`/websites/${websiteId}/sessions`);
+  });
+
+  it('Renders sortable column headers for visits, views, and last seen.', () => {
+    cy.getDataTest('sort-visits').should('exist').and('be.visible');
+    cy.getDataTest('sort-views').should('exist').and('be.visible');
+    cy.getDataTest('sort-createdAt').should('exist').and('be.visible');
+  });
+
+  it('Clicking visits header adds orderBy and sortDescending to URL.', () => {
+    cy.getDataTest('sort-visits').click();
+    cy.url().should('include', 'orderBy=visits');
+    cy.url().should('include', 'sortDescending=true');
+  });
+
+  it('Clicking visits header twice toggles to ascending sort.', () => {
+    cy.getDataTest('sort-visits').click();
+    cy.url().should('include', 'sortDescending=true');
+
+    cy.getDataTest('sort-visits').click();
+    cy.url().should('include', 'orderBy=visits');
+    cy.url().should('include', 'sortDescending=false');
+  });
+
+  it('Clicking visits header three times clears sort params.', () => {
+    cy.getDataTest('sort-visits').click();
+    cy.getDataTest('sort-visits').click();
+    cy.getDataTest('sort-visits').click();
+
+    cy.url().should('not.include', 'orderBy');
+    cy.url().should('not.include', 'sortDescending');
+  });
+
+  it('Clicking a different column switches sort target.', () => {
+    cy.getDataTest('sort-visits').click();
+    cy.url().should('include', 'orderBy=visits');
+
+    cy.getDataTest('sort-views').click();
+    cy.url().should('include', 'orderBy=views');
+    cy.url().should('include', 'sortDescending=true');
+  });
+
+  it('Resets to page 1 when sort changes.', () => {
+    cy.getDataTest('sort-visits').click();
+    cy.url().should('include', 'page=1');
+  });
+
+  after(() => {
+    cy.deleteWebsite(websiteId);
+  });
+});

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
@@ -1,10 +1,10 @@
-import { DataColumn, DataTable, type DataTableProps } from '@umami/react-zen';
-import Link from 'next/link';
-import { Avatar } from '@/components/common/Avatar';
-import { DateDistance } from '@/components/common/DateDistance';
-import { SortableLabel } from '@/components/common/SortableLabel';
-import { TypeIcon } from '@/components/common/TypeIcon';
-import { useFormat, useMessages, useNavigation } from '@/components/hooks';
+import { DataColumn, DataTable, type DataTableProps } from "@umami/react-zen";
+import Link from "next/link";
+import { Avatar } from "@/components/common/Avatar";
+import { DateDistance } from "@/components/common/DateDistance";
+import { SortableLabel } from "@/components/common/SortableLabel";
+import { TypeIcon } from "@/components/common/TypeIcon";
+import { useFormat, useMessages, useNavigation } from "@/components/hooks";
 
 export function SessionsTable(props: DataTableProps) {
   const { formatMessage, labels } = useMessages();
@@ -22,18 +22,22 @@ export function SessionsTable(props: DataTableProps) {
       </DataColumn>
       <DataColumn
         id="visits"
-        label={<SortableLabel column="visits" label={formatMessage(labels.visits)} />}
+        label={
+          <SortableLabel column="visits" label={formatMessage(labels.visits)} />
+        }
         width="100px"
       />
       <DataColumn
         id="views"
-        label={<SortableLabel column="views" label={formatMessage(labels.views)} />}
+        label={
+          <SortableLabel column="views" label={formatMessage(labels.views)} />
+        }
         width="100px"
       />
       <DataColumn id="country" label={formatMessage(labels.country)}>
         {(row: any) => (
           <TypeIcon type="country" value={row.country}>
-            {formatValue(row.country, 'country')}
+            {formatValue(row.country, "country")}
           </TypeIcon>
         )}
       </DataColumn>
@@ -41,29 +45,34 @@ export function SessionsTable(props: DataTableProps) {
       <DataColumn id="browser" label={formatMessage(labels.browser)}>
         {(row: any) => (
           <TypeIcon type="browser" value={row.browser}>
-            {formatValue(row.browser, 'browser')}
+            {formatValue(row.browser, "browser")}
           </TypeIcon>
         )}
       </DataColumn>
       <DataColumn id="os" label={formatMessage(labels.os)}>
         {(row: any) => (
           <TypeIcon type="os" value={row.os}>
-            {formatValue(row.os, 'os')}
+            {formatValue(row.os, "os")}
           </TypeIcon>
         )}
       </DataColumn>
       <DataColumn id="device" label={formatMessage(labels.device)}>
         {(row: any) => (
           <TypeIcon type="device" value={row.device}>
-            {formatValue(row.device, 'device')}
+            {formatValue(row.device, "device")}
           </TypeIcon>
         )}
       </DataColumn>
       <DataColumn
         id="lastAt"
-        label={<SortableLabel column="createdAt" label={formatMessage(labels.lastSeen)} />}
+        label={
+          <SortableLabel
+            column="lastAt"
+            label={formatMessage(labels.lastSeen)}
+          />
+        }
       >
-        {(row: any) => <DateDistance date={new Date(row.createdAt)} />}
+        {(row: any) => <DateDistance date={new Date(row.lastAt)} />}
       </DataColumn>
     </DataTable>
   );

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionsTable.tsx
@@ -2,6 +2,7 @@ import { DataColumn, DataTable, type DataTableProps } from '@umami/react-zen';
 import Link from 'next/link';
 import { Avatar } from '@/components/common/Avatar';
 import { DateDistance } from '@/components/common/DateDistance';
+import { SortableLabel } from '@/components/common/SortableLabel';
 import { TypeIcon } from '@/components/common/TypeIcon';
 import { useFormat, useMessages, useNavigation } from '@/components/hooks';
 
@@ -19,8 +20,16 @@ export function SessionsTable(props: DataTableProps) {
           </Link>
         )}
       </DataColumn>
-      <DataColumn id="visits" label={formatMessage(labels.visits)} width="80px" />
-      <DataColumn id="views" label={formatMessage(labels.views)} width="80px" />
+      <DataColumn
+        id="visits"
+        label={<SortableLabel column="visits" label={formatMessage(labels.visits)} />}
+        width="100px"
+      />
+      <DataColumn
+        id="views"
+        label={<SortableLabel column="views" label={formatMessage(labels.views)} />}
+        width="100px"
+      />
       <DataColumn id="country" label={formatMessage(labels.country)}>
         {(row: any) => (
           <TypeIcon type="country" value={row.country}>
@@ -50,7 +59,10 @@ export function SessionsTable(props: DataTableProps) {
           </TypeIcon>
         )}
       </DataColumn>
-      <DataColumn id="lastAt" label={formatMessage(labels.lastSeen)}>
+      <DataColumn
+        id="lastAt"
+        label={<SortableLabel column="createdAt" label={formatMessage(labels.lastSeen)} />}
+      >
         {(row: any) => <DateDistance date={new Date(row.createdAt)} />}
       </DataColumn>
     </DataTable>

--- a/src/app/api/websites/[websiteId]/sessions/route.ts
+++ b/src/app/api/websites/[websiteId]/sessions/route.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { getQueryFilters, parseRequest } from '@/lib/request';
 import { json, unauthorized } from '@/lib/response';
-import { dateRangeParams, filterParams, pagingParams, searchParams } from '@/lib/schema';
+import { dateRangeParams, filterParams, pagingParams, searchParams, sortingParams } from '@/lib/schema';
 import { canViewWebsite } from '@/permissions';
 import { getWebsiteSessions } from '@/queries/sql';
 
@@ -14,6 +14,7 @@ export async function GET(
     ...filterParams,
     ...pagingParams,
     ...searchParams,
+    ...sortingParams,
   });
 
   const { auth, query, error } = await parseRequest(request, schema);

--- a/src/components/common/SortableLabel.tsx
+++ b/src/components/common/SortableLabel.tsx
@@ -1,0 +1,52 @@
+import { Icon, Row } from '@umami/react-zen';
+import { type ReactNode } from 'react';
+import { ArrowDown, ArrowUp, ArrowUpDown } from '@/components/icons';
+import { useNavigation } from '@/components/hooks';
+
+export interface SortableLabelProps {
+  column: string;
+  label: ReactNode;
+}
+
+export function SortableLabel({ column, label }: SortableLabelProps) {
+  const { router, updateParams, query } = useNavigation();
+  const currentOrderBy = query.orderBy;
+  const currentDesc = query.sortDescending === 'true';
+  const isActive = currentOrderBy === column;
+
+  const handleClick = () => {
+    let orderBy: string | undefined;
+    let sortDescending: string | undefined;
+
+    if (!isActive) {
+      // First click: sort descending (highest first)
+      orderBy = column;
+      sortDescending = 'true';
+    } else if (currentDesc) {
+      // Second click: sort ascending
+      orderBy = column;
+      sortDescending = 'false';
+    } else {
+      // Third click: clear sort (back to default)
+      orderBy = undefined;
+      sortDescending = undefined;
+    }
+
+    router.push(updateParams({ orderBy, sortDescending, page: 1 }));
+  };
+
+  return (
+    <Row
+      alignItems="center"
+      gap="1"
+      onClick={handleClick}
+      data-test={`sort-${column}`}
+      style={{ cursor: 'pointer', userSelect: 'none' }}
+    >
+      {label}
+      <Icon size="sm">
+        {isActive ? currentDesc ? <ArrowDown /> : <ArrowUp /> : <ArrowUpDown />}
+      </Icon>
+    </Row>
+  );
+}

--- a/src/components/hooks/queries/useWebsiteSessionsQuery.ts
+++ b/src/components/hooks/queries/useWebsiteSessionsQuery.ts
@@ -1,8 +1,9 @@
-import { useApi } from '../useApi';
-import { useDateParameters } from '../useDateParameters';
-import { useFilterParameters } from '../useFilterParameters';
-import { useModified } from '../useModified';
-import { usePagedQuery } from '../usePagedQuery';
+import { useApi } from "../useApi";
+import { useDateParameters } from "../useDateParameters";
+import { useFilterParameters } from "../useFilterParameters";
+import { useModified } from "../useModified";
+import { useNavigation } from "../useNavigation";
+import { usePagedQuery } from "../usePagedQuery";
 
 export function useWebsiteSessionsQuery(
   websiteId: string,
@@ -12,13 +13,27 @@ export function useWebsiteSessionsQuery(
   const { modified } = useModified(`sessions`);
   const { startAt, endAt, unit, timezone } = useDateParameters();
   const filters = useFilterParameters();
+  const {
+    query: { orderBy, sortDescending },
+  } = useNavigation();
 
   return usePagedQuery({
     queryKey: [
-      'sessions',
-      { websiteId, modified, startAt, endAt, unit, timezone, ...params, ...filters },
+      "sessions",
+      {
+        websiteId,
+        modified,
+        startAt,
+        endAt,
+        unit,
+        timezone,
+        orderBy,
+        sortDescending,
+        ...params,
+        ...filters,
+      },
     ],
-    queryFn: pageParams => {
+    queryFn: (pageParams) => {
       return get(`/websites/${websiteId}/sessions`, {
         startAt,
         endAt,
@@ -27,6 +42,8 @@ export function useWebsiteSessionsQuery(
         ...filters,
         ...pageParams,
         ...params,
+        orderBy,
+        sortDescending,
         pageSize: 20,
       });
     },

--- a/src/components/hooks/usePagedQuery.ts
+++ b/src/components/hooks/usePagedQuery.ts
@@ -1,27 +1,32 @@
-import type { UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
-import type { PageResult } from '@/lib/types';
-import { useApi } from './useApi';
-import { useNavigation } from './useNavigation';
+import type { UseQueryOptions, UseQueryResult } from "@tanstack/react-query";
+import type { PageResult } from "@/lib/types";
+import { useApi } from "./useApi";
+import { useNavigation } from "./useNavigation";
 
 export function usePagedQuery<TData = any, TError = Error>({
   queryKey,
   queryFn,
   ...options
 }: Omit<
-  UseQueryOptions<PageResult<TData>, TError, PageResult<TData>, readonly unknown[]>,
-  'queryFn' | 'queryKey'
+  UseQueryOptions<
+    PageResult<TData>,
+    TError,
+    PageResult<TData>,
+    readonly unknown[]
+  >,
+  "queryFn" | "queryKey"
 > & {
   queryKey: readonly unknown[];
   queryFn: (params?: object) => Promise<PageResult<TData>> | PageResult<TData>;
 }): UseQueryResult<PageResult<TData>, TError> {
   const {
-    query: { page, search, orderBy, sortDescending },
+    query: { page, search },
   } = useNavigation();
   const { useQuery } = useApi();
 
   return useQuery<PageResult<TData>, TError>({
-    queryKey: [...queryKey, page, search, orderBy, sortDescending] as const,
-    queryFn: () => queryFn({ page, search, orderBy, sortDescending }),
+    queryKey: [...queryKey, page, search] as const,
+    queryFn: () => queryFn({ page, search }),
     ...options,
   });
 }

--- a/src/components/hooks/usePagedQuery.ts
+++ b/src/components/hooks/usePagedQuery.ts
@@ -15,13 +15,13 @@ export function usePagedQuery<TData = any, TError = Error>({
   queryFn: (params?: object) => Promise<PageResult<TData>> | PageResult<TData>;
 }): UseQueryResult<PageResult<TData>, TError> {
   const {
-    query: { page, search },
+    query: { page, search, orderBy, sortDescending },
   } = useNavigation();
   const { useQuery } = useApi();
 
   return useQuery<PageResult<TData>, TError>({
-    queryKey: [...queryKey, page, search] as const,
-    queryFn: () => queryFn({ page, search }),
+    queryKey: [...queryKey, page, search, orderBy, sortDescending] as const,
+    queryFn: () => queryFn({ page, search, orderBy, sortDescending }),
     ...options,
   });
 }

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,17 +1,19 @@
-import { z } from 'zod';
-import { isValidTimezone, normalizeTimezone } from '@/lib/date';
-import { UNIT_TYPES } from './constants';
+import { z } from "zod";
+import { isValidTimezone, normalizeTimezone } from "@/lib/date";
+import { UNIT_TYPES } from "./constants";
 
 export const timezoneParam = z
   .string()
   .refine((value: string) => isValidTimezone(value), {
-    message: 'Invalid timezone',
+    message: "Invalid timezone",
   })
   .transform((value: string) => normalizeTimezone(value));
 
-export const unitParam = z.string().refine(value => UNIT_TYPES.includes(value), {
-  message: 'Invalid unit',
-});
+export const unitParam = z
+  .string()
+  .refine((value) => UNIT_TYPES.includes(value), {
+    message: "Invalid unit",
+  });
 
 export const dateRangeParams = {
   startAt: z.coerce.number().optional(),
@@ -53,74 +55,78 @@ export const pagingParams = {
 };
 
 export const sortingParams = {
-  orderBy: z.string().optional(),
+  orderBy: z.enum(["visits", "views", "createdAt", "firstAt"]).optional(),
   sortDescending: z
-    .enum(['true', 'false'])
-    .transform(v => v === 'true')
+    .enum(["true", "false"])
+    .transform((v) => v === "true")
     .optional(),
 };
 
-export const userRoleParam = z.enum(['admin', 'user', 'view-only']);
+export const userRoleParam = z.enum(["admin", "user", "view-only"]);
 
-export const teamRoleParam = z.enum(['team-member', 'team-view-only', 'team-manager']);
+export const teamRoleParam = z.enum([
+  "team-member",
+  "team-view-only",
+  "team-manager",
+]);
 
 export const anyObjectParam = z.record(z.string(), z.any());
 
 export const urlOrPathParam = z.string().refine(
-  value => {
+  (value) => {
     try {
-      new URL(value, 'https://localhost');
+      new URL(value, "https://localhost");
       return true;
     } catch {
       return false;
     }
   },
   {
-    message: 'Invalid URL.',
+    message: "Invalid URL.",
   },
 );
 
 export const fieldsParam = z.enum([
-  'path',
-  'referrer',
-  'title',
-  'query',
-  'os',
-  'browser',
-  'device',
-  'country',
-  'region',
-  'city',
-  'tag',
-  'hostname',
-  'language',
-  'event',
+  "path",
+  "referrer",
+  "title",
+  "query",
+  "os",
+  "browser",
+  "device",
+  "country",
+  "region",
+  "city",
+  "tag",
+  "hostname",
+  "language",
+  "event",
 ]);
 
 export const reportTypeParam = z.enum([
-  'attribution',
-  'breakdown',
-  'funnel',
-  'goal',
-  'journey',
-  'retention',
-  'revenue',
-  'utm',
+  "attribution",
+  "breakdown",
+  "funnel",
+  "goal",
+  "journey",
+  "retention",
+  "revenue",
+  "utm",
 ]);
 
 export const goalReportSchema = z.object({
-  type: z.literal('goal'),
+  type: z.literal("goal"),
   parameters: z
     .object({
       startDate: z.coerce.date(),
       endDate: z.coerce.date(),
       type: z.string(),
       value: z.string(),
-      operator: z.enum(['count', 'sum', 'average']).optional(),
+      operator: z.enum(["count", "sum", "average"]).optional(),
       property: z.string().optional(),
     })
-    .refine(data => {
-      if (data.type === 'event' && data.property) {
+    .refine((data) => {
+      if (data.type === "event" && data.property) {
         return data.operator && data.property;
       }
       return true;
@@ -128,7 +134,7 @@ export const goalReportSchema = z.object({
 });
 
 export const funnelReportSchema = z.object({
-  type: z.literal('funnel'),
+  type: z.literal("funnel"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -136,7 +142,7 @@ export const funnelReportSchema = z.object({
     steps: z
       .array(
         z.object({
-          type: z.enum(['path', 'event']),
+          type: z.enum(["path", "event"]),
           value: z.string(),
         }),
       )
@@ -146,7 +152,7 @@ export const funnelReportSchema = z.object({
 });
 
 export const journeyReportSchema = z.object({
-  type: z.literal('journey'),
+  type: z.literal("journey"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -157,7 +163,7 @@ export const journeyReportSchema = z.object({
 });
 
 export const retentionReportSchema = z.object({
-  type: z.literal('retention'),
+  type: z.literal("retention"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -166,7 +172,7 @@ export const retentionReportSchema = z.object({
 });
 
 export const utmReportSchema = z.object({
-  type: z.literal('utm'),
+  type: z.literal("utm"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -174,7 +180,7 @@ export const utmReportSchema = z.object({
 });
 
 export const revenueReportSchema = z.object({
-  type: z.literal('revenue'),
+  type: z.literal("revenue"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -184,19 +190,19 @@ export const revenueReportSchema = z.object({
 });
 
 export const attributionReportSchema = z.object({
-  type: z.literal('attribution'),
+  type: z.literal("attribution"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
-    model: z.enum(['first-click', 'last-click']),
-    type: z.enum(['path', 'event']),
+    model: z.enum(["first-click", "last-click"]),
+    type: z.enum(["path", "event"]),
     step: z.string(),
     currency: z.string().optional(),
   }),
 });
 
 export const breakdownReportSchema = z.object({
-  type: z.literal('breakdown'),
+  type: z.literal("breakdown"),
   parameters: z.object({
     startDate: z.coerce.date(),
     endDate: z.coerce.date(),
@@ -212,7 +218,7 @@ export const reportBaseSchema = z.object({
   parameters: anyObjectParam,
 });
 
-export const reportTypeSchema = z.discriminatedUnion('type', [
+export const reportTypeSchema = z.discriminatedUnion("type", [
   goalReportSchema,
   funnelReportSchema,
   journeyReportSchema,
@@ -233,4 +239,4 @@ export const reportResultSchema = z.intersection(
   reportTypeSchema,
 );
 
-export const segmentTypeParam = z.enum(['segment', 'cohort']);
+export const segmentTypeParam = z.enum(["segment", "cohort"]);

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -55,7 +55,7 @@ export const pagingParams = {
 };
 
 export const sortingParams = {
-  orderBy: z.enum(["visits", "views", "createdAt", "firstAt"]).optional(),
+  orderBy: z.enum(["visits", "views", "lastAt", "firstAt"]).optional(),
   sortDescending: z
     .enum(["true", "false"])
     .transform((v) => v === "true")

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -54,6 +54,10 @@ export const pagingParams = {
 
 export const sortingParams = {
   orderBy: z.string().optional(),
+  sortDescending: z
+    .enum(['true', 'false'])
+    .transform(v => v === 'true')
+    .optional(),
 };
 
 export const userRoleParam = z.enum(['admin', 'user', 'view-only']);

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -6,7 +6,7 @@ import type { QueryFilters } from "@/lib/types";
 
 const FUNCTION_NAME = "getWebsiteSessions";
 
-const SORTABLE_COLUMNS = ["visits", "views", "createdAt", "firstAt"] as const;
+const SORTABLE_COLUMNS = ["visits", "views", "lastAt", "firstAt"] as const;
 
 export async function getWebsiteSessions(
   ...args: [websiteId: string, filters: QueryFilters]
@@ -32,7 +32,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
 
   const sortedFilters = {
     ...filters,
-    orderBy: SORT_COLUMNS[filters.orderBy as string] || '"createdAt"',
+    orderBy: SORT_COLUMNS[filters.orderBy as string] || '"lastAt"',
     sortDescending: filters.orderBy ? filters.sortDescending : true,
   };
 
@@ -61,8 +61,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
       min(website_event.created_at) as "firstAt",
       max(website_event.created_at) as "lastAt",
       count(distinct website_event.visit_id) as "visits",
-      sum(case when website_event.event_type = 1 then 1 else 0 end) as "views",
-      max(website_event.created_at) as "createdAt"
+      sum(case when website_event.event_type = 1 then 1 else 0 end) as "views"
     from website_event 
     ${cohortQuery}
     join session on session.session_id = website_event.session_id
@@ -101,7 +100,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
 
   const sortedFilters = {
     ...filters,
-    orderBy: SORT_COLUMNS[filters.orderBy as string] || "createdAt",
+    orderBy: SORT_COLUMNS[filters.orderBy as string] || "lastAt",
     sortDescending: filters.orderBy ? filters.sortDescending : true,
   };
 
@@ -132,8 +131,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       ${getDateStringSQL("min(created_at)")} as firstAt,
       ${getDateStringSQL("max(created_at)")} as lastAt,
       uniq(visit_id) as visits,
-      sumIf(1, event_type = 1) as views,
-      lastAt as createdAt
+      sumIf(1, event_type = 1) as views
     from website_event
     ${cohortQuery}
     where website_id = {websiteId:UUID}
@@ -159,8 +157,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       ${getDateStringSQL("min(min_time)")} as firstAt,
       ${getDateStringSQL("max(max_time)")} as lastAt,
       uniq(visit_id) as visits,
-      sumIf(views, event_type = 1) as views,
-      lastAt as createdAt
+      sumIf(views, event_type = 1) as views
     from website_event_stats_hourly as website_event
     ${cohortQuery}
     where website_id = {websiteId:UUID}

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -1,14 +1,16 @@
-import clickhouse from '@/lib/clickhouse';
-import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
-import prisma from '@/lib/prisma';
-import type { QueryFilters } from '@/lib/types';
+import clickhouse from "@/lib/clickhouse";
+import { EVENT_COLUMNS } from "@/lib/constants";
+import { CLICKHOUSE, PRISMA, runQuery } from "@/lib/db";
+import prisma from "@/lib/prisma";
+import type { QueryFilters } from "@/lib/types";
 
-const FUNCTION_NAME = 'getWebsiteSessions';
+const FUNCTION_NAME = "getWebsiteSessions";
 
-const SORTABLE_COLUMNS = ['visits', 'views', 'createdAt', 'firstAt'] as const;
+const SORTABLE_COLUMNS = ["visits", "views", "createdAt", "firstAt"] as const;
 
-export async function getWebsiteSessions(...args: [websiteId: string, filters: QueryFilters]) {
+export async function getWebsiteSessions(
+  ...args: [websiteId: string, filters: QueryFilters]
+) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
@@ -24,7 +26,9 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
     search: search ? `%${search}%` : undefined,
   });
 
-  const SORT_COLUMNS = Object.fromEntries(SORTABLE_COLUMNS.map(c => [c, `"${c}"`]));
+  const SORT_COLUMNS = Object.fromEntries(
+    SORTABLE_COLUMNS.map((c) => [c, `"${c}"`]),
+  );
 
   const sortedFilters = {
     ...filters,
@@ -38,7 +42,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
            or browser ilike {{search}}
            or os ilike {{search}}
            or device ilike {{search}})`
-    : '';
+    : "";
 
   return pagedRawQuery(
     `
@@ -93,11 +97,11 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     websiteId,
   });
 
-  const SORT_COLUMNS = Object.fromEntries(SORTABLE_COLUMNS.map(c => [c, c]));
+  const SORT_COLUMNS = Object.fromEntries(SORTABLE_COLUMNS.map((c) => [c, c]));
 
   const sortedFilters = {
     ...filters,
-    orderBy: SORT_COLUMNS[filters.orderBy as string] || 'createdAt',
+    orderBy: SORT_COLUMNS[filters.orderBy as string] || "createdAt",
     sortDescending: filters.orderBy ? filters.sortDescending : true,
   };
 
@@ -107,11 +111,11 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
            or (positionCaseInsensitive(browser, {search:String}) > 0)
            or (positionCaseInsensitive(os, {search:String}) > 0)
            or (positionCaseInsensitive(device, {search:String}) > 0))`
-    : '';
+    : "";
 
-  let sql = '';
+  let sql = "";
 
-  if (EVENT_COLUMNS.some(item => Object.keys(filters).includes(item))) {
+  if (EVENT_COLUMNS.some((item) => Object.keys(filters).includes(item))) {
     sql = `
     select
       session_id as id,
@@ -125,8 +129,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       country,
       region,
       city,
-      ${getDateStringSQL('min(created_at)')} as firstAt,
-      ${getDateStringSQL('max(created_at)')} as lastAt,
+      ${getDateStringSQL("min(created_at)")} as firstAt,
+      ${getDateStringSQL("max(created_at)")} as lastAt,
       uniq(visit_id) as visits,
       sumIf(1, event_type = 1) as views,
       lastAt as createdAt
@@ -152,8 +156,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       country,
       region,
       city,
-      ${getDateStringSQL('min(min_time)')} as firstAt,
-      ${getDateStringSQL('max(max_time)')} as lastAt,
+      ${getDateStringSQL("min(min_time)")} as firstAt,
+      ${getDateStringSQL("max(max_time)")} as lastAt,
       uniq(visit_id) as visits,
       sumIf(views, event_type = 1) as views,
       lastAt as createdAt

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -22,6 +22,19 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
     search: search ? `%${search}%` : undefined,
   });
 
+  const SORT_COLUMNS: Record<string, string> = {
+    visits: '"visits"',
+    views: '"views"',
+    createdAt: '"createdAt"',
+    firstAt: '"firstAt"',
+  };
+
+  const sortedFilters = {
+    ...filters,
+    orderBy: SORT_COLUMNS[filters.orderBy as string] || '"createdAt"',
+    sortDescending: filters.orderBy ? filters.sortDescending : true,
+  };
+
   const searchQuery = search
     ? `and (distinct_id ilike {{search}}
            or city ilike {{search}}
@@ -68,10 +81,9 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
       session.country, 
       session.region, 
       session.city
-    order by max(website_event.created_at) desc
     `,
     queryParams,
-    filters,
+    sortedFilters,
     FUNCTION_NAME,
   );
 }
@@ -83,6 +95,19 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     ...filters,
     websiteId,
   });
+
+  const SORT_COLUMNS: Record<string, string> = {
+    visits: 'visits',
+    views: 'views',
+    createdAt: 'createdAt',
+    firstAt: 'firstAt',
+  };
+
+  const sortedFilters = {
+    ...filters,
+    orderBy: SORT_COLUMNS[filters.orderBy as string] || 'createdAt',
+    sortDescending: filters.orderBy ? filters.sortDescending : true,
+  };
 
   const searchQuery = search
     ? `and ((positionCaseInsensitive(distinct_id, {search:String}) > 0)
@@ -120,7 +145,6 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     ${filterQuery}
     ${searchQuery}
     group by session_id, website_id, hostname, browser, os, device, screen, language, country, region, city
-    order by lastAt desc
     `;
   } else {
     sql = `
@@ -148,9 +172,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     ${filterQuery}
     ${searchQuery}
     group by session_id, website_id, hostname, browser, os, device, screen, language, country, region, city
-    order by lastAt desc
     `;
   }
 
-  return pagedRawQuery(sql, queryParams, filters, FUNCTION_NAME);
+  return pagedRawQuery(sql, queryParams, sortedFilters, FUNCTION_NAME);
 }

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -6,6 +6,8 @@ import type { QueryFilters } from '@/lib/types';
 
 const FUNCTION_NAME = 'getWebsiteSessions';
 
+const SORTABLE_COLUMNS = ['visits', 'views', 'createdAt', 'firstAt'] as const;
+
 export async function getWebsiteSessions(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
@@ -22,12 +24,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
     search: search ? `%${search}%` : undefined,
   });
 
-  const SORT_COLUMNS: Record<string, string> = {
-    visits: '"visits"',
-    views: '"views"',
-    createdAt: '"createdAt"',
-    firstAt: '"firstAt"',
-  };
+  const SORT_COLUMNS = Object.fromEntries(SORTABLE_COLUMNS.map(c => [c, `"${c}"`]));
 
   const sortedFilters = {
     ...filters,
@@ -96,12 +93,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     websiteId,
   });
 
-  const SORT_COLUMNS: Record<string, string> = {
-    visits: 'visits',
-    views: 'views',
-    createdAt: 'createdAt',
-    firstAt: 'firstAt',
-  };
+  const SORT_COLUMNS = Object.fromEntries(SORTABLE_COLUMNS.map(c => [c, c]));
 
   const sortedFilters = {
     ...filters,


### PR DESCRIPTION
This PR adds server-side sorting to the sessions table for Visits, Views, and Last Seen Columns. Clicking a sortable header cycles through descending -> ascending > default sort order

The motivation behind this is that there is no way to currently sort session table data by metrics (views, visits) which is something I find myself wanting to do.

