### PR TITLE
Extract tracker code into its own module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ package-lock.json
 /dist
 /generated
 /src/generated
+/packages/tracker/dist
 
 # misc
 .DS_Store

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -1,0 +1,214 @@
+# @umami/tracker
+
+Umami analytics tracker library for JavaScript/TypeScript projects.
+
+## Overview
+
+This package contains reusable tracking logic for the Umami analytics platform.
+
+It can be used in any JavaScript or TypeScript project to integrate Umami analytics
+programmatically, i.e. without resorting to an embed code.
+
+While this does require a separate build tool, you'll likely save a network trip
+and have a higher propability of avoiding ad blockers. Do keep in mind, that
+this this dependency needs to be kept up-to-date (matching your Umami instance).
+
+## Installation
+
+```bash
+npm install @umami/tracker
+# or
+pnpm add @umami/tracker
+# or
+yarn add @umami/tracker
+```
+
+## Usage
+
+### Basic Setup
+
+```typescript
+import { createTracker } from '@umami/tracker';
+
+const tracker = createTracker({
+  website: 'your-website-id',
+  endpoint: 'https://your-umami-instance.com/api/send',
+});
+
+// Track a page view
+tracker.track();
+
+// Track a custom event
+tracker.track('button-click');
+
+// Track an event with data
+tracker.track('signup', {
+  plan: 'premium',
+  source: 'homepage',
+});
+```
+
+### Configuration Options
+
+```typescript
+interface TrackerConfig {
+  website: string;              // Required: Your website ID
+  endpoint?: string;            // API endpoint URL
+  tag?: string;                 // Optional tag for categorizing data
+  autoTrack?: boolean;          // Enable automatic page view tracking (default: true)
+  domains?: string[];           // Limit tracking to specific domains
+  excludeSearch?: boolean;      // Exclude search params from URLs
+  excludeHash?: boolean;        // Exclude hash from URLs
+  doNotTrack?: boolean;         // Respect Do Not Track browser setting
+  beforeSend?: (type, payload) => payload | null;  // Modify or cancel events
+  credentials?: RequestCredentials;  // Fetch credentials mode (default: 'omit')
+}
+```
+
+### Advanced Usage
+
+#### User Identification
+
+```typescript
+// Identify a user
+tracker.identify('user-123');
+
+// Identify with additional data
+tracker.identify('user-123', {
+  email: 'user@example.com',
+  plan: 'premium',
+});
+
+// Or identify with just data
+tracker.identify({
+  company: 'Acme Inc',
+  role: 'admin',
+});
+```
+
+#### Custom Event Functions
+
+```typescript
+// Track with a custom function
+tracker.track((props) => ({
+  ...props,
+  name: 'custom-event',
+  data: {
+    timestamp: Date.now(),
+  },
+}));
+```
+
+#### Manual Initialization
+
+```typescript
+const tracker = createTracker({
+  website: 'your-website-id',
+  endpoint: 'https://your-umami-instance.com/api/send',
+  autoTrack: false,  // Disable auto-tracking
+});
+
+// Manually initialize when ready
+tracker.init();
+```
+
+#### Before Send Hook
+
+```typescript
+const tracker = createTracker({
+  website: 'your-website-id',
+  endpoint: 'https://your-umami-instance.com/api/send',
+  beforeSend: (type, payload) => {
+    // Modify payload
+    payload.custom_field = 'value';
+
+    // Or cancel the event by returning null
+    if (payload.url.includes('admin')) {
+      return null;
+    }
+
+    return payload;
+  },
+});
+```
+
+## TypeScript Support
+
+This package is written in TypeScript and includes full type definitions.
+
+```typescript
+import type { TrackerConfig, UmamiTracker, EventData } from '@umami/tracker';
+```
+
+## Framework Integration
+
+### React
+
+```typescript
+import { useEffect } from 'react';
+import { createTracker } from '@umami/tracker';
+
+const tracker = createTracker({
+  website: 'your-website-id',
+  endpoint: 'https://your-umami-instance.com/api/send',
+});
+
+function MyApp() {
+  useEffect(() => {
+    tracker.track(); // Track page view on mount
+  }, []);
+
+  return (
+    <button onClick={() => tracker.track('button-click')}>
+      Click me
+    </button>
+  );
+}
+```
+
+### Vue
+
+```typescript
+import { onMounted } from 'vue';
+import { createTracker } from '@umami/tracker';
+
+const tracker = createTracker({
+  website: 'your-website-id',
+  endpoint: 'https://your-umami-instance.com/api/send',
+});
+
+export default {
+  setup() {
+    onMounted(() => {
+      tracker.track();
+    });
+
+    const handleClick = () => {
+      tracker.track('button-click');
+    };
+
+    return { handleClick };
+  },
+};
+```
+
+## Browser Compatibility
+
+This package works in all modern browsers that support:
+- ES2020 features
+- `fetch` API
+- `Promise`
+- `URL` API
+
+## Zero Dependencies
+
+This package has zero runtime dependencies, keeping your bundle size small.
+
+## License
+
+MIT
+
+## Related
+
+- [Umami Analytics](https://umami.is) - The main Umami analytics platform
+- [Umami Documentation](https://umami.is/docs) - Full documentation

--- a/packages/tracker/README.md
+++ b/packages/tracker/README.md
@@ -10,8 +10,8 @@ It can be used in any JavaScript or TypeScript project to integrate Umami analyt
 programmatically, i.e. without resorting to an embed code.
 
 While this does require a separate build tool, you'll likely save a network trip
-and have a higher propability of avoiding ad blockers. Do keep in mind, that
-this this dependency needs to be kept up-to-date (matching your Umami instance).
+and have a higher probability of avoiding ad blockers. Do keep in mind, that
+this dependency needs to be kept up-to-date (matching your Umami instance).
 
 ## Installation
 

--- a/packages/tracker/package.json
+++ b/packages/tracker/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@umami/tracker",
+  "version": "3.0.3",
+  "description": "Umami analytics tracker core library",
+  "author": "Umami Software, Inc. <hello@umami.is>",
+  "license": "MIT",
+  "homepage": "https://umami.is",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/umami-software/umami.git",
+    "directory": "packages/tracker"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false
+}

--- a/packages/tracker/src/index.ts
+++ b/packages/tracker/src/index.ts
@@ -1,0 +1,12 @@
+export { createTracker } from './tracker';
+
+export type {
+  CustomEventFunction,
+  EventData,
+  EventProperties,
+  PageViewProperties,
+  TrackedProperties,
+  TrackerConfig,
+  UmamiTracker,
+  WithRequired,
+} from './types';

--- a/packages/tracker/src/tracker.ts
+++ b/packages/tracker/src/tracker.ts
@@ -1,0 +1,254 @@
+import type {
+  CustomEventFunction,
+  EventData,
+  PageViewProperties,
+  TrackerConfig,
+  UmamiTracker,
+} from './types';
+
+/**
+ * Creates a new Umami tracker instance
+ *
+ * @param config - Configuration options for the tracker
+ * @returns A tracker instance with track() and identify() methods
+ */
+export function createTracker(config: TrackerConfig): UmamiTracker {
+  const {
+    website,
+    endpoint = '',
+    tag,
+    autoTrack = true,
+    domains = [],
+    excludeSearch = false,
+    excludeHash = false,
+    doNotTrack = false,
+    beforeSend,
+    credentials = 'omit',
+  } = config;
+
+  // Get browser/window globals
+  const {
+    screen: { width, height },
+    navigator,
+    location,
+    document,
+    history,
+    top,
+    localStorage: windowLocalStorage,
+  } = window;
+
+  const { language } = navigator;
+  const ndnt = (navigator as any).doNotTrack;
+  const msdnt = (navigator as any).msDoNotTrack;
+  const windowDnt = (window as any).doNotTrack;
+  const { hostname, href, origin } = location;
+  const { referrer } = document;
+  const localStorage = href.startsWith('data:') ? undefined : windowLocalStorage;
+  const screen = `${width}x${height}`;
+
+  // State
+  let initialized = false;
+  let disabled = false;
+  let cache: string | undefined;
+  let identity: string | undefined;
+  let currentUrl = '';
+  let currentRef = '';
+
+  // Constants
+  const eventRegex = /data-umami-event-([\w-_]+)/;
+  const eventNameAttribute = 'data-umami-event';
+  const delayDuration = 300;
+
+  /* Helper functions */
+
+  const normalize = (raw: string): string => {
+    if (!raw) return raw;
+    try {
+      const u = new URL(raw, location.href);
+      if (excludeSearch) u.search = '';
+      if (excludeHash) u.hash = '';
+      return u.toString();
+    } catch {
+      return raw;
+    }
+  };
+
+  const getPayload = (): PageViewProperties => ({
+    website,
+    screen,
+    language,
+    title: document.title,
+    hostname,
+    url: currentUrl,
+    referrer: currentRef,
+    tag,
+    id: identity ? identity : undefined,
+  });
+
+  const hasDoNotTrack = (): boolean => {
+    const dnt = windowDnt || ndnt || msdnt;
+    return dnt === 1 || dnt === '1' || dnt === 'yes';
+  };
+
+  const trackingDisabled = (): boolean =>
+    disabled ||
+    !website ||
+    !!localStorage?.getItem('umami.disabled') ||
+    (domains.length > 0 && !domains.includes(hostname)) ||
+    (doNotTrack && hasDoNotTrack());
+
+  /* Event handlers */
+
+  const handlePush = (_state: any, _title: string, url?: string) => {
+    if (!url) return;
+
+    currentRef = currentUrl;
+    currentUrl = normalize(new URL(url, location.href).toString());
+
+    if (currentUrl !== currentRef) {
+      setTimeout(track, delayDuration);
+    }
+  };
+
+  const handlePathChanges = () => {
+    const hook = (_this: any, method: string, callback: (...args: any[]) => void) => {
+      const orig = _this[method];
+      return (...args: any[]) => {
+        callback.apply(null, args);
+        return orig.apply(_this, args);
+      };
+    };
+
+    history.pushState = hook(history, 'pushState', handlePush);
+    history.replaceState = hook(history, 'replaceState', handlePush);
+  };
+
+  const handleClicks = () => {
+    const trackElement = async (el: Element) => {
+      const eventName = el.getAttribute(eventNameAttribute);
+      if (eventName) {
+        const eventData: EventData = {};
+
+        el.getAttributeNames().forEach(name => {
+          const match = name.match(eventRegex);
+          if (match) eventData[match[1]] = el.getAttribute(name)!;
+        });
+
+        return track(eventName, eventData);
+      }
+    };
+
+    const onClick = async (e: MouseEvent) => {
+      const el = e.target as Element;
+      const parentElement = el.closest('a,button');
+      if (!parentElement) return trackElement(el);
+
+      const { href, target } = parentElement as HTMLAnchorElement;
+      if (!parentElement.getAttribute(eventNameAttribute)) return;
+
+      if (parentElement.tagName === 'BUTTON') {
+        return trackElement(parentElement);
+      }
+
+      if (parentElement.tagName === 'A' && href) {
+        const external =
+          target === '_blank' ||
+          e.ctrlKey ||
+          e.shiftKey ||
+          e.metaKey ||
+          (e.button && e.button === 1);
+        if (!external) e.preventDefault();
+        return trackElement(parentElement).then(() => {
+          if (!external) {
+            (target === '_top' ? top?.location || location : location).href = href;
+          }
+        });
+      }
+    };
+
+    document.addEventListener('click', onClick, true);
+  };
+
+  /* Tracking functions */
+
+  const send = async (payload: any, type: string = 'event'): Promise<void> => {
+    if (trackingDisabled()) return;
+
+    if (typeof beforeSend === 'function') {
+      payload = await Promise.resolve(beforeSend(type, payload));
+    }
+
+    if (!payload) return;
+
+    try {
+      const res = await fetch(endpoint, {
+        keepalive: true,
+        method: 'POST',
+        body: JSON.stringify({ type, payload }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(typeof cache !== 'undefined' && { 'x-umami-cache': cache }),
+        },
+        credentials,
+      });
+
+      const data = await res.json();
+      if (data) {
+        disabled = !!data.disabled;
+        cache = data.cache;
+      }
+    } catch (_e) {
+      /* no-op */
+    }
+  };
+
+  const init = () => {
+    if (!initialized) {
+      initialized = true;
+      track();
+      handlePathChanges();
+      handleClicks();
+    }
+  };
+
+  const track: UmamiTracker['track'] = (name?: any, data?: any): Promise<void> => {
+    if (typeof name === 'string') return send({ ...getPayload(), name, data });
+    if (typeof name === 'object') return send({ ...name });
+    if (typeof name === 'function') return send(name(getPayload()));
+    return send(getPayload());
+  };
+
+  const identify = (id: string | EventData, data?: EventData): Promise<void> => {
+    if (typeof id === 'string') {
+      identity = id;
+    }
+
+    cache = '';
+    return send(
+      {
+        ...getPayload(),
+        data: typeof id === 'object' ? id : data,
+      },
+      'identify',
+    );
+  };
+
+  // Initialize current URL and referrer
+  currentUrl = normalize(href);
+  currentRef = normalize(referrer.startsWith(origin) ? '' : referrer);
+
+  // Auto-initialize if enabled
+  if (autoTrack && !trackingDisabled()) {
+    if (document.readyState === 'complete') {
+      init();
+    } else {
+      document.addEventListener('readystatechange', init, true);
+    }
+  }
+
+  return {
+    track,
+    identify,
+    init,
+  };
+}

--- a/packages/tracker/src/tracker.ts
+++ b/packages/tracker/src/tracker.ts
@@ -242,7 +242,10 @@ export function createTracker(config: TrackerConfig): UmamiTracker {
     if (document.readyState === 'complete') {
       init();
     } else {
-      document.addEventListener('readystatechange', init, true);
+      document.addEventListener('readystatechange', init, {
+        capture: true,
+        once: true,
+      });
     }
   }
 

--- a/packages/tracker/src/types.ts
+++ b/packages/tracker/src/types.ts
@@ -1,0 +1,231 @@
+export type TrackedProperties = {
+  /**
+   * Hostname of server
+   *
+   * @description extracted from `window.location.hostname`
+   * @example 'analytics.umami.is'
+   */
+  hostname: string;
+
+  /**
+   * Browser language
+   *
+   * @description extracted from `window.navigator.language`
+   * @example 'en-US', 'fr-FR'
+   */
+  language: string;
+
+  /**
+   * Page referrer
+   *
+   * @description extracted from `window.navigator.language`
+   * @example 'https://analytics.umami.is/docs/getting-started'
+   */
+  referrer: string;
+
+  /**
+   * Screen dimensions
+   *
+   * @description extracted from `window.screen.width` and `window.screen.height`
+   * @example '1920x1080', '2560x1440'
+   */
+  screen: string;
+
+  /**
+   * Page title
+   *
+   * @description extracted from `document.querySelector('head > title')`
+   * @example 'umami'
+   */
+  title: string;
+
+  /**
+   * Page url
+   *
+   * @description built from `${window.location.pathname}${window.location.search}`
+   * @example 'docs/getting-started'
+   */
+  url: string;
+
+  /**
+   * Website ID (required)
+   *
+   * @example 'b59e9c65-ae32-47f1-8400-119fcf4861c4'
+   */
+  website: string;
+
+  /**
+   * Optional tag for categorizing tracking data
+   */
+  tag?: string;
+
+  /**
+   * Optional identity ID for user identification
+   */
+  id?: string;
+};
+
+export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
+
+/**
+ * Event Data can work with any JSON data. There are a few rules in place to maintain performance.
+ * - Numbers have a max precision of 4.
+ * - Strings have a max length of 500.
+ * - Arrays are converted to a String, with the same max length of 500.
+ * - Objects have a max of 50 properties. Arrays are considered 1 property.
+ */
+export interface EventData {
+  [key: string]: number | string | EventData | number[] | string[] | EventData[];
+}
+
+export type EventProperties = {
+  /**
+   * NOTE: event names will be truncated past 50 characters
+   */
+  name: string;
+  data?: EventData;
+} & WithRequired<TrackedProperties, 'website'>;
+
+export type PageViewProperties = WithRequired<TrackedProperties, 'website'>;
+
+export type CustomEventFunction = (
+  props: PageViewProperties,
+) => EventProperties | PageViewProperties;
+
+/**
+ * Configuration options for creating a tracker instance
+ */
+export interface TrackerConfig {
+  /**
+   * Website ID (required)
+   */
+  website: string;
+
+  /**
+   * Full endpoint URL
+   */
+  endpoint?: string;
+
+  /**
+   * Optional tag for categorizing tracking data
+   */
+  tag?: string;
+
+  /**
+   * Enable automatic page view tracking
+   * @default true
+   */
+  autoTrack?: boolean;
+
+  /**
+   * List of domains to track (empty means track all)
+   * @default []
+   */
+  domains?: string[];
+
+  /**
+   * Exclude search query parameters from URLs
+   * @default false
+   */
+  excludeSearch?: boolean;
+
+  /**
+   * Exclude hash from URLs
+   * @default false
+   */
+  excludeHash?: boolean;
+
+  /**
+   * Respect Do Not Track browser setting
+   * @default false
+   */
+  doNotTrack?: boolean;
+
+  /**
+   * Callback function called before sending data
+   * Return modified payload or null to prevent sending
+   */
+  beforeSend?: (type: string, payload: any) => any | Promise<any> | null;
+
+  /**
+   * Fetch credentials mode
+   * @default 'omit'
+   */
+  credentials?: RequestCredentials;
+}
+
+/**
+ * Tracker instance interface
+ */
+export interface UmamiTracker {
+  /**
+   * Track a page view or custom event
+   */
+  track: {
+    /**
+     * Track a page view
+     *
+     * @example ```
+     * tracker.track();
+     * ```
+     */
+    (): Promise<void>;
+
+    /**
+     * Track an event with a given name
+     *
+     * NOTE: event names will be truncated past 50 characters
+     *
+     * @example ```
+     * tracker.track('signup-button');
+     * ```
+     */
+    (eventName: string): Promise<void>;
+
+    /**
+     * Tracks an event with dynamic data.
+     *
+     * NOTE: event names will be truncated past 50 characters
+     *
+     * @example ```
+     * tracker.track('signup-button', { name: 'newsletter', id: 123 });
+     * ```
+     */
+    (eventName: string, obj: EventData): Promise<void>;
+
+    /**
+     * Tracks a page view with custom properties
+     *
+     * @example ```
+     * tracker.track({ website: 'e676c9b4-11e4-4ef1-a4d7-87001773e9f2', url: '/home', title: 'Home page' });
+     * ```
+     */
+    (properties: PageViewProperties): Promise<void>;
+
+    /**
+     * Tracks an event with fully customizable dynamic data
+     *
+     * @example ```
+     * tracker.track((props) => ({ ...props, url: path }));
+     * ```
+     */
+    (eventFunction: CustomEventFunction): Promise<void>;
+  };
+
+  /**
+   * Identify a user
+   *
+   * @example ```
+   * tracker.identify('user-123');
+   * tracker.identify('user-123', { plan: 'premium' });
+   * tracker.identify({ email: 'user@example.com' });
+   * ```
+   */
+  identify(id: string, data?: EventData): Promise<void>;
+  identify(data: EventData): Promise<void>;
+
+  /**
+   * Initialize the tracker (sets up event listeners for auto-tracking)
+   */
+  init(): void;
+}

--- a/packages/tracker/src/types.ts
+++ b/packages/tracker/src/types.ts
@@ -18,7 +18,7 @@ export type TrackedProperties = {
   /**
    * Page referrer
    *
-   * @description extracted from `window.navigator.language`
+   * @description extracted from `document.referrer`
    * @example 'https://analytics.umami.is/docs/getting-started'
    */
   referrer: string;

--- a/packages/tracker/tsconfig.json
+++ b/packages/tracker/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM"],
+    "moduleResolution": "bundler",
+    "strict": true,
+    "strictNullChecks": false,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/tracker/tsconfig.json
+++ b/packages/tracker/tsconfig.json
@@ -5,7 +5,6 @@
     "lib": ["ES2020", "DOM"],
     "moduleResolution": "bundler",
     "strict": true,
-    "strictNullChecks": false,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -331,6 +331,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/tracker: {}
+
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/rollup.tracker.config.js
+++ b/rollup.tracker.config.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import replace from '@rollup/plugin-replace';
 import terser from '@rollup/plugin-terser';
+import typescript from '@rollup/plugin-typescript';
 
 export default {
   input: 'src/tracker/index.js',
@@ -9,6 +10,12 @@ export default {
     format: 'iife',
   },
   plugins: [
+    typescript({
+      tsconfig: 'packages/tracker/tsconfig.json',
+      declaration: false,
+      declarationMap: false,
+      sourceMap: false,
+    }),
     replace({
       __COLLECT_API_HOST__: process.env.COLLECT_API_HOST || '',
       __COLLECT_API_ENDPOINT__: process.env.COLLECT_API_ENDPOINT || '/api/send',

--- a/src/tracker/index.d.ts
+++ b/src/tracker/index.d.ts
@@ -1,153 +1,21 @@
-export type TrackedProperties = {
-  /**
-   * Hostname of server
-   *
-   * @description extracted from `window.location.hostname`
-   * @example 'analytics.umami.is'
-   */
-  hostname: string;
+import type { UmamiTracker } from '../../packages/tracker/src/types';
 
-  /**
-   * Browser language
-   *
-   * @description extracted from `window.navigator.language`
-   * @example 'en-US', 'fr-FR'
-   */
-  language: string;
+export type {
+  TrackedProperties,
+  WithRequired,
+  EventData,
+  EventProperties,
+  PageViewProperties,
+  CustomEventFunction,
+  TrackerConfig,
+  UmamiTracker,
+} from '../../packages/tracker/src/types';
 
-  /**
-   * Page referrer
-   *
-   * @description extracted from `window.navigator.language`
-   * @example 'https://analytics.umami.is/docs/getting-started'
-   */
-  referrer: string;
-
-  /**
-   * Screen dimensions
-   *
-   * @description extracted from `window.screen.width` and `window.screen.height`
-   * @example '1920x1080', '2560x1440'
-   */
-  screen: string;
-
-  /**
-   * Page title
-   *
-   * @description extracted from `document.querySelector('head > title')`
-   * @example 'umami'
-   */
-  title: string;
-
-  /**
-   * Page url
-   *
-   * @description built from `${window.location.pathname}${window.location.search}`
-   * @example 'docs/getting-started'
-   */
-  url: string;
-
-  /**
-   * Website ID (required)
-   *
-   * @example 'b59e9c65-ae32-47f1-8400-119fcf4861c4'
-   */
-  website: string;
-};
-
-export type WithRequired<T, K extends keyof T> = T & { [P in K]-?: T[P] };
-
-/**
- *
- * Event Data can work with any JSON data. There are a few rules in place to maintain performance.
- * - Numbers have a max precision of 4.
- * - Strings have a max length of 500.
- * - Arrays are converted to a String, with the same max length of 500.
- * - Objects have a max of 50 properties. Arrays are considered 1 property.
- */
-export interface EventData {
-  [key: string]: number | string | EventData | number[] | string[] | EventData[];
-}
-
-export type EventProperties = {
-  /**
-   * NOTE: event names will be truncated past 50 characters
-   */
-  name: string;
-  data?: EventData;
-} & WithRequired<TrackedProperties, 'website'>;
-export type PageViewProperties = WithRequired<TrackedProperties, 'website'>;
-export type CustomEventFunction = (
-  props: PageViewProperties,
-) => EventProperties | PageViewProperties;
-
-export type UmamiTracker = {
-  track: {
-    /**
-     * Track a page view
-     *
-     * @example ```
-     * umami.track();
-     * ```
-     */
-    (): Promise<string>;
-
-    /**
-     * Track an event with a given name
-     *
-     * NOTE: event names will be truncated past 50 characters
-     *
-     * @example ```
-     * umami.track('signup-button');
-     * ```
-     */
-    (eventName: string): Promise<string>;
-
-    /**
-     * Tracks an event with dynamic data.
-     *
-     * NOTE: event names will be truncated past 50 characters
-     *
-     * When tracking events, the default properties are included in the payload. This is equivalent to running:
-     *
-     * ```js
-     * umami.track(props => ({
-     *   ...props,
-     *   name: 'signup-button',
-     *   data: {
-     *     name: 'newsletter',
-     *     id: 123
-     *   }
-     * }));
-     * ```
-     *
-     * @example ```
-     * umami.track('signup-button', { name: 'newsletter', id: 123 });
-     * ```
-     */
-    (eventName: string, obj: EventData): Promise<string>;
-
-    /**
-     * Tracks a page view with custom properties
-     *
-     * @example ```
-     * umami.track({ website: 'e676c9b4-11e4-4ef1-a4d7-87001773e9f2', url: '/home', title: 'Home page' });
-     * ```
-     */
-    (properties: PageViewProperties): Promise<string>;
-
-    /**
-     * Tracks an event with fully customizable dynamic data
-     * If you don't specify any `name` and/or `data`, it will be treated as a page view
-     *
-     * @example ```
-     * umami.track((props) => ({ ...props, url: path }));
-     * ```
-     */
-    (eventFunction: CustomEventFunction): Promise<string>;
-  };
-};
-
-export interface Window {
-  umami: UmamiTracker;
+declare global {
+  interface Window {
+    umami: {
+      track: UmamiTracker['track'];
+      identify: UmamiTracker['identify'];
+    };
+  }
 }

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -20,7 +20,10 @@ import { createTracker } from '../../packages/tracker/src';
     endpoint: `${host.replace(/\/$/, '')}__COLLECT_API_ENDPOINT__`,
     tag: attr(`${_data}tag`) || undefined,
     autoTrack: attr(`${_data}auto-track`) !== _false,
-    domains: (attr(`${_data}domains`) || '').split(',').map(n => n.trim()),
+    domains: (attr(`${_data}domains`) || '')
+      .split(',')
+      .map(n => n.trim())
+      .filter(Boolean),
     excludeSearch: attr(`${_data}exclude-search`) === _true,
     excludeHash: attr(`${_data}exclude-hash`) === _true,
     doNotTrack: attr(`${_data}do-not-track`) === _true,

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -1,240 +1,38 @@
-(window => {
-  const {
-    screen: { width, height },
-    navigator: { language, doNotTrack: ndnt, msDoNotTrack: msdnt },
-    location,
-    document,
-    history,
-    top,
-    doNotTrack,
-  } = window;
-  const { currentScript, referrer } = document;
-  if (!currentScript) return;
+import { createTracker } from '../../packages/tracker/src';
 
-  const { hostname, href, origin } = location;
-  const localStorage = href.startsWith('data:') ? undefined : window.localStorage;
+(window => {
+  const { currentScript } = window.document;
+  if (!currentScript) return;
 
   const _data = 'data-';
   const _false = 'false';
   const _true = 'true';
   const attr = currentScript.getAttribute.bind(currentScript);
-
-  const website = attr(`${_data}website-id`);
-  const hostUrl = attr(`${_data}host-url`);
   const beforeSend = attr(`${_data}before-send`);
-  const tag = attr(`${_data}tag`) || undefined;
-  const autoTrack = attr(`${_data}auto-track`) !== _false;
-  const dnt = attr(`${_data}do-not-track`) === _true;
-  const excludeSearch = attr(`${_data}exclude-search`) === _true;
-  const excludeHash = attr(`${_data}exclude-hash`) === _true;
-  const domain = attr(`${_data}domains`) || '';
-  const credentials = attr(`${_data}fetch-credentials`) || 'omit';
-
-  const domains = domain.split(',').map(n => n.trim());
   const host =
-    hostUrl || '__COLLECT_API_HOST__' || currentScript.src.split('/').slice(0, -1).join('/');
-  const endpoint = `${host.replace(/\/$/, '')}__COLLECT_API_ENDPOINT__`;
-  const screen = `${width}x${height}`;
-  const eventRegex = /data-umami-event-([\w-_]+)/;
-  const eventNameAttribute = `${_data}umami-event`;
-  const delayDuration = 300;
+    attr(`${_data}host-url`) ||
+    '__COLLECT_API_HOST__' ||
+    currentScript.src.split('/').slice(0, -1).join('/');
 
-  /* Helper functions */
-
-  const normalize = raw => {
-    if (!raw) return raw;
-    try {
-      const u = new URL(raw, location.href);
-      if (excludeSearch) u.search = '';
-      if (excludeHash) u.hash = '';
-      return u.toString();
-    } catch {
-      return raw;
-    }
-  };
-
-  const getPayload = () => ({
-    website,
-    screen,
-    language,
-    title: document.title,
-    hostname,
-    url: currentUrl,
-    referrer: currentRef,
-    tag,
-    id: identity ? identity : undefined,
+  // Create tracker instance
+  const tracker = createTracker({
+    website: attr(`${_data}website-id`),
+    endpoint: `${host.replace(/\/$/, '')}__COLLECT_API_ENDPOINT__`,
+    tag: attr(`${_data}tag`) || undefined,
+    autoTrack: attr(`${_data}auto-track`) !== _false,
+    domains: (attr(`${_data}domains`) || '').split(',').map(n => n.trim()),
+    excludeSearch: attr(`${_data}exclude-search`) === _true,
+    excludeHash: attr(`${_data}exclude-hash`) === _true,
+    doNotTrack: attr(`${_data}do-not-track`) === _true,
+    beforeSend: beforeSend ? window[beforeSend] : undefined,
+    credentials: attr(`${_data}fetch-credentials`) || 'omit',
   });
 
-  const hasDoNotTrack = () => {
-    const dnt = doNotTrack || ndnt || msdnt;
-    return dnt === 1 || dnt === '1' || dnt === 'yes';
-  };
-
-  /* Event handlers */
-
-  const handlePush = (_state, _title, url) => {
-    if (!url) return;
-
-    currentRef = currentUrl;
-    currentUrl = normalize(new URL(url, location.href).toString());
-
-    if (currentUrl !== currentRef) {
-      setTimeout(track, delayDuration);
-    }
-  };
-
-  const handlePathChanges = () => {
-    const hook = (_this, method, callback) => {
-      const orig = _this[method];
-      return (...args) => {
-        callback.apply(null, args);
-        return orig.apply(_this, args);
-      };
-    };
-
-    history.pushState = hook(history, 'pushState', handlePush);
-    history.replaceState = hook(history, 'replaceState', handlePush);
-  };
-
-  const handleClicks = () => {
-    const trackElement = async el => {
-      const eventName = el.getAttribute(eventNameAttribute);
-      if (eventName) {
-        const eventData = {};
-
-        el.getAttributeNames().forEach(name => {
-          const match = name.match(eventRegex);
-          if (match) eventData[match[1]] = el.getAttribute(name);
-        });
-
-        return track(eventName, eventData);
-      }
-    };
-    const onClick = async e => {
-      const el = e.target;
-      const parentElement = el.closest('a,button');
-      if (!parentElement) return trackElement(el);
-
-      const { href, target } = parentElement;
-      if (!parentElement.getAttribute(eventNameAttribute)) return;
-
-      if (parentElement.tagName === 'BUTTON') {
-        return trackElement(parentElement);
-      }
-      if (parentElement.tagName === 'A' && href) {
-        const external =
-          target === '_blank' ||
-          e.ctrlKey ||
-          e.shiftKey ||
-          e.metaKey ||
-          (e.button && e.button === 1);
-        if (!external) e.preventDefault();
-        return trackElement(parentElement).then(() => {
-          if (!external) {
-            (target === '_top' ? top.location : location).href = href;
-          }
-        });
-      }
-    };
-    document.addEventListener('click', onClick, true);
-  };
-
-  /* Tracking functions */
-
-  const trackingDisabled = () =>
-    disabled ||
-    !website ||
-    localStorage?.getItem('umami.disabled') ||
-    (domain && !domains.includes(hostname)) ||
-    (dnt && hasDoNotTrack());
-
-  const send = async (payload, type = 'event') => {
-    if (trackingDisabled()) return;
-
-    const callback = window[beforeSend];
-
-    if (typeof callback === 'function') {
-      payload = await Promise.resolve(callback(type, payload));
-    }
-
-    if (!payload) return;
-
-    try {
-      const res = await fetch(endpoint, {
-        keepalive: true,
-        method: 'POST',
-        body: JSON.stringify({ type, payload }),
-        headers: {
-          'Content-Type': 'application/json',
-          ...(typeof cache !== 'undefined' && { 'x-umami-cache': cache }),
-        },
-        credentials,
-      });
-
-      const data = await res.json();
-      if (data) {
-        disabled = !!data.disabled;
-        cache = data.cache;
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    } catch (_e) {
-      /* no-op */
-    }
-  };
-
-  const init = () => {
-    if (!initialized) {
-      initialized = true;
-      track();
-      handlePathChanges();
-      handleClicks();
-    }
-  };
-
-  const track = (name, data) => {
-    if (typeof name === 'string') return send({ ...getPayload(), name, data });
-    if (typeof name === 'object') return send({ ...name });
-    if (typeof name === 'function') return send(name(getPayload()));
-    return send(getPayload());
-  };
-
-  const identify = (id, data) => {
-    if (typeof id === 'string') {
-      identity = id;
-    }
-
-    cache = '';
-    return send(
-      {
-        ...getPayload(),
-        data: typeof id === 'object' ? id : data,
-      },
-      'identify',
-    );
-  };
-
-  /* Start */
-
+  // Expose to window.umami
   if (!window.umami) {
     window.umami = {
-      track,
-      identify,
+      track: tracker.track,
+      identify: tracker.identify,
     };
-  }
-
-  let currentUrl = normalize(href);
-  let currentRef = normalize(referrer.startsWith(origin) ? '' : referrer);
-
-  let initialized = false;
-  let disabled = false;
-  let cache;
-  let identity;
-
-  if (autoTrack && !trackingDisabled()) {
-    if (document.readyState === 'complete') {
-      init();
-    } else {
-      document.addEventListener('readystatechange', init, true);
-    }
   }
 })(window);


### PR DESCRIPTION
This is a prototype created from #4104, following these goals:

- Extract the tracker code into a separate module (for consumption in other JS/TS projects).
- Keep `public/script.js` intact (no breaking changes for existing users of the embed snippet).

A before/after of the `public/script.js` can be inspected here:

https://gist.github.com/dmke/d155ac45ddbd3081edda23c1e81535f6

While it has gained a little weight (2688 → 3047 bytes, +359 bytes), it uses the same package to ensure parity.

The new module currently lives in `./packages/tracker` and has basic NPM publishing infrastructure, but nothing fleshed out. I'm not sure how you would want to handle this, whether it should be moved into its own repository, how/whether to keep version number in sync, etc.

I've included a README.md showcasing the use in a React and Vue project.