### PR TITLE
fix: use settings timezone in revenue chart date range

### DIFF
--- a/src/app/(main)/websites/[websiteId]/(reports)/revenue/RevenuePage.tsx
+++ b/src/app/(main)/websites/[websiteId]/(reports)/revenue/RevenuePage.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { Column } from '@umami/react-zen';
 import { WebsiteControls } from '@/app/(main)/websites/[websiteId]/WebsiteControls';
-import { useDateRange } from '@/components/hooks';
+import { useDateRange, useTimezone } from '@/components/hooks';
 import { Revenue } from './Revenue';
 
 export function RevenuePage({ websiteId }: { websiteId: string }) {
+  const { timezone } = useTimezone();
   const {
     dateRange: { startDate, endDate, unit },
-  } = useDateRange();
+  } = useDateRange({ timezone });
 
   return (
     <Column gap>


### PR DESCRIPTION
## Summary

Fixes #4107

The revenue chart was using the browser's **local timezone** instead of the timezone configured in Umami settings. This caused:
- Chart X-axis to display timestamps based on local PC time
- Header stats (total, average, transactions) to use the settings timezone  
- A visible mismatch: header showed 2 transactions while chart showed only 1 data point (as described in the issue)

## Root Cause

`RevenuePage` called `useDateRange()` without a timezone argument, so `parseDateRange()` fell back to the browser's local time when computing `startDate`/`endDate`:

```ts
// Before (no timezone → uses browser local TZ)
const { dateRange: { startDate, endDate, unit } } = useDateRange();
```

Compare with `EventsChart`, which correctly passes the configured timezone:

```ts
const { timezone } = useTimezone();
const { dateRange: { startDate, endDate, unit } } = useDateRange({ timezone });
```

## Fix

Mirror the `EventsChart` pattern in `RevenuePage`:

```ts
const { timezone } = useTimezone();
const { dateRange: { startDate, endDate, unit } } = useDateRange({ timezone });
```

This ensures the date range boundaries are computed in the user's configured timezone, matching the server-side timezone used for the stats.

## Changed Files

- `src/app/(main)/websites/[websiteId]/(reports)/revenue/RevenuePage.tsx` — 3-line change