### PR TITLE
fix: preserve sessions date filter when closing session modal

### DIFF
--- a/src/components/hooks/useNavigation.ts
+++ b/src/components/hooks/useNavigation.ts
@@ -1,5 +1,4 @@
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
 import { buildPath } from '@/lib/url';
 
 export function useNavigation() {
@@ -8,26 +7,25 @@ export function useNavigation() {
   const searchParams = useSearchParams();
   const [, teamId] = pathname.match(/\/teams\/([a-f0-9-]+)/) || [];
   const [, websiteId] = pathname.match(/\/websites\/([a-f0-9-]+)/) || [];
-  const [queryParams, setQueryParams] = useState(Object.fromEntries(searchParams));
+  const queryParams = Object.fromEntries(searchParams.entries());
 
-  const updateParams = (params?: Record<string, string | number>) => {
+  const updateParams = (params?: Record<string, string | number | undefined>) => {
     return buildPath(pathname, { ...queryParams, ...params });
   };
 
-  const replaceParams = (params?: Record<string, string | number>) => {
+  const replaceParams = (params?: Record<string, string | number | undefined>) => {
     return buildPath(pathname, params);
   };
 
-  const renderUrl = (path: string, params?: Record<string, string | number> | false) => {
+  const renderUrl = (
+    path: string,
+    params?: Record<string, string | number | undefined> | false,
+  ) => {
     return buildPath(
       teamId ? `/teams/${teamId}${path}` : path,
       params === false ? {} : { ...queryParams, ...params },
     );
   };
-
-  useEffect(() => {
-    setQueryParams(Object.fromEntries(searchParams));
-  }, [searchParams.toString()]);
 
   return {
     router,


### PR DESCRIPTION
## Summary

When a user selects a custom Sessions page date filter such as `Last 7 days`, opens a session, and then closes the session modal, the page currently falls back to the default `Last 24 hours` filter.

## Root Cause

`useNavigation()` was copying `searchParams` into local state and syncing them in an effect. That meant `updateParams()` could build the modal close URL from stale query state and drop the current `date` parameter.

## Fix

Use the current `useSearchParams()` values directly when building URLs instead of mirroring them through local state.

This keeps the existing query string intact when the session modal is opened or closed, so the selected Sessions date filter persists as expected.

## Changed Files

- `src/components/hooks/useNavigation.ts` — remove the mirrored query state and build `query`, `updateParams()`, and `renderUrl()` from the live search params