### PR TITLE
Fix incomplete retention report

### DIFF
--- a/src/app/(main)/websites/[websiteId]/(reports)/retention/Retention.tsx
+++ b/src/app/(main)/websites/[websiteId]/(reports)/retention/Retention.tsx
@@ -1,5 +1,6 @@
 import { Column, Grid, Icon, Row, Text } from '@umami/react-zen';
 import type { ReactNode } from 'react';
+import { differenceInCalendarDays } from 'date-fns';
 import { LoadingPanel } from '@/components/common/LoadingPanel';
 import { Panel } from '@/components/common/Panel';
 import { useLocale, useMessages, useResultQuery } from '@/components/hooks';
@@ -45,8 +46,6 @@ export function Retention({ websiteId, days = DAYS, startDate, endDate }: Retent
       return arr;
     }, []) || [];
 
-  const totalDays = rows.length;
-
   return (
     <LoadingPanel data={data} isLoading={isLoading} error={error}>
       {data && (
@@ -84,6 +83,7 @@ export function Retention({ websiteId, days = DAYS, startDate, endDate }: Retent
                 ))}
               </Grid>
               {rows.map(({ date, visitors, records }: any, rowIndex: number) => {
+                const maxDay = differenceInCalendarDays(endDate, new Date(date));
                 return (
                   <Grid
                     key={rowIndex}
@@ -103,10 +103,8 @@ export function Retention({ websiteId, days = DAYS, startDate, endDate }: Retent
                       </Row>
                     </Column>
                     {days.map(day => {
-                      if (totalDays - rowIndex < day) {
-                        return null;
-                      }
-                      const percentage = records.filter(a => a.day === day)[0]?.percentage;
+                      if (day > maxDay) return null;
+                      const percentage = records.find(a => a.day === day)?.percentage;
                       return (
                         <Cell key={day}>
                           {percentage ? `${Number(percentage).toFixed(2)}%` : ''}


### PR DESCRIPTION
Closes #3450.

As stated in issue, days shown per cohort are currently limited to the number of cohorts, which can skip values for websites without new visitors every day.

Moreover, grey squares are possibly shown in impossible positions, like in Day 1 of a cohort that started on the last day of the month.
Current docs [example](https://docs.umami.is/docs/_next/static/media/retention-details.ec47ef35.png) has an impossible square on Day 28 of Aug 4 cohort.

This PR fixes the incomplete issue and ensures `Cell` on every possible position
\+ a slight code change: `find()` instead of `filter()[0]`

Note that a cohort starting the last day of the month will then appear thinner (you might want to update styling):
<img width="558" height="418" alt="retention" src="https://github.com/user-attachments/assets/8cdb1a19-bc51-40a5-8484-925b0456e470" />
