### PR TITLE
fix: prevent NaN timestamps from breaking event charts in Firefox

### DIFF
--- a/src/components/hooks/useDateParameters.ts
+++ b/src/components/hooks/useDateParameters.ts
@@ -7,14 +7,18 @@ export function useDateParameters() {
   } = useDateRange();
   const { timezone, localToUtc, canonicalizeTimezone } = useTimezone();
 
-  const startAtValue = +localToUtc(startDate);
-  const endAtValue = +localToUtc(endDate);
+  const utcStart = localToUtc(startDate);
+  const utcEnd = localToUtc(endDate);
+  const startAtValue = +utcStart;
+  const endAtValue = +utcEnd;
+  const isStartValid = Number.isFinite(startAtValue);
+  const isEndValid = Number.isFinite(endAtValue);
 
   return {
-    startAt: Number.isFinite(startAtValue) ? startAtValue : +startDate,
-    endAt: Number.isFinite(endAtValue) ? endAtValue : +endDate,
-    startDate: localToUtc(startDate).toISOString(),
-    endDate: localToUtc(endDate).toISOString(),
+    startAt: isStartValid ? startAtValue : +startDate,
+    endAt: isEndValid ? endAtValue : +endDate,
+    startDate: isStartValid ? utcStart.toISOString() : startDate.toISOString(),
+    endDate: isEndValid ? utcEnd.toISOString() : endDate.toISOString(),
     unit,
     timezone: canonicalizeTimezone(timezone),
   };

--- a/src/components/hooks/useDateParameters.ts
+++ b/src/components/hooks/useDateParameters.ts
@@ -1,6 +1,14 @@
 import { useDateRange } from './useDateRange';
 import { useTimezone } from './useTimezone';
 
+function safeToISOString(date: Date, fallback: Date): string {
+  try {
+    return date.toISOString();
+  } catch {
+    return fallback.toISOString();
+  }
+}
+
 export function useDateParameters() {
   const {
     dateRange: { startDate, endDate, unit },
@@ -17,8 +25,8 @@ export function useDateParameters() {
   return {
     startAt: isStartValid ? startAtValue : +startDate,
     endAt: isEndValid ? endAtValue : +endDate,
-    startDate: isStartValid ? utcStart.toISOString() : startDate.toISOString(),
-    endDate: isEndValid ? utcEnd.toISOString() : endDate.toISOString(),
+    startDate: safeToISOString(isStartValid ? utcStart : startDate, startDate),
+    endDate: safeToISOString(isEndValid ? utcEnd : endDate, endDate),
     unit,
     timezone: canonicalizeTimezone(timezone),
   };

--- a/src/components/hooks/useDateParameters.ts
+++ b/src/components/hooks/useDateParameters.ts
@@ -7,9 +7,12 @@ export function useDateParameters() {
   } = useDateRange();
   const { timezone, localToUtc, canonicalizeTimezone } = useTimezone();
 
+  const startAtValue = +localToUtc(startDate);
+  const endAtValue = +localToUtc(endDate);
+
   return {
-    startAt: +localToUtc(startDate),
-    endAt: +localToUtc(endDate),
+    startAt: Number.isFinite(startAtValue) ? startAtValue : +startDate,
+    endAt: Number.isFinite(endAtValue) ? endAtValue : +endDate,
     startDate: localToUtc(startDate).toISOString(),
     endDate: localToUtc(endDate).toISOString(),
     unit,

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -2,7 +2,7 @@ export function getQueryString(params: object = {}): string {
   const searchParams = new URLSearchParams();
 
   Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined) {
+    if (value !== undefined && value !== null && !Number.isNaN(value)) {
       searchParams.append(key, value);
     }
   });


### PR DESCRIPTION
## Summary

Fixes #4121

Event charts display "Something went wrong" exclusively in Firefox while working correctly in Chrome. The root cause is that `date-fns-tz` v1.x `zonedTimeToUtc` can return `Invalid Date` in Firefox due to differences in `Intl.DateTimeFormat` timezone offset parsing, producing `NaN` timestamps that are sent to the server as query parameters.

## Root Cause Analysis

1. **`useDateParameters.ts`** calls `+localToUtc(startDate)` which uses `zonedTimeToUtc` from `date-fns-tz@1.3.8`
2. In Firefox, certain timezone edge cases cause this to return `Invalid Date`, and the `+` unary operator converts it to `NaN`
3. **`getQueryString`** in `url.ts` sends `NaN` as a string (`startAt=NaN`) because `NaN !== undefined` passes the filter
4. Routes with `z.coerce.number().int()` validation (`/events/series`, `/event-data/properties`) reject `NaN` since `Number.isInteger(NaN) === false`, returning 400 errors
5. The `/events` route uses `.optional()` without `.int()`, so `NaN` passes Zod but creates `Invalid Date` in the DB query, causing 500 errors

## Changes

- **`useDateParameters.ts`**: Falls back to raw date timestamp when `localToUtc` produces `NaN`, ensuring valid numeric values are always sent
- **`url.ts`**: Added `Number.isNaN(value)` check in `getQueryString` to prevent `NaN` values from being sent as query parameters

## Test plan

- [ ] Verify event charts render correctly in Firefox
- [ ] Verify event charts still work in Chrome/Safari
- [ ] Test with different timezones configured
- [ ] Verify `/events`, `/events/series`, and `/event-data/properties` endpoints return valid data