### PR TITLE
fix: make username login case-insensitive

### DIFF
--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -59,14 +59,14 @@ export async function POST(request: Request, { params }: { params: Promise<{ use
   }
 
   if (username && auth.user.isAdmin) {
-    data.username = username;
+    data.username = username.toLowerCase();
   }
 
   // Check when username changes
   if (data.username && user.username !== data.username) {
-    const user = await getUserByUsername(username);
+    const existingUser = await getUserByUsername(data.username);
 
-    if (user) {
+    if (existingUser && existingUser.id !== userId) {
       return badRequest({ message: 'User already exists' });
     }
   }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
 
   const user = await createUser({
     id: id || uuid(),
-    username,
+    username: username.toLowerCase(),
     password: hashPassword(password),
     role: role ?? ROLES.user,
   });

--- a/src/queries/prisma/user.ts
+++ b/src/queries/prisma/user.ts
@@ -42,7 +42,7 @@ export async function getUser(userId: string, options: GetUserOptions = {}) {
 }
 
 export async function getUserByUsername(username: string, options: GetUserOptions = {}) {
-  return findUser({ where: { username } }, options);
+  return findUser({ where: { username: username.toLowerCase() } }, options);
 }
 
 export async function getUsers(criteria: UserFindManyArgs, filters: QueryFilters = {}) {


### PR DESCRIPTION
## Summary

Normalizes usernames to lowercase on lookup, creation, and update so that login is case-insensitive. Users can now sign in with `Admin`, `admin`, or `ADMIN` and reach the same account.

## Issue

Fixes #3981

## Changes

- `getUserByUsername()` — lowercase the input before querying so lookups are case-insensitive
- User creation — store username in lowercase
- User update — store username in lowercase; fix variable shadowing (`const user` → `const existingUser`) and allow same-user casing changes without false "already exists" error

## Note

A previous fix (#4048) was reverted because it included unrelated formatting changes. This PR contains **only** the logic changes — no quote-style or whitespace modifications.

### Post-merge migration

Existing mixed-case usernames should be lowercased:

```sql
UPDATE "user" SET username = LOWER(username) WHERE username != LOWER(username);
```

## Testing

- Login with uppercase/mixed-case variant of existing username
- Create a new user and verify it is stored lowercase
- Update a username and verify it is stored lowercase
- Verify uniqueness is enforced case-insensitively