### PR TITLE
fix(i18n): update country name from Turkey to Türkiye

### DIFF
--- a/public/intl/country/en-GB.json
+++ b/public/intl/country/en-GB.json
@@ -227,7 +227,7 @@
   "TO": "Tonga",
   "TT": "Trinidad & Tobago",
   "TN": "Tunisia",
-  "TR": "Turkey",
+  "TR": "T\u00fcrkiye",
   "TM": "Turkmenistan",
   "TC": "Turks & Caicos Islands",
   "TV": "Tuvalu",

--- a/public/intl/country/en-US.json
+++ b/public/intl/country/en-US.json
@@ -227,7 +227,7 @@
   "TO": "Tonga",
   "TT": "Trinidad & Tobago",
   "TN": "Tunisia",
-  "TR": "Turkey",
+  "TR": "T\u00fcrkiye",
   "TM": "Turkmenistan",
   "TC": "Turks & Caicos Islands",
   "TV": "Tuvalu",


### PR DESCRIPTION
- Updates the English locale to reflect the official 2022 ISO 3166-1 name change.
- Uses the \u00fc Unicode escape sequence to ensure safe rendering.