### PR TITLE
4168 - Fix for 'Dashboard and Board Editing in Firefox Isn't Working'

### DIFF
--- a/src/app/(main)/boards/[boardId]/BoardEditBody.tsx
+++ b/src/app/(main)/boards/[boardId]/BoardEditBody.tsx
@@ -110,8 +110,8 @@ export function BoardEditBody({ requiresBoardWebsite = true }: { requiresBoardWe
   const minHeight = (rows.length || 1) * MAX_ROW_HEIGHT + BUTTON_ROW_HEIGHT;
 
   return (
-    <Box minHeight={`${minHeight}px`}>
-      <Group groupRef={rowGroupRef} orientation="vertical">
+    <Box>
+      <Group style={{ minHeight: `${minHeight}px` }} groupRef={rowGroupRef} orientation="vertical">
         {rows.map((row, index) => (
           <Fragment key={`${row.id}:${row.size ?? 'auto'}`}>
             <Panel


### PR DESCRIPTION
HI Team,

This is a fix for the issue https://github.com/umami-software/umami/issues/4168

As discussed there, I don’t think the min height is causing the issue. I checked the ‘react-resizable-panels’  documentation. Even the example there has a the same styling. However I noticed the minimum height set at group level. They have a class ''min-h-30'. Please refer the below screenshot

<img width="1900" height="907" alt="Screenshot 2026-04-20 at 9 13 06 AM" src="https://github.com/user-attachments/assets/5ee4747f-a8b3-40b2-a540-2e68d5221a58" />


Hence I tried moving the min height that was set from Box to Group. This solved the issue. Checked in Firefox,Safari,Chrome. Please find the before vs after below

Before:

<img width="1905" height="878" alt="Screenshot 2026-04-20 at 9 10 03 AM" src="https://github.com/user-attachments/assets/92cce010-1e13-4212-8fd6-1c2a1bf16720" />

After:

<img width="1916" height="917" alt="Screenshot 2026-04-20 at 9 04 35 AM" src="https://github.com/user-attachments/assets/96525373-8d0e-4ba1-9288-1c8b3bfeb87b" />


PS: Future enhancements can be made to handle this in a better way.  But for now this is simple fix looks good to me for the raised issue
