### PR TITLE
fix: fixes #4186

### DIFF
--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -67,7 +67,8 @@ async function checkDatabaseVersion() {
 
 async function applyMigration() {
   if (!process.env.SKIP_DB_MIGRATION) {
-    console.log(execSync('prisma migrate deploy').toString());
+    const directUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+    console.log(execSync('prisma migrate deploy', { env: { ...process.env, DATABASE_URL: directUrl } }).toString());
 
     success('Database is up to date.');
   }


### PR DESCRIPTION
Some database providers, like supabase, provides two URLs to access the database. A main URL behind pgBouncer's for load balancing, and a direct separated URL to perform migrations (running DDL operations), as does not support advisory locks or multi-statement DDL required by migrations.

Before v3.1.0, adding `directUrl` along with `url` to `prisma/schema.prisma` was enought.

Now, I'm making a commit to use direct URL when set (env variable `DIRECT_DATABASE_URL` exists and is not empty). Otherwise, default to the already existing `DATABASE_URL`. This should work for all deployments, so it shouldn't break anything, while fixing the current issue with some providers

Fixes #4186 