### PR TITLE
feat: enhance global configuration handling and improve attribute retrieval logic

### DIFF
--- a/src/recorder/index.js
+++ b/src/recorder/index.js
@@ -5,9 +5,18 @@ import { record } from 'rrweb';
   const { currentScript } = document;
   if (!currentScript) return;
 
+  const globalConfig = window.umamiConfig || {};
   const _data = 'data-';
   const attr = currentScript.getAttribute.bind(currentScript);
-  const config = value => attr(`${_data}${value}`);
+  const toCamelCase = str => str.replace(/-([a-z])/g, g => g[1].toUpperCase());
+  const config = value => {
+    const camelKey = toCamelCase(value);
+    if (globalConfig[camelKey] != null) {
+      const v = globalConfig[camelKey];
+      return typeof v === 'function' ? v : Array.isArray(v) ? v.join(',') : String(v);
+    }
+    return attr(`${_data}${value}`);
+  };
 
   const website = config(`website-id`);
   const hostUrl = config(`host-url`);

--- a/src/recorder/index.js
+++ b/src/recorder/index.js
@@ -13,7 +13,7 @@ import { record } from 'rrweb';
     const camelKey = toCamelCase(value);
     if (globalConfig[camelKey] != null) {
       const v = globalConfig[camelKey];
-      return typeof v === 'function' ? v : Array.isArray(v) ? v.join(',') : String(v);
+      return Array.isArray(v) ? v.join(',') : String(v);
     }
     return attr(`${_data}${value}`);
   };

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -30,7 +30,7 @@
 
   const config = value => {
     const camelKey = toCamelCase(value);
-    if (globalConfig[camelKey] !== undefined) {
+    if (globalConfig[camelKey] != null) {
       return String(globalConfig[camelKey]);
     }
     return attr(`${_data}${value}`);

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -32,7 +32,7 @@
     const camelKey = toCamelCase(value);
     if (globalConfig[camelKey] != null) {
       const v = globalConfig[camelKey];
-      return typeof v === 'function' ? v : Array.isArray(v) ? v.join(',') : String(v);
+      return value === 'before-send' && typeof v === 'function' ? v : Array.isArray(v) ? v.join(',') : String(v);
     }
     return attr(`${_data}${value}`);
   };

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -9,7 +9,8 @@
     doNotTrack,
   } = window;
   const { currentScript, referrer } = document;
-  if (!currentScript) return;
+  const globalConfig = window.umamiConfig || {};
+  if (!currentScript && !globalConfig.websiteId) return;
 
   const { hostname, href, origin } = location;
 
@@ -23,8 +24,17 @@
   const _data = 'data-';
   const _false = 'false';
   const _true = 'true';
-  const attr = currentScript.getAttribute.bind(currentScript);
-  const config = value => attr(`${_data}${value}`);
+  const attr = currentScript ? currentScript.getAttribute.bind(currentScript) : () => null;
+
+  const toCamelCase = str => str.replace(/-([a-z])/g, g => g[1].toUpperCase());
+
+  const config = value => {
+    const camelKey = toCamelCase(value);
+    if (globalConfig[camelKey] !== undefined) {
+      return String(globalConfig[camelKey]);
+    }
+    return attr(`${_data}${value}`);
+  };
 
   const website = config('website-id');
   const hostUrl = config('host-url');
@@ -40,7 +50,7 @@
 
   const domains = domain.split(',').map(n => n.trim());
   const host =
-    hostUrl || '__COLLECT_API_HOST__' || currentScript.src.split('/').slice(0, -1).join('/');
+    hostUrl || '__COLLECT_API_HOST__' || (currentScript ? currentScript.src.split('/').slice(0, -1).join('/') : '');
   const endpoint = `${host.replace(/\/$/, '')}__COLLECT_API_ENDPOINT__`;
   const screen = `${width}x${height}`;
   const eventRegex = /data-umami-event-([\w-_]+)/;

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -31,7 +31,8 @@
   const config = value => {
     const camelKey = toCamelCase(value);
     if (globalConfig[camelKey] != null) {
-      return String(globalConfig[camelKey]);
+      const v = globalConfig[camelKey];
+      return typeof v === 'function' ? v : Array.isArray(v) ? v.join(',') : String(v);
     }
     return attr(`${_data}${value}`);
   };
@@ -173,7 +174,7 @@
   const send = async (payload, type = 'event') => {
     if (trackingDisabled()) return;
 
-    const callback = window[beforeSend];
+    const callback = typeof beforeSend === 'function' ? beforeSend : window[beforeSend];
 
     if (typeof callback === 'function') {
       payload = await Promise.resolve(callback(type, payload));


### PR DESCRIPTION
This pull request updates the tracker initialization logic to allow configuration via a global `umamiConfig` object in addition to the existing method of using `data-` attributes on the script tag. This makes it possible to initialize the tracker even when the script tag is not present, and allows for more flexible configuration.

Key changes:

**Configuration improvements:**

* Added support for a global `umamiConfig` object to provide configuration values (such as `websiteId` and `hostUrl`) as an alternative to `data-` attributes on the script tag. This enables initialization without requiring the script tag to be present. [[1]](diffhunk://#diff-d8bd372df1c0eb7de6e935b8ad4012a040200d2aa1ae9819719fc6cdeadc4d88L12-R13) [[2]](diffhunk://#diff-d8bd372df1c0eb7de6e935b8ad4012a040200d2aa1ae9819719fc6cdeadc4d88L26-R37)

* Updated the `config` function to prioritize values from `umamiConfig`, falling back to `data-` attributes if not found. Also added a utility to convert config keys from kebab-case to camelCase for compatibility.

**Robustness improvements:**

* Modified logic to safely handle cases where `currentScript` is not available, preventing errors during initialization and when constructing the API host URL. [[1]](diffhunk://#diff-d8bd372df1c0eb7de6e935b8ad4012a040200d2aa1ae9819719fc6cdeadc4d88L12-R13) [[2]](diffhunk://#diff-d8bd372df1c0eb7de6e935b8ad4012a040200d2aa1ae9819719fc6cdeadc4d88L43-R53)


Closes: #4177 