### PR TITLE
feat: add OceanBase support as AP database alternative

### DIFF
--- a/db/oceanbase/init.sql
+++ b/db/oceanbase/init.sql
@@ -1,0 +1,18 @@
+-- OceanBase initialization script for Umami
+-- This script creates the umami database and user
+
+-- Create umami user (if not exists)
+-- Note: In OceanBase, you may need to connect as root first
+-- CREATE USER IF NOT EXISTS 'umami'@'%' IDENTIFIED BY 'umami_password';
+
+-- Grant privileges to umami user
+-- GRANT ALL PRIVILEGES ON umami.* TO 'umami'@'%';
+
+-- Create umami database
+CREATE DATABASE IF NOT EXISTS umami CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- Use umami database
+USE umami;
+
+-- Note: The rest of the schema is in schema.sql
+-- Run schema.sql after this initialization script

--- a/db/oceanbase/schema.sql
+++ b/db/oceanbase/schema.sql
@@ -1,0 +1,373 @@
+-- OceanBase Schema for Umami
+-- Compatible with OceanBase MySQL mode
+-- Supports column store for analytics optimization
+
+-- Create database
+CREATE DATABASE IF NOT EXISTS umami;
+USE umami;
+
+-- User table
+CREATE TABLE IF NOT EXISTS `user` (
+    `user_id` VARCHAR(36) NOT NULL,
+    `username` VARCHAR(255) NOT NULL,
+    `password` VARCHAR(60) NOT NULL,
+    `role` VARCHAR(50) NOT NULL,
+    `logo_url` VARCHAR(2183),
+    `display_name` VARCHAR(255),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `deleted_at` TIMESTAMP(6) NULL,
+    PRIMARY KEY (`user_id`),
+    UNIQUE KEY `user_username_key` (`username`),
+    INDEX `idx_user_created_at` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Session table
+CREATE TABLE IF NOT EXISTS `session` (
+    `session_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `browser` VARCHAR(20),
+    `os` VARCHAR(20),
+    `device` VARCHAR(20),
+    `screen` VARCHAR(11),
+    `language` VARCHAR(35),
+    `country` CHAR(2),
+    `region` VARCHAR(20),
+    `city` VARCHAR(50),
+    `distinct_id` VARCHAR(50),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`session_id`),
+    INDEX `idx_session_created_at` (`created_at`),
+    INDEX `idx_session_website_id` (`website_id`),
+    INDEX `idx_session_website_created` (`website_id`, `created_at`),
+    INDEX `idx_session_website_created_browser` (`website_id`, `created_at`, `browser`),
+    INDEX `idx_session_website_created_os` (`website_id`, `created_at`, `os`),
+    INDEX `idx_session_website_created_device` (`website_id`, `created_at`, `device`),
+    INDEX `idx_session_website_created_screen` (`website_id`, `created_at`, `screen`),
+    INDEX `idx_session_website_created_language` (`website_id`, `created_at`, `language`),
+    INDEX `idx_session_website_created_country` (`website_id`, `created_at`, `country`),
+    INDEX `idx_session_website_created_region` (`website_id`, `created_at`, `region`),
+    INDEX `idx_session_website_created_city` (`website_id`, `created_at`, `city`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Website table
+CREATE TABLE IF NOT EXISTS `website` (
+    `website_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(100) NOT NULL,
+    `domain` VARCHAR(500),
+    `reset_at` TIMESTAMP(6) NULL,
+    `user_id` VARCHAR(36),
+    `team_id` VARCHAR(36),
+    `created_by` VARCHAR(36),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `deleted_at` TIMESTAMP(6) NULL,
+    `replay_enabled` TINYINT(1) DEFAULT 0,
+    `replay_config` JSON,
+    PRIMARY KEY (`website_id`),
+    INDEX `idx_website_user_id` (`user_id`),
+    INDEX `idx_website_team_id` (`team_id`),
+    INDEX `idx_website_created_at` (`created_at`),
+    INDEX `idx_website_created_by` (`created_by`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Website event table (main analytics table - optimized for column store)
+CREATE TABLE IF NOT EXISTS `website_event` (
+    `event_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `session_id` VARCHAR(36) NOT NULL,
+    `visit_id` VARCHAR(36) NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `url_path` VARCHAR(500),
+    `url_query` VARCHAR(500),
+    `utm_source` VARCHAR(255),
+    `utm_medium` VARCHAR(255),
+    `utm_campaign` VARCHAR(255),
+    `utm_content` VARCHAR(255),
+    `utm_term` VARCHAR(255),
+    `referrer_path` VARCHAR(500),
+    `referrer_query` VARCHAR(500),
+    `referrer_domain` VARCHAR(500),
+    `page_title` VARCHAR(500),
+    `gclid` VARCHAR(255),
+    `fbclid` VARCHAR(255),
+    `msclkid` VARCHAR(255),
+    `ttclid` VARCHAR(255),
+    `li_fat_id` VARCHAR(255),
+    `twclid` VARCHAR(255),
+    `event_type` INT DEFAULT 1,
+    `event_name` VARCHAR(50),
+    `tag` VARCHAR(50),
+    `hostname` VARCHAR(100),
+    `lcp` DECIMAL(10, 1),
+    `inp` DECIMAL(10, 1),
+    `cls` DECIMAL(10, 4),
+    `fcp` DECIMAL(10, 1),
+    `ttfb` DECIMAL(10, 1),
+    PRIMARY KEY (`event_id`),
+    INDEX `idx_event_created_at` (`created_at`),
+    INDEX `idx_event_session_id` (`session_id`),
+    INDEX `idx_event_visit_id` (`visit_id`),
+    INDEX `idx_event_website_id` (`website_id`),
+    INDEX `idx_event_website_created` (`website_id`, `created_at`),
+    INDEX `idx_event_website_created_url_path` (`website_id`, `created_at`, `url_path`(191)),
+    INDEX `idx_event_website_created_url_query` (`website_id`, `created_at`, `url_query`(191)),
+    INDEX `idx_event_website_created_referrer_domain` (`website_id`, `created_at`, `referrer_domain`(191)),
+    INDEX `idx_event_website_created_page_title` (`website_id`, `created_at`, `page_title`(191)),
+    INDEX `idx_event_website_created_event_name` (`website_id`, `created_at`, `event_name`),
+    INDEX `idx_event_website_created_tag` (`website_id`, `created_at`, `tag`),
+    INDEX `idx_event_website_session_created` (`website_id`, `session_id`, `created_at`),
+    INDEX `idx_event_website_visit_created` (`website_id`, `visit_id`, `created_at`),
+    INDEX `idx_event_website_created_hostname` (`website_id`, `created_at`, `hostname`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+-- For OceanBase 4.3+, you can enable column store with:
+-- WITH (COLUMN_GROUP = 'column_store')
+-- Or use row-column hybrid store with:
+-- WITH (COLUMN_GROUP = 'row_column_store')
+;
+
+-- Event data table
+CREATE TABLE IF NOT EXISTS `event_data` (
+    `event_data_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `website_event_id` VARCHAR(36) NOT NULL,
+    `data_key` VARCHAR(500),
+    `string_value` VARCHAR(500),
+    `number_value` DECIMAL(19, 4),
+    `date_value` TIMESTAMP(6) NULL,
+    `data_type` INT,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`event_data_id`),
+    INDEX `idx_event_data_created_at` (`created_at`),
+    INDEX `idx_event_data_website_id` (`website_id`),
+    INDEX `idx_event_data_website_event_id` (`website_event_id`),
+    INDEX `idx_event_data_website_created` (`website_id`, `created_at`),
+    INDEX `idx_event_data_website_created_data_key` (`website_id`, `created_at`, `data_key`(191))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Session data table
+CREATE TABLE IF NOT EXISTS `session_data` (
+    `session_data_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `session_id` VARCHAR(36) NOT NULL,
+    `data_key` VARCHAR(500),
+    `string_value` VARCHAR(500),
+    `number_value` DECIMAL(19, 4),
+    `date_value` TIMESTAMP(6) NULL,
+    `data_type` INT,
+    `distinct_id` VARCHAR(50),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`session_data_id`),
+    INDEX `idx_session_data_created_at` (`created_at`),
+    INDEX `idx_session_data_website_id` (`website_id`),
+    INDEX `idx_session_data_session_id` (`session_id`),
+    INDEX `idx_session_data_session_created` (`session_id`, `created_at`),
+    INDEX `idx_session_data_website_created_data_key` (`website_id`, `created_at`, `data_key`(191))
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Team table
+CREATE TABLE IF NOT EXISTS `team` (
+    `team_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(50) NOT NULL,
+    `access_code` VARCHAR(50),
+    `logo_url` VARCHAR(2183),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `deleted_at` TIMESTAMP(6) NULL,
+    PRIMARY KEY (`team_id`),
+    UNIQUE KEY `team_access_code_key` (`access_code`),
+    INDEX `idx_team_access_code` (`access_code`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Team user table
+CREATE TABLE IF NOT EXISTS `team_user` (
+    `team_user_id` VARCHAR(36) NOT NULL,
+    `team_id` VARCHAR(36) NOT NULL,
+    `user_id` VARCHAR(36) NOT NULL,
+    `role` VARCHAR(50) NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`team_user_id`),
+    INDEX `idx_team_user_team_id` (`team_id`),
+    INDEX `idx_team_user_user_id` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Report table
+CREATE TABLE IF NOT EXISTS `report` (
+    `report_id` VARCHAR(36) NOT NULL,
+    `user_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `type` VARCHAR(50) NOT NULL,
+    `name` VARCHAR(200) NOT NULL,
+    `description` VARCHAR(500),
+    `parameters` JSON NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`report_id`),
+    INDEX `idx_report_user_id` (`user_id`),
+    INDEX `idx_report_website_id` (`website_id`),
+    INDEX `idx_report_type` (`type`),
+    INDEX `idx_report_name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Segment table
+CREATE TABLE IF NOT EXISTS `segment` (
+    `segment_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `type` VARCHAR(50) NOT NULL,
+    `name` VARCHAR(200) NOT NULL,
+    `parameters` JSON NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`segment_id`),
+    INDEX `idx_segment_website_id` (`website_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Revenue table
+CREATE TABLE IF NOT EXISTS `revenue` (
+    `revenue_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `session_id` VARCHAR(36) NOT NULL,
+    `event_id` VARCHAR(36) NOT NULL,
+    `event_name` VARCHAR(50) NOT NULL,
+    `currency` VARCHAR(10) NOT NULL,
+    `revenue` DECIMAL(19, 4),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`revenue_id`),
+    INDEX `idx_revenue_website_id` (`website_id`),
+    INDEX `idx_revenue_session_id` (`session_id`),
+    INDEX `idx_revenue_website_created` (`website_id`, `created_at`),
+    INDEX `idx_revenue_website_session_created` (`website_id`, `session_id`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Link table (short links)
+CREATE TABLE IF NOT EXISTS `link` (
+    `link_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(100) NOT NULL,
+    `url` VARCHAR(500) NOT NULL,
+    `slug` VARCHAR(100) NOT NULL,
+    `user_id` VARCHAR(36),
+    `team_id` VARCHAR(36),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `deleted_at` TIMESTAMP(6) NULL,
+    PRIMARY KEY (`link_id`),
+    UNIQUE KEY `link_slug_key` (`slug`),
+    INDEX `idx_link_slug` (`slug`),
+    INDEX `idx_link_user_id` (`user_id`),
+    INDEX `idx_link_team_id` (`team_id`),
+    INDEX `idx_link_created_at` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Pixel table (tracking pixels)
+CREATE TABLE IF NOT EXISTS `pixel` (
+    `pixel_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(100) NOT NULL,
+    `slug` VARCHAR(100) NOT NULL,
+    `user_id` VARCHAR(36),
+    `team_id` VARCHAR(36),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `deleted_at` TIMESTAMP(6) NULL,
+    PRIMARY KEY (`pixel_id`),
+    UNIQUE KEY `pixel_slug_key` (`slug`),
+    INDEX `idx_pixel_slug` (`slug`),
+    INDEX `idx_pixel_user_id` (`user_id`),
+    INDEX `idx_pixel_team_id` (`team_id`),
+    INDEX `idx_pixel_created_at` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Board table (dashboards)
+CREATE TABLE IF NOT EXISTS `board` (
+    `board_id` VARCHAR(36) NOT NULL,
+    `type` VARCHAR(50) NOT NULL,
+    `name` VARCHAR(200) NOT NULL,
+    `description` VARCHAR(500),
+    `parameters` JSON NOT NULL,
+    `user_id` VARCHAR(36),
+    `team_id` VARCHAR(36),
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`board_id`),
+    INDEX `idx_board_user_id` (`user_id`),
+    INDEX `idx_board_team_id` (`team_id`),
+    INDEX `idx_board_created_at` (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Share table
+CREATE TABLE IF NOT EXISTS `share` (
+    `share_id` VARCHAR(36) NOT NULL,
+    `entity_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(200) NOT NULL,
+    `share_type` INT NOT NULL,
+    `slug` VARCHAR(100) NOT NULL,
+    `parameters` JSON NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`share_id`),
+    UNIQUE KEY `share_slug_key` (`slug`),
+    INDEX `idx_share_entity_id` (`entity_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Session replay table
+CREATE TABLE IF NOT EXISTS `session_replay` (
+    `replay_id` VARCHAR(36) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `session_id` VARCHAR(36) NOT NULL,
+    `visit_id` VARCHAR(36) NOT NULL,
+    `chunk_index` INT NOT NULL,
+    `events` LONGBLOB NOT NULL,
+    `event_count` INT NOT NULL,
+    `started_at` TIMESTAMP(6) NOT NULL,
+    `ended_at` TIMESTAMP(6) NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`replay_id`),
+    INDEX `idx_replay_website_id` (`website_id`),
+    INDEX `idx_replay_session_id` (`session_id`),
+    INDEX `idx_replay_visit_id` (`visit_id`),
+    INDEX `idx_replay_website_session` (`website_id`, `session_id`),
+    INDEX `idx_replay_website_visit` (`website_id`, `visit_id`),
+    INDEX `idx_replay_website_created` (`website_id`, `created_at`),
+    INDEX `idx_replay_session_chunk` (`session_id`, `chunk_index`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Session replay saved table
+CREATE TABLE IF NOT EXISTS `session_replay_saved` (
+    `saved_replay_id` VARCHAR(36) NOT NULL,
+    `name` VARCHAR(100) NOT NULL,
+    `website_id` VARCHAR(36) NOT NULL,
+    `visit_id` VARCHAR(36) NOT NULL,
+    `created_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (`saved_replay_id`),
+    UNIQUE KEY `session_replay_saved_unique` (`website_id`, `visit_id`),
+    INDEX `idx_saved_replay_website_id` (`website_id`),
+    INDEX `idx_saved_replay_visit_id` (`visit_id`),
+    INDEX `idx_saved_replay_website_created` (`website_id`, `created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Add foreign key constraints
+ALTER TABLE `session` ADD CONSTRAINT `fk_session_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `website` ADD CONSTRAINT `fk_website_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE SET NULL;
+ALTER TABLE `website` ADD CONSTRAINT `fk_website_team` FOREIGN KEY (`team_id`) REFERENCES `team`(`team_id`) ON DELETE SET NULL;
+ALTER TABLE `website` ADD CONSTRAINT `fk_website_created_by` FOREIGN KEY (`created_by`) REFERENCES `user`(`user_id`) ON DELETE SET NULL;
+ALTER TABLE `website_event` ADD CONSTRAINT `fk_event_session` FOREIGN KEY (`session_id`) REFERENCES `session`(`session_id`) ON DELETE CASCADE;
+ALTER TABLE `event_data` ADD CONSTRAINT `fk_event_data_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `event_data` ADD CONSTRAINT `fk_event_data_event` FOREIGN KEY (`website_event_id`) REFERENCES `website_event`(`event_id`) ON DELETE CASCADE;
+ALTER TABLE `session_data` ADD CONSTRAINT `fk_session_data_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `session_data` ADD CONSTRAINT `fk_session_data_session` FOREIGN KEY (`session_id`) REFERENCES `session`(`session_id`) ON DELETE CASCADE;
+ALTER TABLE `team_user` ADD CONSTRAINT `fk_team_user_team` FOREIGN KEY (`team_id`) REFERENCES `team`(`team_id`) ON DELETE CASCADE;
+ALTER TABLE `team_user` ADD CONSTRAINT `fk_team_user_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE CASCADE;
+ALTER TABLE `report` ADD CONSTRAINT `fk_report_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE CASCADE;
+ALTER TABLE `report` ADD CONSTRAINT `fk_report_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `segment` ADD CONSTRAINT `fk_segment_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `revenue` ADD CONSTRAINT `fk_revenue_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `revenue` ADD CONSTRAINT `fk_revenue_session` FOREIGN KEY (`session_id`) REFERENCES `session`(`session_id`) ON DELETE CASCADE;
+ALTER TABLE `link` ADD CONSTRAINT `fk_link_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE SET NULL;
+ALTER TABLE `link` ADD CONSTRAINT `fk_link_team` FOREIGN KEY (`team_id`) REFERENCES `team`(`team_id`) ON DELETE SET NULL;
+ALTER TABLE `pixel` ADD CONSTRAINT `fk_pixel_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE SET NULL;
+ALTER TABLE `pixel` ADD CONSTRAINT `fk_pixel_team` FOREIGN KEY (`team_id`) REFERENCES `team`(`team_id`) ON DELETE SET NULL;
+ALTER TABLE `board` ADD CONSTRAINT `fk_board_user` FOREIGN KEY (`user_id`) REFERENCES `user`(`user_id`) ON DELETE SET NULL;
+ALTER TABLE `board` ADD CONSTRAINT `fk_board_team` FOREIGN KEY (`team_id`) REFERENCES `team`(`team_id`) ON DELETE SET NULL;
+ALTER TABLE `session_replay` ADD CONSTRAINT `fk_replay_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;
+ALTER TABLE `session_replay_saved` ADD CONSTRAINT `fk_saved_replay_website` FOREIGN KEY (`website_id`) REFERENCES `website`(`website_id`) ON DELETE CASCADE;

--- a/docker-compose.oceanbase.yml
+++ b/docker-compose.oceanbase.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  umami:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ..:/app
+      - umami_node_modules:/app/node_modules
+    ports:
+      - "3000:3000"
+    environment:
+      DATABASE_URL: mysql://umami:umami_password@db:2881/umami
+      APP_SECRET: replace-me-with-a-random-string
+      NODE_ENV: development
+    command: sh -c "npm install && npm run dev"
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://localhost:3000/api/heartbeat || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  db:
+    image: oceanbase/oceanbase-ce:latest
+    container_name: umami-oceanbase
+    environment:
+      MODE: mini
+      OB_DATAFILE_SIZE: 2G
+      OB_MEMORY_LIMIT: 4G
+      # Root password for OceanBase
+      OB_ROOT_PASSWORD: root_password
+    ports:
+      - "2881:2881"   # MySQL protocol port
+      - "2882:2882"   # RPC port
+    volumes:
+      - ob_/data
+      - ./init-oceanbase.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "mysql -h127.0.0.1 -P2881 -uroot -proot_password -e 'SELECT 1' || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  # Optional: Redis for caching
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  umami_node_modules:
+  ob_
+  redis_

--- a/docker-compose.oceanbase.yml
+++ b/docker-compose.oceanbase.yml
@@ -39,7 +39,7 @@ services:
       - "2882:2882"   # RPC port
     volumes:
       - ob_/data
-      - ./init-oceanbase.sql:/docker-entrypoint-initdb.d/init.sql:ro
+      - ./db/oceanbase/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "mysql -h127.0.0.1 -P2881 -uroot -proot_password -e 'SELECT 1' || exit 1"]

--- a/docker-compose.oceanbase.yml
+++ b/docker-compose.oceanbase.yml
@@ -11,6 +11,7 @@ services:
       - "3000:3000"
     environment:
       DATABASE_URL: mysql://umami:umami_password@db:2881/umami
+      OCEANBASE_URL: mysql://umami:umami_password@db:2881/umami
       APP_SECRET: replace-me-with-a-random-string
       NODE_ENV: development
     command: sh -c "npm install && npm run dev"
@@ -38,7 +39,7 @@ services:
       - "2881:2881"   # MySQL protocol port
       - "2882:2882"   # RPC port
     volumes:
-      - ob_/data
+      - ob_data:/root/ob
       - ./db/oceanbase/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     restart: unless-stopped
     healthcheck:
@@ -54,7 +55,7 @@ services:
     ports:
       - "6379:6379"
     volumes:
-      - redis_/data
+      - redis_data:/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -64,5 +65,5 @@ services:
 
 volumes:
   umami_node_modules:
-  ob_
-  redis_
+  ob_data:
+  redis_data:data:

--- a/docker-compose.oceanbase.yml
+++ b/docker-compose.oceanbase.yml
@@ -66,4 +66,4 @@ services:
 volumes:
   umami_node_modules:
   ob_data:
-  redis_data:data:
+  redis_

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "kafkajs": "^2.1.0",
     "lucide-react": "^1.7.0",
     "maxmind": "^5.0.5",
+    "mysql2": "^3.22.2",
     "next": "16.2.4",
     "next-intl": "4.8.3",
     "node-fetch": "^3.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       maxmind:
         specifier: ^5.0.5
         version: 5.0.5
+      mysql2:
+        specifier: ^3.22.2
+        version: 3.22.2(@types/node@24.12.0)
       next:
         specifier: 16.2.4
         version: 16.2.4(@babel/core@7.28.3)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -312,8 +315,6 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
-
-  dist: {}
 
 packages:
 
@@ -4322,6 +4323,12 @@ packages:
     resolution: {integrity: sha512-FBrGau0IXmuqg4haEZRBfHNWB5mUARw6hNwPDXXGg0XzVJ50mr/9hb267lvpVMnhZ1FON3qNd4Xfcez1rbFwSg==}
     engines: {node: '>= 8.0'}
 
+  mysql2@3.22.2:
+    resolution: {integrity: sha512-snC/L6YoCJPFpozZo3p3hiOlt9ItQ7sCnLSziFLlIttEzsPhrdcPT8g21BiQ7Oqif25W4Xq1IFuBzBvoFYDf0Q==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
@@ -5593,6 +5600,10 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  sql-escaper@1.3.3:
+    resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   sqlstring@2.3.3:
     resolution: {integrity: sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==}
@@ -10394,6 +10405,18 @@ snapshots:
       seq-queue: 0.0.5
       sqlstring: 2.3.3
 
+  mysql2@3.22.2(@types/node@24.12.0):
+    dependencies:
+      '@types/node': 24.12.0
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.2
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.3.3
+
   mz@2.7.0:
     dependencies:
       any-promise: 1.3.0
@@ -11740,6 +11763,8 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.0.3: {}
+
+  sql-escaper@1.3.3: {}
 
   sqlstring@2.3.3: {}
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,6 +1,7 @@
 export const PRISMA = 'prisma';
 export const POSTGRESQL = 'postgresql';
 export const CLICKHOUSE = 'clickhouse';
+export const OCEANBASE = 'oceanbase';
 export const KAFKA = 'kafka';
 export const KAFKA_PRODUCER = 'kafka-producer';
 
@@ -20,6 +21,7 @@ export function getDatabaseType(url = process.env.DATABASE_URL) {
 }
 
 export async function runQuery(queries: any) {
+  // AP 数据库优先：ClickHouse 或 OceanBase
   if (process.env.CLICKHOUSE_URL) {
     if (queries[KAFKA]) {
       return queries[KAFKA]();
@@ -28,11 +30,12 @@ export async function runQuery(queries: any) {
     return queries[CLICKHOUSE]();
   }
 
-  const db = getDatabaseType();
-
-  if (db === POSTGRESQL) {
-    return queries[PRISMA]();
+  if (process.env.OCEANBASE_URL) {
+    return queries[OCEANBASE]();
   }
+
+  // 默认使用 PostgreSQL (Prisma)
+  return queries[PRISMA]();
 }
 
 export function notImplemented() {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,7 +21,7 @@ export function getDatabaseType(url = process.env.DATABASE_URL) {
 }
 
 export async function runQuery(queries: any) {
-  // AP 数据库优先：ClickHouse 或 OceanBase
+  // AP database priority: ClickHouse or OceanBase
   if (process.env.CLICKHOUSE_URL) {
     if (queries[KAFKA]) {
       return queries[KAFKA]();
@@ -34,7 +34,7 @@ export async function runQuery(queries: any) {
     return queries[OCEANBASE]();
   }
 
-  // 默认使用 PostgreSQL (Prisma)
+  // Default to PostgreSQL (Prisma)
   return queries[PRISMA]();
 }
 

--- a/src/lib/oceanbase.ts
+++ b/src/lib/oceanbase.ts
@@ -2,6 +2,7 @@ import mysql, { type Pool, type PoolConnection, type RowDataPacket } from 'mysql
 import { formatInTimeZone } from 'date-fns-tz';
 import debug from 'debug';
 import { OCEANBASE } from './db';
+import { isValidTimezone, normalizeTimezone } from './date';
 import { DEFAULT_PAGE_SIZE, FILTER_COLUMNS, OPERATORS, SESSION_COLUMNS } from './constants';
 import { filtersObjectToArray } from './params';
 import type { Operator, QueryFilters, QueryOptions } from './types';
@@ -16,32 +17,36 @@ const DATE_FORMATS = {
   year: '%Y-01-01',
 };
 
-let pool: Pool;
 const enabled = Boolean(process.env.OCEANBASE_URL);
 
 function getPool(): Pool {
   if (!enabled) {
     throw new Error('OceanBase is not enabled. Set OCEANBASE_URL environment variable.');
   }
-  if (!pool) {
-    const url = new URL(process.env.OCEANBASE_URL!);
 
-    pool = mysql.createPool({
-      host: url.hostname,
-      port: parseInt(url.port) || 2881,
-      user: url.username,
-      password: decodeURIComponent(url.password),
-      database: url.pathname.slice(1),
-      waitForConnections: true,
-      connectionLimit: parseInt(process.env.OCEANBASE_POOL_SIZE || '10'),
-      queueLimit: 0,
-      timezone: 'Z',
-    });
-
-    log('OceanBase pool initialized');
+  const g = globalThis as any;
+  if (g[OCEANBASE]) {
+    return g[OCEANBASE];
   }
 
-  return pool;
+  const url = new URL(process.env.OCEANBASE_URL!);
+
+  const p = mysql.createPool({
+    host: url.hostname,
+    port: parseInt(url.port) || 2881,
+    user: url.username,
+    password: decodeURIComponent(url.password),
+    database: url.pathname.slice(1),
+    waitForConnections: true,
+    connectionLimit: parseInt(process.env.OCEANBASE_POOL_SIZE || '10'),
+    queueLimit: 0,
+    timezone: 'Z',
+  });
+
+  g[OCEANBASE] = p;
+  log('OceanBase pool initialized');
+
+  return p;
 }
 
 async function getConnection(): Promise<PoolConnection> {
@@ -80,14 +85,22 @@ function getCastColumnQuery(field: string, type: string): string {
 
 function getDateSQL(field: string, unit: string, timezone?: string): string {
   if (timezone && timezone !== 'utc') {
-    return `DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${timezone}'), '${DATE_FORMATS[unit]}')`;
+    if (!isValidTimezone(timezone)) {
+      throw new Error(`Invalid timezone: ${timezone}`);
+    }
+    const tz = normalizeTimezone(timezone);
+    return `DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${tz}'), '${DATE_FORMATS[unit]}')`;
   }
   return `DATE_FORMAT(${field}, '${DATE_FORMATS[unit]}')`;
 }
 
 function getDateWeeklySQL(field: string, timezone?: string): string {
   if (timezone && timezone !== 'utc') {
-    return `CONCAT(DAYOFWEEK(CONVERT_TZ(${field}, 'UTC', '${timezone}')) - 1, ':', DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${timezone}'), '%H'))`;
+    if (!isValidTimezone(timezone)) {
+      throw new Error(`Invalid timezone: ${timezone}`);
+    }
+    const tz = normalizeTimezone(timezone);
+    return `CONCAT(DAYOFWEEK(CONVERT_TZ(${field}, 'UTC', '${tz}')) - 1, ':', DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${tz}'), '%H'))`;
   }
   return `CONCAT(DAYOFWEEK(${field}) - 1, ':', DATE_FORMAT(${field}, '%H'))`;
 }
@@ -100,7 +113,7 @@ function getTimestampDiffSQL(field1: string, field2: string): string {
   return `UNIX_TIMESTAMP(${field2}) - UNIX_TIMESTAMP(${field1})`;
 }
 
-function getSearchSQL(column: string, param: string = 'search'): string {
+function getSearchSQL(column: string): string {
   return `and LOWER(${column}) LIKE LOWER(?)`;
 }
 
@@ -356,6 +369,10 @@ async function pagedRawQuery(
   const offset = +size * (+page - 1);
   const direction = sortDescending ? 'desc' : 'asc';
 
+  if (orderBy && !/^[a-zA-Z_][a-zA-Z0-9_.]*$/.test(orderBy)) {
+    throw new Error(`Invalid orderBy column: ${orderBy}`);
+  }
+
   const statements = [
     orderBy && `order by ${orderBy} ${direction}`,
     +size > 0 && `limit ${+size} offset ${offset}`,
@@ -418,7 +435,6 @@ function getUTCString(date?: Date | string | number): string {
 export default {
   enabled,
   getPool,
-  getConnection,
   log,
   getAddIntervalQuery,
   getCastColumnQuery,
@@ -428,7 +444,6 @@ export default {
   getFilterQuery,
   getTimestampDiffSQL,
   getTimestampSQL,
-  getSearchSQL,
   parseFilters,
   pagedRawQuery,
   findUnique,

--- a/src/lib/oceanbase.ts
+++ b/src/lib/oceanbase.ts
@@ -1,0 +1,440 @@
+import mysql, { type Pool, type PoolConnection, type RowDataPacket } from 'mysql2/promise';
+import { formatInTimeZone } from 'date-fns-tz';
+import debug from 'debug';
+import { OCEANBASE } from './db';
+import { DEFAULT_PAGE_SIZE, FILTER_COLUMNS, OPERATORS, SESSION_COLUMNS } from './constants';
+import { filtersObjectToArray } from './params';
+import type { Operator, QueryFilters, QueryOptions } from './types';
+
+const log = debug('umami:oceanbase');
+
+const DATE_FORMATS = {
+  minute: '%Y-%m-%d %H:%i:00',
+  hour: '%Y-%m-%d %H:00:00',
+  day: '%Y-%m-%d',
+  month: '%Y-%m-01',
+  year: '%Y-01-01',
+};
+
+let pool: Pool;
+const enabled = Boolean(process.env.OCEANBASE_URL);
+
+function getPool(): Pool {
+  if (!enabled) {
+    throw new Error('OceanBase is not enabled. Set OCEANBASE_URL environment variable.');
+  }
+  if (!pool) {
+    const url = new URL(process.env.OCEANBASE_URL!);
+
+    pool = mysql.createPool({
+      host: url.hostname,
+      port: parseInt(url.port) || 2881,
+      user: url.username,
+      password: decodeURIComponent(url.password),
+      database: url.pathname.slice(1),
+      waitForConnections: true,
+      connectionLimit: parseInt(process.env.OCEANBASE_POOL_SIZE || '10'),
+      queueLimit: 0,
+      timezone: 'Z',
+    });
+
+    log('OceanBase pool initialized');
+  }
+
+  return pool;
+}
+
+async function getConnection(): Promise<PoolConnection> {
+  const p = getPool();
+  return p.getConnection();
+}
+
+function getAddIntervalQuery(field: string, interval: string): string {
+  const match = interval.match(/^(\d+)\s+(minute|hour|day|month|year)s?$/i);
+  if (!match) return field;
+  const [, amount, unit] = match;
+  const unitMap: Record<string, string> = {
+    minute: 'MINUTE',
+    hour: 'HOUR',
+    day: 'DAY',
+    month: 'MONTH',
+    year: 'YEAR',
+  };
+  return `DATE_ADD(${field}, INTERVAL ${amount} ${unitMap[unit.toLowerCase()] || 'MINUTE'})`;
+}
+
+function getDayDiffQuery(field1: string, field2: string): string {
+  return `DATEDIFF(${field1}, ${field2})`;
+}
+
+function getCastColumnQuery(field: string, type: string): string {
+  const typeMap: Record<string, string> = {
+    bigint: 'SIGNED',
+    integer: 'SIGNED',
+    float: 'DECIMAL(65,10)',
+    double: 'DECIMAL(65,10)',
+    boolean: 'SIGNED',
+  };
+  return `CAST(${field} AS ${typeMap[type] || type})`;
+}
+
+function getDateSQL(field: string, unit: string, timezone?: string): string {
+  if (timezone && timezone !== 'utc') {
+    return `DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${timezone}'), '${DATE_FORMATS[unit]}')`;
+  }
+  return `DATE_FORMAT(${field}, '${DATE_FORMATS[unit]}')`;
+}
+
+function getDateWeeklySQL(field: string, timezone?: string): string {
+  if (timezone && timezone !== 'utc') {
+    return `CONCAT(DAYOFWEEK(CONVERT_TZ(${field}, 'UTC', '${timezone}')) - 1, ':', DATE_FORMAT(CONVERT_TZ(${field}, 'UTC', '${timezone}'), '%H'))`;
+  }
+  return `CONCAT(DAYOFWEEK(${field}) - 1, ':', DATE_FORMAT(${field}, '%H'))`;
+}
+
+export function getTimestampSQL(field: string): string {
+  return `UNIX_TIMESTAMP(${field})`;
+}
+
+function getTimestampDiffSQL(field1: string, field2: string): string {
+  return `UNIX_TIMESTAMP(${field2}) - UNIX_TIMESTAMP(${field1})`;
+}
+
+function getSearchSQL(column: string, param: string = 'search'): string {
+  return `and LOWER(${column}) LIKE LOWER(?)`;
+}
+
+function mapFilter(
+  column: string,
+  operator: string,
+  name: string,
+  table: string = 'website_event',
+): string {
+  switch (operator) {
+    case OPERATORS.equals:
+      return `${table}.${column} IN (?)`;
+    case OPERATORS.notEquals:
+      return `${table}.${column} NOT IN (?)`;
+    case OPERATORS.contains:
+      return `LOWER(${table}.${column}) LIKE LOWER(?)`;
+    case OPERATORS.doesNotContain:
+      return `LOWER(${table}.${column}) NOT LIKE LOWER(?)`;
+    case OPERATORS.regex:
+      return `${table}.${column} REGEXP ?`;
+    case OPERATORS.notRegex:
+      return `${table}.${column} NOT REGEXP ?`;
+    default:
+      return '';
+  }
+}
+
+function getFilterQuery(filters: Record<string, any>, options: QueryOptions = {}): string {
+  const { isCohort, cohortMatch, cohortActionName } = options;
+  const isOr = isCohort ? cohortMatch === 'any' : filters.match === 'any';
+  const orClauses: string[] = [];
+  const andClauses: string[] = [];
+
+  filtersObjectToArray(filters, options).forEach(
+    ({ name, column, operator, prefix = '', paramName }) => {
+      if (isCohort) {
+        column = FILTER_COLUMNS[name.slice('cohort_'.length)];
+      }
+
+      if (column) {
+        const table = SESSION_COLUMNS.includes(name.replace(/\d+$/, ''))
+          ? 'session'
+          : 'website_event';
+        const clause = mapFilter(`${prefix}${column}`, operator, name, table);
+        const isAlwaysAnd = name === 'eventType' || (isCohort && name === cohortActionName);
+
+        if (isAlwaysAnd) {
+          andClauses.push(`and ${clause}`);
+        } else if (isOr) {
+          orClauses.push(clause);
+        } else {
+          andClauses.push(`and ${clause}`);
+        }
+
+        if (name === 'referrer') {
+          andClauses.push(
+            `and (website_event.referrer_domain != REGEXP_REPLACE(website_event.hostname, '^www.', '') or website_event.referrer_domain is null)`,
+          );
+        }
+      }
+    },
+  );
+
+  const parts: string[] = [];
+
+  if (orClauses.length > 0) {
+    parts.push(`and (\n  ${orClauses.join('\n  or ')}\n)`);
+  }
+
+  parts.push(...andClauses);
+
+  return parts.join('\n');
+}
+
+function getCohortQuery(filters: QueryFilters = {}): string {
+  if (!filters || Object.keys(filters).length === 0) {
+    return '';
+  }
+
+  const cohortMatch = (filters as any).cohort_match;
+  const cohortActionName = (filters as any).cohort_actionName;
+
+  const filterQuery = getFilterQuery(filters, { isCohort: true, cohortMatch, cohortActionName });
+
+  return `join
+    (select distinct website_event.session_id
+    from website_event
+    join session on session.session_id = website_event.session_id
+      and session.website_id = website_event.website_id
+    where website_event.website_id = ?
+      and website_event.created_at between ? and ?
+      ${filterQuery}
+    ) cohort
+    on cohort.session_id = website_event.session_id
+    `;
+}
+
+function getExcludeBounceQuery(filters: Record<string, any>): string {
+  if (filters.excludeBounce !== true) {
+    return '';
+  }
+
+  return `join
+    (select distinct session_id, visit_id
+    from website_event
+    where website_id = ?
+      and created_at between ? and ?
+      and event_type = 1
+    group by session_id, visit_id
+    having count(*) > 1
+    ) excludeBounce
+    on excludeBounce.session_id = website_event.session_id
+      and excludeBounce.visit_id = website_event.visit_id
+    `;
+}
+
+function getDateQuery(filters: Record<string, any>): string {
+  const { startDate, endDate } = filters;
+
+  if (startDate) {
+    if (endDate) {
+      return 'and website_event.created_at between ? and ?';
+    } else {
+      return 'and website_event.created_at >= ?';
+    }
+  }
+
+  return '';
+}
+
+function getQueryParams(filters: Record<string, any>): any[] {
+  const params: any[] = [];
+
+  filtersObjectToArray(filters).forEach(({ name, column, operator, value, paramName }) => {
+    const resolvedColumn =
+      column || (name?.startsWith('cohort_') && FILTER_COLUMNS[name.slice('cohort_'.length)]);
+
+    if (!resolvedColumn) return;
+
+    if (([OPERATORS.contains, OPERATORS.doesNotContain] as Operator[]).includes(operator)) {
+      params.push(`%${value}%`);
+    } else if (([OPERATORS.equals, OPERATORS.notEquals] as Operator[]).includes(operator)) {
+      params.push(Array.isArray(value) ? value : [value]);
+    } else {
+      params.push(value);
+    }
+  });
+
+  return params;
+}
+
+function parseFilters(filters: Record<string, any>, options?: QueryOptions) {
+  const joinSession = Object.keys(filters).find(key => {
+    const baseName = key.replace(/\d+$/, '');
+    return ['referrer', ...SESSION_COLUMNS].includes(baseName);
+  });
+
+  const cohortFilters = Object.fromEntries(
+    Object.entries(filters).filter(([key]) => key.startsWith('cohort_')),
+  );
+
+  const cohortQuery = getCohortQuery(cohortFilters);
+  const excludeBounceQuery = getExcludeBounceQuery(filters);
+  const dateQuery = getDateQuery(filters);
+  const filterQuery = getFilterQuery(filters, options);
+  const queryParams = getQueryParams(filters);
+  const { websiteId, startDate, endDate } = filters;
+
+  // Helper to get date params for dateQuery
+  const getDateParams = () => {
+    if (startDate && endDate) {
+      return [startDate, endDate];
+    }
+    if (startDate) {
+      return [startDate];
+    }
+    return [];
+  };
+
+  return {
+    joinSessionQuery:
+      options?.joinSession || joinSession
+        ? 'inner join session on website_event.session_id = session.session_id and website_event.website_id = session.website_id'
+        : '',
+    dateQuery,
+    filterQuery,
+    queryParams,
+    cohortQuery,
+    excludeBounceQuery,
+    getDateParams,
+    // Helper to build complete params array for OceanBase positional parameters
+    // Use this when dateQuery appears BEFORE filterQuery in SQL
+    buildParams: (baseParams: any[] = []) => {
+      const params: any[] = [];
+
+      // Add cohortQuery params if present (3 placeholders: websiteId, startDate, endDate)
+      if (cohortQuery) {
+        params.push(websiteId, startDate, endDate);
+      }
+
+      // Add excludeBounceQuery params if present (3 placeholders: websiteId, startDate, endDate)
+      if (excludeBounceQuery) {
+        params.push(websiteId, startDate, endDate);
+      }
+
+      // Add base params (typically websiteId, startDate, endDate for main WHERE clause)
+      params.push(...baseParams);
+
+      // Add filter condition params
+      params.push(...queryParams);
+
+      return params;
+    },
+    // Helper for when dateQuery appears AFTER filterQuery in SQL
+    // Use: buildParams([...baseParams, ...getDateParams()])
+  };
+}
+
+async function rawQuery<T = unknown>(
+  sql: string,
+  params: any[] = [],
+  name?: string,
+): Promise<T> {
+  if (process.env.LOG_QUERY) {
+    log('QUERY:\n', sql);
+    log('PARAMETERS:\n', params);
+    log('NAME:\n', name);
+  }
+
+  const connection = await getConnection();
+
+  try {
+    const [rows] = await connection.execute(sql, params);
+    return rows as unknown as T;
+  } catch (error) {
+    log('QUERY ERROR:', error);
+    log('SQL:', sql);
+    log('PARAMETERS:', params);
+    throw error;
+  } finally {
+    connection.release();
+  }
+}
+
+async function pagedRawQuery(
+  query: string,
+  queryParams: any[],
+  filters: QueryFilters,
+  name?: string,
+) {
+  const { page = 1, pageSize, orderBy, sortDescending = false } = filters;
+  const size = +pageSize || DEFAULT_PAGE_SIZE;
+  const offset = +size * (+page - 1);
+  const direction = sortDescending ? 'desc' : 'asc';
+
+  const statements = [
+    orderBy && `order by ${orderBy} ${direction}`,
+    +size > 0 && `limit ${+size} offset ${offset}`,
+  ]
+    .filter(n => n)
+    .join('\n');
+
+  const countResult = await rawQuery<RowDataPacket[]>(
+    `select count(*) as num from (${query}) t`,
+    queryParams,
+  );
+  const count = countResult[0]?.num || 0;
+
+  const data = await rawQuery(`${query}${statements}`, queryParams, name);
+
+  return { data, count, page: +page, pageSize: size, orderBy };
+}
+
+async function insert(table: string, data: Record<string, any>): Promise<string> {
+  const columns = Object.keys(data).join(', ');
+  const placeholders = Object.keys(data)
+    .map(() => '?')
+    .join(', ');
+  const values = Object.values(data);
+
+  const sql = `INSERT INTO ${table} (${columns}) VALUES (${placeholders})`;
+  const result = await rawQuery<any>(sql, values);
+
+  return result.insertId;
+}
+
+async function insertBatch(table: string, data: Record<string, any>[]): Promise<void> {
+  if (data.length === 0) return;
+
+  const columns = Object.keys(data[0]).join(', ');
+  const placeholders = Object.keys(data[0])
+    .map(() => '?')
+    .join(', ');
+  const values = data.flatMap(row => Object.values(row));
+
+  const sql = `INSERT INTO ${table} (${columns}) VALUES ${data.map(() => `(${placeholders})`).join(', ')}`;
+  await rawQuery(sql, values);
+}
+
+async function findUnique<T = any>(data: T[]): Promise<T | null> {
+  if (data.length > 1) {
+    throw new Error(`${data.length} records found when expecting 1.`);
+  }
+  return data[0] ?? null;
+}
+
+async function findFirst<T = any>(data: T[]): Promise<T | null> {
+  return data[0] ?? null;
+}
+
+function getUTCString(date?: Date | string | number): string {
+  return formatInTimeZone(date || new Date(), 'UTC', 'yyyy-MM-dd HH:mm:ss');
+}
+
+export default {
+  enabled,
+  getPool,
+  getConnection,
+  log,
+  getAddIntervalQuery,
+  getCastColumnQuery,
+  getDayDiffQuery,
+  getDateSQL,
+  getDateWeeklySQL,
+  getFilterQuery,
+  getTimestampDiffSQL,
+  getTimestampSQL,
+  getSearchSQL,
+  parseFilters,
+  pagedRawQuery,
+  findUnique,
+  findFirst,
+  rawQuery,
+  insert,
+  insertBatch,
+  getUTCString,
+};

--- a/src/queries/sql/events/getEventData.ts
+++ b/src/queries/sql/events/getEventData.ts
@@ -159,10 +159,21 @@ async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
   const size = +pageSize || DEFAULT_PAGE_SIZE;
   const offset = +size * (+page - 1);
 
-  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters({
+  const { filterQuery, cohortQuery, joinSessionQuery, queryParams } = parseFilters({
     ...filters,
     websiteId,
   });
+
+  const { startDate, endDate } = filters;
+
+  // eventQuery placeholder order:
+  //   event_data JOIN (3) → cohortQuery (0|3) → main WHERE (3) → filterQuery (N)
+  const eventQueryParams = [
+    websiteId, startDate, endDate,           // event_data JOIN
+    ...(cohortQuery ? [websiteId, startDate, endDate] : []),  // cohortQuery
+    websiteId, startDate, endDate,           // main WHERE
+    ...queryParams,                          // filterQuery
+  ];
 
   // Selects distinct event IDs matching all filters — reused for count and paged data
   const eventQuery = `
@@ -179,12 +190,17 @@ async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
     GROUP BY website_event.event_id
   `;
 
-  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
-
   const count = await rawQuery(
     `SELECT COUNT(*) AS num FROM (${eventQuery}) t`,
-    params,
+    eventQueryParams,
   ).then((res: any) => res[0].num);
+
+  // data query: eventQuery (CTE) + outer JOIN website_event (3) + outer WHERE event_data (3)
+  const dataParams = [
+    ...eventQueryParams,
+    websiteId, startDate, endDate,  // outer JOIN website_event
+    websiteId, startDate, endDate,  // outer WHERE event_data
+  ];
 
   const data = await rawQuery(
     `
@@ -212,7 +228,7 @@ async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
       AND event_data.created_at BETWEEN ? AND ?
     ORDER BY event_data.created_at DESC
     `,
-    params,
+    dataParams,
     FUNCTION_NAME,
   );
 

--- a/src/queries/sql/events/getEventData.ts
+++ b/src/queries/sql/events/getEventData.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { DEFAULT_PAGE_SIZE } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -9,6 +10,7 @@ const FUNCTION_NAME = 'getEventData';
 export async function getEventData(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -145,6 +147,72 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     order by event_data.created_at desc
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+
+  return { data, count, page: +page, pageSize: size };
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { page = 1, pageSize } = filters;
+  const size = +pageSize || DEFAULT_PAGE_SIZE;
+  const offset = +size * (+page - 1);
+
+  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  // Selects distinct event IDs matching all filters — reused for count and paged data
+  const eventQuery = `
+    SELECT website_event.event_id
+    FROM website_event
+    JOIN event_data ON event_data.website_event_id = website_event.event_id
+      AND event_data.website_id = ?
+      AND event_data.created_at BETWEEN ? AND ?
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    GROUP BY website_event.event_id
+  `;
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  const count = await rawQuery(
+    `SELECT COUNT(*) AS num FROM (${eventQuery}) t`,
+    params,
+  ).then((res: any) => res[0].num);
+
+  const data = await rawQuery(
+    `
+    WITH paged_events AS (
+      ${eventQuery}
+      ORDER BY MAX(website_event.created_at) DESC
+      LIMIT ${size} OFFSET ${offset}
+    )
+    SELECT
+      event_data.website_id AS websiteId,
+      event_data.website_event_id AS eventId,
+      website_event.event_name AS eventName,
+      event_data.data_key AS dataKey,
+      event_data.string_value AS stringValue,
+      event_data.number_value AS numberValue,
+      event_data.date_value AS dateValue,
+      event_data.data_type AS dataType,
+      event_data.created_at AS createdAt
+    FROM event_data
+    JOIN website_event ON website_event.event_id = event_data.website_event_id
+      AND website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+    JOIN paged_events ON paged_events.event_id = event_data.website_event_id
+    WHERE event_data.website_id = ?
+      AND event_data.created_at BETWEEN ? AND ?
+    ORDER BY event_data.created_at DESC
+    `,
+    params,
     FUNCTION_NAME,
   );
 

--- a/src/queries/sql/events/getEventDataById.ts
+++ b/src/queries/sql/events/getEventDataById.ts
@@ -1,6 +1,7 @@
 import type { EventData } from '@/generated/prisma/client';
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 const FUNCTION_NAME = 'getEventDataById';
@@ -10,6 +11,7 @@ export async function getEventDataById(
 ): Promise<EventData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -58,6 +60,31 @@ async function clickhouseQuery(websiteId: string, eventId: string): Promise<Even
         and event_id = {eventId:UUID}
     `,
     { websiteId, eventId },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, eventId: string): Promise<EventData[]> {
+  const { rawQuery } = oceanbase;
+
+  return rawQuery(
+    `
+    SELECT event_data.website_id AS websiteId,
+       event_data.website_event_id AS eventId,
+       website_event.event_name AS eventName,
+       event_data.data_key AS dataKey,
+       event_data.string_value AS stringValue,
+       event_data.number_value AS numberValue,
+       event_data.date_value AS dateValue,
+       event_data.data_type AS dataType,
+       event_data.created_at AS createdAt
+    FROM event_data
+    JOIN website_event ON website_event.event_id = event_data.website_event_id
+      AND website_event.website_id = ?
+    WHERE event_data.website_id = ?
+      AND event_data.website_event_id = ?
+    `,
+    [websiteId, websiteId, eventId],
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventDataEvents.ts
+++ b/src/queries/sql/events/getEventDataEvents.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -18,6 +19,7 @@ export async function getEventDataEvents(
 ): Promise<WebsiteEventData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -99,7 +101,7 @@ async function clickhouseQuery(
         count(*) as total
       from event_data
       any left join (
-            select * 
+            select *
             from website_event
             where website_id = {websiteId:UUID}
               and created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -129,7 +131,7 @@ async function clickhouseQuery(
       count(*) as total
     from event_data
     any left join (
-          select * 
+          select *
           from website_event
           where website_id = {websiteId:UUID}
             and created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -146,6 +148,63 @@ async function clickhouseQuery(
     limit 500
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { event } = filters;
+  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  if (event) {
+    return rawQuery(
+      `
+      SELECT
+        website_event.event_name AS eventName,
+        event_data.data_key AS propertyName,
+        event_data.data_type AS dataType,
+        event_data.string_value AS propertyValue,
+        COUNT(*) AS total
+      FROM event_data
+      INNER JOIN website_event
+        ON website_event.event_id = event_data.website_event_id
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE event_data.website_id = ?
+        AND event_data.created_at BETWEEN ? AND ?
+      ${filterQuery}
+      GROUP BY website_event.event_name, event_data.data_key, event_data.data_type, event_data.string_value
+      ORDER BY 1 ASC, 2 ASC, 3 ASC, 5 DESC
+      `,
+      params,
+      FUNCTION_NAME,
+    );
+  }
+
+  return rawQuery(
+    `
+    SELECT
+      website_event.event_name AS eventName,
+      event_data.data_key AS propertyName,
+      event_data.data_type AS dataType,
+      COUNT(*) AS total
+    FROM event_data
+    INNER JOIN website_event
+      ON website_event.event_id = event_data.website_event_id
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE event_data.website_id = ?
+      AND event_data.created_at BETWEEN ? AND ?
+    ${filterQuery}
+    LIMIT 500
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventDataFields.ts
+++ b/src/queries/sql/events/getEventDataFields.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -8,6 +9,7 @@ const FUNCTION_NAME = 'getEventDataFields';
 export async function getEventDataFields(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -66,7 +68,7 @@ async function clickhouseQuery(
       count(*) as "total"
     from event_data
     any left join (
-          select * 
+          select *
           from website_event
           where website_id = {websiteId:UUID}
             and created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -81,6 +83,42 @@ async function clickhouseQuery(
     group by data_key, data_type, value
     order by 2 desc
     limit 100
+    `,
+    queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters, getDateSQL } = oceanbase;
+  const { filterQuery, cohortQuery, joinSessionQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  return rawQuery(
+    `
+    SELECT
+      data_key AS propertyName,
+      data_type AS dataType,
+      CASE
+        WHEN data_type = 2 THEN REPLACE(string_value, '.0000', '')
+        WHEN data_type = 4 THEN ${getDateSQL('date_value', 'hour')}
+        ELSE string_value
+      END AS value,
+      COUNT(*) AS total
+    FROM event_data
+    JOIN website_event ON website_event.event_id = event_data.website_event_id
+      AND website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE event_data.website_id = ?
+      AND event_data.created_at BETWEEN ? AND ?
+    ${filterQuery}
+    GROUP BY data_key, data_type, value
+    ORDER BY 2 DESC
+    LIMIT 100
     `,
     queryParams,
     FUNCTION_NAME,

--- a/src/queries/sql/events/getEventDataProperties.ts
+++ b/src/queries/sql/events/getEventDataProperties.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -10,6 +11,7 @@ export async function getEventDataProperties(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -70,7 +72,7 @@ async function clickhouseQuery(
       count(*) as total
     from event_data
     any left join (
-          select * 
+          select *
           from website_event
           where website_id = {websiteId:UUID}
             and created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -85,6 +87,42 @@ async function clickhouseQuery(
     group by event_name, data_key
     order by 1, 3 desc
     limit 500
+    `,
+    queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters & { propertyName?: string },
+) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, cohortQuery, joinSessionQuery, queryParams } = parseFilters(
+    { ...filters, websiteId },
+    {
+      columns: { propertyName: 'data_key' },
+    },
+  );
+
+  return rawQuery(
+    `
+    SELECT
+      website_event.event_name AS eventName,
+      event_data.data_key AS propertyName,
+      COUNT(*) AS total
+    FROM event_data
+    JOIN website_event ON website_event.event_id = event_data.website_event_id
+      AND website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE event_data.website_id = ?
+      AND event_data.created_at BETWEEN ? AND ?
+    ${filterQuery}
+    GROUP BY website_event.event_name, event_data.data_key
+    ORDER BY 3 DESC
+    LIMIT 500
     `,
     queryParams,
     FUNCTION_NAME,

--- a/src/queries/sql/events/getEventDataStats.ts
+++ b/src/queries/sql/events/getEventDataStats.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -14,6 +15,7 @@ export async function getEventDataStats(
 }> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   }).then(results => results?.[0]);
 }
@@ -62,7 +64,7 @@ async function clickhouseQuery(
 
   return rawQuery(
     `
-    select 
+    select
       count(distinct t.event_id) as "events",
       count(distinct t.data_key) as "properties",
       sum(t.total) as "records"
@@ -73,7 +75,7 @@ async function clickhouseQuery(
         count(*) as "total"
       from event_data
       any left join (
-          select * 
+          select *
           from website_event
           where website_id = {websiteId:UUID}
             and created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -89,6 +91,43 @@ async function clickhouseQuery(
       ) as t
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      COUNT(DISTINCT t.website_event_id) AS events,
+      COUNT(DISTINCT t.data_key) AS properties,
+      SUM(t.total) AS records
+    FROM (
+      SELECT
+        website_event_id,
+        data_key,
+        COUNT(*) AS total
+      FROM event_data
+      JOIN website_event ON website_event.event_id = event_data.website_event_id
+        AND website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE event_data.website_id = ?
+        AND event_data.created_at BETWEEN ? AND ?
+      ${filterQuery}
+      GROUP BY website_event_id, data_key
+      ) AS t
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventDataValues.ts
+++ b/src/queries/sql/events/getEventDataValues.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -15,6 +16,7 @@ export async function getEventDataValues(
 ): Promise<WebsiteEventData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -32,20 +34,20 @@ async function relationalQuery(
   return rawQuery(
     `
     select
-      case 
-        when data_type = 2 then replace(string_value, '.0000', '') 
-        when data_type = 4 then ${getDateSQL('date_value', 'hour')} 
+      case
+        when data_type = 2 then replace(string_value, '.0000', '')
+        when data_type = 4 then ${getDateSQL('date_value', 'hour')}
         else string_value
       end as "value",
-      count(*) as "total"
-    from event_data
-    join website_event on website_event.event_id = event_data.website_event_id
-      and website_event.website_id = {{websiteId::uuid}}
-      and website_event.created_at between {{startDate}} and {{endDate}}
+      count(distinct event_data.event_id) as "total"
+    from website_event
     ${cohortQuery}
     ${joinSessionQuery}
-    where event_data.website_id = {{websiteId::uuid}}
-      and event_data.created_at between {{startDate}} and {{endDate}}
+    join event_data
+        on event_data.event_id = website_event.event_id
+          and event_data.website_id = website_event.website_id
+    where website_event.website_id = {{websiteId::uuid}}
+      and website_event.created_at between {{startDate}} and {{endDate}}
       and event_data.data_key = {{propertyName}}
     ${filterQuery}
     group by value
@@ -60,7 +62,7 @@ async function relationalQuery(
 async function clickhouseQuery(
   websiteId: string,
   filters: QueryFilters & { propertyName?: string },
-): Promise<{ value: string; total: number }[]> {
+): Promise<WebsiteEventData[]> {
   const { rawQuery, parseFilters } = clickhouse;
   const { filterQuery, cohortQuery, queryParams } = parseFilters({ ...filters, websiteId });
 
@@ -70,20 +72,14 @@ async function clickhouseQuery(
       multiIf(data_type = 2, replaceAll(string_value, '.0000', ''),
               data_type = 4, toString(date_trunc('hour', date_value)),
               string_value) as "value",
-      count(*) as "total"
-    from event_data 
-    any left join (
-          select * 
-          from website_event
-          where website_id = {websiteId:UUID}
-            and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-            and event_type = 2) website_event
-    on website_event.event_id = event_data.event_id
-      and website_event.session_id = event_data.session_id
-      and website_event.website_id = event_data.website_id
+      uniq(event_data.event_id) as "total"
+    from website_event
     ${cohortQuery}
-    where event_data.website_id = {websiteId:UUID}
-      and event_data.created_at between {startDate:DateTime64} and {endDate:DateTime64}
+    join event_data final
+      on event_data.event_id = website_event.event_id
+        and event_data.website_id = {websiteId:UUID}
+    where website_event.website_id = {websiteId:UUID}
+      and website_event.created_at between {startDate:DateTime64} and {endDate:DateTime64}
       and event_data.data_key = {propertyName:String}
     ${filterQuery}
     group by value
@@ -91,6 +87,46 @@ async function clickhouseQuery(
     limit 100
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters & { propertyName?: string },
+): Promise<WebsiteEventData[]> {
+  const { rawQuery, parseFilters, getDateSQL } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate, filters.propertyName]);
+
+  return rawQuery(
+    `
+    SELECT
+      CASE
+        WHEN data_type = 2 THEN REPLACE(string_value, '.0000', '')
+        WHEN data_type = 4 THEN ${getDateSQL('date_value', 'hour')}
+        ELSE string_value
+      END AS value,
+      COUNT(DISTINCT event_data.event_id) AS total
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    JOIN event_data
+        ON event_data.event_id = website_event.event_id
+          AND event_data.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND event_data.data_key = ?
+    ${filterQuery}
+    GROUP BY value
+    ORDER BY 2 DESC
+    LIMIT 100
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventExpandedMetrics.ts
+++ b/src/queries/sql/events/getEventExpandedMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -26,6 +27,7 @@ export async function getEventExpandedMetrics(
 ): Promise<EventExpandedMetricData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -122,12 +124,67 @@ async function clickhouseQuery(
         ${filterQuery}
       group by name, session_id, visit_id
     ) as t
-    group by name 
+    group by name
     order by visitors desc, visits desc
     limit ${limit}
     offset ${offset}
     `,
     { ...queryParams, ...parameters },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: EventExpandedMetricParameters,
+  filters: QueryFilters,
+): Promise<EventExpandedMetricData[]> {
+  const { type, limit = 500, offset = 0 } = parameters;
+  const column = FILTER_COLUMNS[type] || type;
+  const { rawQuery, parseFilters, getTimestampDiffSQL } = oceanbase;
+  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters(
+    {
+      ...filters,
+      websiteId,
+      eventType: EVENT_TYPE.customEvent,
+    },
+    { joinSession: SESSION_COLUMNS.includes(type) },
+  );
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      name,
+      SUM(t.c) AS pageviews,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      SUM(CASE WHEN t.c = 1 THEN 1 ELSE 0 END) AS bounces,
+      SUM(${getTimestampDiffSQL('t.min_time', 't.max_time')}) AS totaltime
+    FROM (
+      SELECT
+        ${column} AS name,
+        website_event.session_id,
+        website_event.visit_id,
+        COUNT(*) AS c,
+        MIN(website_event.created_at) AS min_time,
+        MAX(website_event.created_at) AS max_time
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        ${filterQuery}
+      GROUP BY name, website_event.session_id, website_event.visit_id
+    ) AS t
+    WHERE name != ''
+    GROUP BY name
+    ORDER BY visitors DESC, visits DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventMetrics.ts
+++ b/src/queries/sql/events/getEventMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -23,6 +24,7 @@ export async function getEventMetrics(
 ): Promise<EventMetricData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -92,6 +94,45 @@ async function clickhouseQuery(
      offset ${offset}
     `,
     { ...queryParams, ...parameters },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: EventMetricParameters,
+  filters: QueryFilters,
+) {
+  const { type, limit = 500, offset = 0 } = parameters;
+  const column = FILTER_COLUMNS[type] || type;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters(
+    {
+      ...filters,
+      websiteId,
+      eventType: EVENT_TYPE.customEvent,
+    },
+    { joinSession: SESSION_COLUMNS.includes(type) },
+  );
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT ${column} x,
+      COUNT(*) AS y
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getEventStats.ts
+++ b/src/queries/sql/events/getEventStats.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -20,6 +21,7 @@ export async function getEventStats(
 ): Promise<WebsiteEventMetric[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -137,4 +139,54 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, queryParams, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: EventStatsParameters,
+  filters: QueryFilters,
+) {
+  const { limit } = parameters;
+  const { timezone = 'utc', unit = 'day' } = filters;
+  const { rawQuery, getDateSQL, parseFilters } = oceanbase;
+  const { filterQuery, cohortQuery, joinSessionQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const limitQuery = limit
+    ? `AND event_name IN (
+    SELECT event_name
+    FROM website_event
+    WHERE website_id = ?
+      AND created_at BETWEEN ? AND ?
+      AND event_type = 2
+    GROUP BY event_name
+    ORDER BY COUNT(*) DESC
+    LIMIT ${limit}
+  )`
+    : '';
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      event_name x,
+      ${getDateSQL('website_event.created_at', unit, timezone)} t,
+      COUNT(*) y
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type = 2
+      ${filterQuery}
+      ${limitQuery}
+    GROUP BY 1, 2
+    ORDER BY 2
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/events/getEventStats.ts
+++ b/src/queries/sql/events/getEventStats.ts
@@ -169,6 +169,11 @@ async function oceanbaseQuery(
 
   const params = buildParams([websiteId, filters.startDate, filters.endDate]);
 
+  // limitQuery adds 3 more placeholders (websiteId, startDate, endDate)
+  const finalParams = limit
+    ? [...params, websiteId, filters.startDate, filters.endDate]
+    : params;
+
   return rawQuery(
     `
     SELECT
@@ -186,7 +191,7 @@ async function oceanbaseQuery(
     GROUP BY 1, 2
     ORDER BY 2
     `,
-    params,
+    finalParams,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/events/getWebsiteEventStats.ts
+++ b/src/queries/sql/events/getWebsiteEventStats.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -17,6 +18,7 @@ export async function getWebsiteEventStats(
 ): Promise<WebsiteEventStatsData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -92,6 +94,46 @@ async function clickhouseQuery(
     ) as t;
     `,
     queryParams,
+    FUNCTION_NAME,
+  ).then(result => result?.[0]);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<WebsiteEventStatsData[]> {
+  const { parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      CAST(COALESCE(SUM(t.c), 0) AS SIGNED) AS events,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      COUNT(DISTINCT t.event_name) AS uniqueEvents
+    FROM (
+      SELECT
+        website_event.session_id,
+        website_event.visit_id,
+        website_event.event_name,
+        COUNT(*) AS c
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        AND website_event.event_type = 2
+        ${filterQuery}
+      GROUP BY 1, 2, 3
+    ) AS t
+    `,
+    params,
     FUNCTION_NAME,
   ).then(result => result?.[0]);
 }

--- a/src/queries/sql/events/getWebsiteEvents.ts
+++ b/src/queries/sql/events/getWebsiteEvents.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -8,6 +9,7 @@ const FUNCTION_NAME = 'getWebsiteEvents';
 export function getWebsiteEvents(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -83,7 +85,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     `
     select
       event_id as id,
-      website_id as websiteId, 
+      website_id as websiteId,
       session_id as sessionId,
       created_at as createdAt,
       hostname,
@@ -100,8 +102,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       page_title as pageTitle,
       event_type as eventType,
       event_name as eventName,
-      event_id IN (select event_id 
-                   from event_data 
+      event_id IN (select event_id
+                   from event_data
                    where website_id = {websiteId:UUID}
                    ${dateQuery}) as hasData
     from website_event
@@ -113,6 +115,67 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     order by created_at desc
     `,
     queryParams,
+    filters,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { pagedRawQuery, parseFilters } = oceanbase;
+  const { search } = filters;
+  const { filterQuery, dateQuery, cohortQuery, buildParams, getDateParams } = parseFilters({
+    ...filters,
+    websiteId,
+    search: search ? `%${search}%` : undefined,
+  });
+
+  // SQL order: cohortQuery, subquery(websiteId,startDate,endDate), websiteId, dateQuery, filterQuery, searchQuery
+  const params = buildParams([websiteId, filters.startDate, filters.endDate, websiteId, ...getDateParams()]);
+
+  // Add search params if needed
+  const searchParams = search ? [search, search] : [];
+
+  const searchQuery = search
+    ? `AND ((LOWER(event_name) LIKE ? AND event_type = 2)
+           OR (LOWER(url_path) LIKE ? AND event_type = 1))`
+    : '';
+
+  return pagedRawQuery(
+    `
+    SELECT
+      website_event.event_id AS id,
+      website_event.website_id AS websiteId,
+      website_event.session_id AS sessionId,
+      website_event.created_at AS createdAt,
+      website_event.hostname,
+      website_event.url_path AS urlPath,
+      website_event.url_query AS urlQuery,
+      website_event.referrer_path AS referrerPath,
+      website_event.referrer_query AS referrerQuery,
+      website_event.referrer_domain AS referrerDomain,
+      session.country AS country,
+      city AS city,
+      device AS device,
+      os AS os,
+      browser AS browser,
+      page_title AS pageTitle,
+      website_event.event_type AS eventType,
+      website_event.event_name AS eventName,
+      event_id IN (SELECT website_event_id
+                   FROM event_data
+                   WHERE website_id = ?
+                      AND created_at BETWEEN ? AND ?) AS hasData
+    FROM website_event
+    ${cohortQuery}
+    JOIN session ON session.session_id = website_event.session_id
+      AND session.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+    ${dateQuery}
+    ${filterQuery}
+    ${searchQuery}
+    ORDER BY website_event.created_at DESC
+    `,
+    [...params, ...searchParams],
     filters,
     FUNCTION_NAME,
   );

--- a/src/queries/sql/getActiveVisitors.ts
+++ b/src/queries/sql/getActiveVisitors.ts
@@ -1,6 +1,7 @@
 import { subMinutes } from 'date-fns';
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 const FUNCTION_NAME = 'getActiveVisitors';
@@ -8,6 +9,7 @@ const FUNCTION_NAME = 'getActiveVisitors';
 export async function getActiveVisitors(...args: [websiteId: string]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -47,4 +49,22 @@ async function clickhouseQuery(websiteId: string): Promise<{ x: number }> {
   );
 
   return result[0] ?? null;
+}
+
+async function oceanbaseQuery(websiteId: string) {
+  const { rawQuery } = oceanbase;
+  const startDate = subMinutes(new Date(), 5);
+
+  const result = await rawQuery(
+    `
+    SELECT COUNT(DISTINCT session_id) AS visitors
+    FROM website_event
+    WHERE website_id = ?
+      AND created_at >= ?
+    `,
+    [websiteId, startDate],
+    FUNCTION_NAME,
+  );
+
+  return result?.[0] ?? null;
 }

--- a/src/queries/sql/getChannelExpandedMetrics.ts
+++ b/src/queries/sql/getChannelExpandedMetrics.ts
@@ -7,7 +7,8 @@ import {
   SOCIAL_DOMAINS,
   VIDEO_DOMAINS,
 } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -32,6 +33,7 @@ export async function getChannelExpandedMetrics(
 ): Promise<ChannelExpandedMetricsData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -116,7 +118,7 @@ async function relationalQuery(
       `,
     queryParams,
     FUNCTION_NAME,
-  ).then(results => results.map(item => ({ ...item, y: Number(item.y) })));
+  ).then(results => results as ChannelExpandedMetricsData[]);
 }
 
 async function clickhouseQuery(
@@ -195,4 +197,93 @@ function toClickHouseStringArray(arr: string[]): string {
 
 function toPostgresPositionClause(column: string, arr: string[]) {
   return arr.map(val => `${column} ilike '%${val.replace(/'/g, "''")}%'`).join(' OR\n  ');
+}
+
+function toOceanBasePositionClause(column: string, arr: string[]) {
+  return arr.map(val => `LOWER(${column}) LIKE '%${val.toLowerCase()}%'`).join(' OR\n  ');
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<ChannelExpandedMetricsData[]> {
+  const { rawQuery, parseFilters, getTimestampDiffSQL } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, dateQuery, buildParams, getDateParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const params = buildParams([websiteId, ...getDateParams()]);
+
+  return rawQuery<ChannelExpandedMetricsData[]>(
+    `
+    WITH prefix AS (
+      SELECT CASE WHEN website_event.utm_medium LIKE 'p%' OR
+          website_event.utm_medium LIKE '%ppc%' OR
+          website_event.utm_medium LIKE '%retargeting%' OR
+          website_event.utm_medium LIKE '%paid%' THEN 'paid' ELSE 'organic' END prefix,
+          website_event.referrer_domain,
+          website_event.url_query,
+          website_event.utm_medium,
+          website_event.utm_source,
+          website_event.session_id,
+          website_event.visit_id,
+          website_event.hostname,
+          COUNT(*) c,
+          MIN(website_event.created_at) min_time,
+          MAX(website_event.created_at) max_time
+      FROM website_event
+      ${cohortQuery}
+      ${excludeBounceQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.event_type NOT IN (2, 5)
+        ${dateQuery}
+        ${filterQuery}
+      GROUP BY prefix,
+          website_event.referrer_domain,
+          website_event.url_query,
+          website_event.utm_medium,
+          website_event.utm_source,
+          website_event.session_id,
+          website_event.visit_id,
+          website_event.hostname),
+
+    channels AS (
+      SELECT CASE
+          WHEN referrer_domain = '' AND url_query = '' THEN 'direct'
+          WHEN ${toOceanBasePositionClause('url_query', PAID_AD_PARAMS)} THEN 'paidAds'
+          WHEN ${toOceanBasePositionClause('utm_medium', ['referral', 'app', 'link'])} THEN 'referral'
+          WHEN LOWER(utm_medium) LIKE '%affiliate%' THEN 'affiliate'
+          WHEN LOWER(utm_medium) LIKE '%sms%' OR LOWER(utm_source) LIKE '%sms%' THEN 'sms'
+          WHEN ${toOceanBasePositionClause('referrer_domain', SEARCH_DOMAINS)} OR LOWER(utm_medium) LIKE '%organic%' THEN CONCAT(prefix, 'Search')
+          WHEN ${toOceanBasePositionClause('referrer_domain', SOCIAL_DOMAINS)} THEN CONCAT(prefix, 'Social')
+          WHEN ${toOceanBasePositionClause('referrer_domain', EMAIL_DOMAINS)} OR LOWER(utm_medium) LIKE '%mail%' THEN 'email'
+          WHEN ${toOceanBasePositionClause('referrer_domain', SHOPPING_DOMAINS)} OR LOWER(utm_medium) LIKE '%shop%' THEN CONCAT(prefix, 'Shopping')
+          WHEN ${toOceanBasePositionClause('referrer_domain', VIDEO_DOMAINS)} OR LOWER(utm_medium) LIKE '%video%' THEN CONCAT(prefix, 'Video')
+          WHEN referrer_domain != REGEXP_REPLACE(hostname, '^www.', '') AND referrer_domain != '' THEN 'referral'
+          ELSE '' END AS name,
+          session_id,
+          visit_id,
+          c,
+          min_time,
+          max_time
+      FROM prefix)
+
+    SELECT
+      name,
+      SUM(c) AS pageviews,
+      COUNT(DISTINCT session_id) AS visitors,
+      COUNT(DISTINCT visit_id) AS visits,
+      SUM(CASE WHEN c = 1 THEN 1 ELSE 0 END) AS bounces,
+      SUM(${getTimestampDiffSQL('min_time', 'max_time')}) AS totaltime
+    FROM channels
+    WHERE name != ''
+    GROUP BY name
+    ORDER BY visitors DESC, visits DESC
+    `,
+    params,
+    FUNCTION_NAME,
+  ).then(results => results as ChannelExpandedMetricsData[]);
 }

--- a/src/queries/sql/getChannelMetrics.ts
+++ b/src/queries/sql/getChannelMetrics.ts
@@ -7,7 +7,8 @@ import {
   SOCIAL_DOMAINS,
   VIDEO_DOMAINS,
 } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -16,6 +17,7 @@ const FUNCTION_NAME = 'getChannelMetrics';
 export async function getChannelMetrics(...args: [websiteId: string, filters?: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -146,4 +148,73 @@ function toClickHouseStringArray(arr: string[]): string {
 
 function toPostgresLikeClause(column: string, arr: string[]) {
   return arr.map(val => `${column} ilike '%${val.replace(/'/g, "''")}%'`).join(' OR\n  ');
+}
+
+function toOceanBaseLikeClause(column: string, arr: string[]) {
+  return arr.map(val => `LOWER(${column}) LIKE '%${val.toLowerCase()}%'`).join(' OR\n  ');
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<{ x: string; y: number }[]> {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, dateQuery, buildParams, getDateParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const params = buildParams([websiteId, ...getDateParams()]);
+
+  return rawQuery<{ x: string; y: number }[]>(
+    `
+    WITH prefix AS (
+      SELECT CASE WHEN website_event.utm_medium LIKE 'p%' OR
+          website_event.utm_medium LIKE '%ppc%' OR
+          website_event.utm_medium LIKE '%retargeting%' OR
+          website_event.utm_medium LIKE '%paid%' THEN 'paid' ELSE 'organic' END prefix,
+          website_event.referrer_domain,
+          website_event.url_query,
+          website_event.utm_medium,
+          website_event.utm_source,
+          website_event.session_id,
+          website_event.hostname
+      FROM website_event
+      ${cohortQuery}
+      ${excludeBounceQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.event_type NOT IN (2, 5)
+        ${dateQuery}
+        ${filterQuery}),
+
+    channels AS (
+      SELECT CASE
+          WHEN referrer_domain = '' AND url_query = '' THEN 'direct'
+          WHEN ${toOceanBaseLikeClause('url_query', PAID_AD_PARAMS)} THEN 'paidAds'
+          WHEN ${toOceanBaseLikeClause('utm_medium', ['referral', 'app', 'link'])} THEN 'referral'
+          WHEN LOWER(utm_medium) LIKE '%affiliate%' THEN 'affiliate'
+          WHEN LOWER(utm_medium) LIKE '%sms%' OR LOWER(utm_source) LIKE '%sms%' THEN 'sms'
+          WHEN ${toOceanBaseLikeClause('referrer_domain', SEARCH_DOMAINS)} OR LOWER(utm_medium) LIKE '%organic%' THEN CONCAT(prefix, 'Search')
+          WHEN ${toOceanBaseLikeClause('referrer_domain', SOCIAL_DOMAINS)} THEN CONCAT(prefix, 'Social')
+          WHEN ${toOceanBaseLikeClause('referrer_domain', EMAIL_DOMAINS)} OR LOWER(utm_medium) LIKE '%mail%' THEN 'email'
+          WHEN ${toOceanBaseLikeClause('referrer_domain', SHOPPING_DOMAINS)} OR LOWER(utm_medium) LIKE '%shop%' THEN CONCAT(prefix, 'Shopping')
+          WHEN ${toOceanBaseLikeClause('referrer_domain', VIDEO_DOMAINS)} OR LOWER(utm_medium) LIKE '%video%' THEN CONCAT(prefix, 'Video')
+          WHEN referrer_domain != REGEXP_REPLACE(hostname, '^www.', '') AND referrer_domain != '' THEN 'referral'
+          ELSE '' END AS x,
+        COUNT(DISTINCT session_id) y
+      FROM prefix
+      GROUP BY 1
+      ORDER BY y DESC)
+
+    SELECT x, SUM(y) y
+    FROM channels
+    WHERE x != ''
+    GROUP BY x
+    ORDER BY y DESC
+    `,
+    params,
+    FUNCTION_NAME,
+  ).then(results => results.map(item => ({ ...item, y: Number(item.y) })));
 }

--- a/src/queries/sql/getRealtimeActivity.ts
+++ b/src/queries/sql/getRealtimeActivity.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -8,6 +9,7 @@ const FUNCTION_NAME = 'getRealtimeActivity';
 export async function getRealtimeActivity(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -77,6 +79,45 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters): Promis
         limit 100
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, cohortQuery, dateQuery, buildParams, getDateParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  // dateQuery appears after filterQuery, so add date params at the end
+  const params = [...buildParams([websiteId]), ...getDateParams()];
+
+  return rawQuery(
+    `
+    SELECT
+        website_event.session_id AS sessionId,
+        website_event.event_name AS eventName,
+        website_event.created_at AS createdAt,
+        session.browser,
+        session.os,
+        session.device,
+        session.country,
+        website_event.url_path AS urlPath,
+        website_event.referrer_domain AS referrerDomain,
+        website_event.hostname
+    FROM website_event
+    ${cohortQuery}
+    INNER JOIN session
+      ON session.session_id = website_event.session_id
+        AND session.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+    ${filterQuery}
+    ${dateQuery}
+    ORDER BY website_event.created_at DESC
+    LIMIT 100
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/getValues.ts
+++ b/src/queries/sql/getValues.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -10,6 +11,7 @@ export async function getValues(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -124,6 +126,54 @@ async function clickhouseQuery(websiteId: string, column: string, filters: Query
       search,
       ...params,
     },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, column: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { startDate, endDate, search } = filters;
+  const params: any[] = [];
+
+  let searchQuery = '';
+  let excludeDomain = '';
+
+  if (column === 'referrer_domain') {
+    excludeDomain = `AND website_event.referrer_domain != REGEXP_REPLACE(website_event.hostname, '^www.', '')
+      AND website_event.referrer_domain != ''`;
+  }
+
+  if (search) {
+    if (decodeURIComponent(search).includes(',')) {
+      const searchValues = decodeURIComponent(search).split(',').slice(0, 5);
+      searchQuery = `AND (${searchValues
+        .map((value: string) => {
+          params.push(`%${value}%`);
+          return `LOWER(${column}) LIKE LOWER(?)`;
+        })
+        .join(' OR ')})`;
+    } else {
+      searchQuery = `AND LOWER(${column}) LIKE LOWER(?)`;
+      params.push(`%${search}%`);
+    }
+  }
+
+  return rawQuery(
+    `
+    SELECT ${column} AS value, COUNT(*) AS count
+    FROM website_event
+    INNER JOIN session
+      ON session.session_id = website_event.session_id
+        AND session.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      ${searchQuery}
+      ${excludeDomain}
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+    `,
+    [websiteId, startDate, endDate, ...params],
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/getWebsiteDateRange.ts
+++ b/src/queries/sql/getWebsiteDateRange.ts
@@ -1,11 +1,13 @@
 import clickhouse from '@/lib/clickhouse';
 import { DEFAULT_RESET_DATE } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 export async function getWebsiteDateRange(...args: [websiteId: string]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -49,6 +51,31 @@ async function clickhouseQuery(websiteId: string) {
       and created_at >= {startDate:DateTime64}
     `,
     queryParams,
+  );
+
+  return result[0] ?? null;
+}
+
+async function oceanbaseQuery(websiteId: string) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const startDate = new Date(DEFAULT_RESET_DATE);
+  const { buildParams } = parseFilters({
+    startDate,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, startDate]);
+
+  const result = await rawQuery(
+    `
+    SELECT
+      MIN(created_at) AS startDate,
+      MAX(created_at) AS endDate
+    FROM website_event
+    WHERE website_id = ?
+      AND created_at >= ?
+    `,
+    params,
   );
 
   return result[0] ?? null;

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -19,6 +20,7 @@ export async function getWebsiteStats(
 ): Promise<WebsiteStatsData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -135,4 +137,51 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, queryParams, FUNCTION_NAME).then(result => result?.[0]);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<WebsiteStatsData[]> {
+  const { getTimestampDiffSQL, parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const { excludeBounce } = filters;
+  const bounceQuery = excludeBounce ? '0' : 'COALESCE(SUM(CASE WHEN t.c = 1 THEN 1 ELSE 0 END), 0)';
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      CAST(COALESCE(SUM(t.c), 0) AS SIGNED) AS pageviews,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      ${bounceQuery} AS bounces,
+      CAST(COALESCE(SUM(${getTimestampDiffSQL('t.min_time', 't.max_time')}), 0) AS SIGNED) AS totaltime
+    FROM (
+      SELECT
+        website_event.session_id,
+        website_event.visit_id,
+        COUNT(*) AS c,
+        MIN(website_event.created_at) AS min_time,
+        MAX(website_event.created_at) AS max_time
+      FROM website_event
+      ${cohortQuery}
+      ${excludeBounceQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        AND website_event.event_type NOT IN (2, 5)
+        ${filterQuery}
+      GROUP BY 1, 2
+    ) AS t
+    `,
+    params,
+    FUNCTION_NAME,
+  ).then(result => result?.[0]);
 }

--- a/src/queries/sql/getWeeklyTraffic.ts
+++ b/src/queries/sql/getWeeklyTraffic.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -9,6 +10,7 @@ const FUNCTION_NAME = 'getWeeklyTraffic';
 export async function getWeeklyTraffic(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -40,7 +42,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
     `,
     queryParams,
     FUNCTION_NAME,
-  ).then(formatResults);
+  ).then(formatResults as ( unknown) => any[]);
 }
 
 async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
@@ -85,10 +87,10 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
     `;
   }
 
-  return rawQuery(sql, queryParams, FUNCTION_NAME).then(formatResults);
+  return rawQuery(sql, queryParams, FUNCTION_NAME).then(formatResults as ( unknown) => any[]);
 }
 
-function formatResults(data: any) {
+function formatResults(data: { time: string; value: number }[]) {
   const days = [];
 
   for (let i = 0; i < 7; i++) {
@@ -104,4 +106,36 @@ function formatResults(data: any) {
   }
 
   return days;
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { timezone = 'utc' } = filters;
+  const { rawQuery, getDateWeeklySQL, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      ${getDateWeeklySQL('website_event.created_at', timezone)} AS time,
+      COUNT(DISTINCT website_event.session_id) AS value
+    FROM website_event
+    ${cohortQuery}
+    ${excludeBounceQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+      ${filterQuery}
+    GROUP BY time
+    ORDER BY 1
+    `,
+    params,
+    FUNCTION_NAME,
+  ).then(formatResults as ( unknown) => any[]);
 }

--- a/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
+++ b/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { FILTER_COLUMNS, GROUPED_DOMAINS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -26,6 +27,7 @@ export async function getPageviewExpandedMetrics(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -227,4 +229,112 @@ export function toPostgresGroupedReferrer(
 
 function toPostgresLikeClause(column: string, arr: string[]) {
   return arr.map(val => `${column} ilike '%${val.replace(/'/g, "''")}%'`).join(' OR\n  ');
+}
+
+export function toOceanBaseGroupedReferrer(
+  domains: any[],
+  column: string = 'referrer_domain',
+): string {
+  return [
+    'CASE',
+    ...domains.map(group => {
+      const matches = Array.isArray(group.match) ? group.match : [group.match];
+
+      return `WHEN ${toOceanBaseLikeClause(column, matches)} THEN '${group.domain}'`;
+    }),
+    "  ELSE 'Other'",
+    'END',
+  ].join('\n');
+}
+
+function toOceanBaseLikeClause(column: string, arr: string[]) {
+  return arr.map(val => `LOWER(${column}) LIKE '%${val.toLowerCase()}%'`).join(' OR\n  ');
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: PageviewExpandedMetricsParameters,
+  filters: QueryFilters,
+): Promise<PageviewExpandedMetricsData[]> {
+  const { type, limit = 500, offset = 0 } = parameters;
+  let column = FILTER_COLUMNS[type] || type;
+  const { rawQuery, parseFilters, getTimestampDiffSQL } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters(
+      {
+        ...filters,
+        websiteId,
+      },
+      { joinSession: SESSION_COLUMNS.includes(type) },
+    );
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  let entryExitQuery = '';
+  let excludeDomain = '';
+
+  if (column === 'referrer_domain') {
+    excludeDomain = `AND website_event.referrer_domain != REGEXP_REPLACE(website_event.hostname, '^www.', '')
+      AND website_event.referrer_domain != ''`;
+    if (type === 'domain') {
+      column = toOceanBaseGroupedReferrer(GROUPED_DOMAINS);
+    }
+  }
+
+  if (type === 'entry' || type === 'exit') {
+    const aggregrate = type === 'entry' ? 'MIN' : 'MAX';
+
+    entryExitQuery = `
+      JOIN (
+        SELECT visit_id,
+            ${aggregrate}(created_at) target_created_at
+        FROM website_event
+        WHERE website_event.website_id = ?
+          AND website_event.created_at BETWEEN ? AND ?
+          AND website_event.event_type NOT IN (2, 5)
+        GROUP BY visit_id
+      ) x
+      ON x.visit_id = website_event.visit_id
+          AND x.target_created_at = website_event.created_at
+    `;
+  }
+
+  return rawQuery(
+    `
+    SELECT
+      name,
+      SUM(t.c) AS pageviews,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      SUM(CASE WHEN t.c = 1 THEN 1 ELSE 0 END) AS bounces,
+      SUM(${getTimestampDiffSQL('t.min_time', 't.max_time')}) AS totaltime
+    FROM (
+      SELECT
+        ${column} AS name,
+        website_event.session_id,
+        website_event.visit_id,
+        COUNT(*) AS c,
+        MIN(website_event.created_at) AS min_time,
+        MAX(website_event.created_at) AS max_time
+      FROM website_event
+      ${cohortQuery}
+      ${excludeBounceQuery}
+      ${joinSessionQuery}
+      ${entryExitQuery}
+      WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+        ${excludeDomain}
+        ${filterQuery}
+      GROUP BY ${column}, website_event.session_id, website_event.visit_id
+    ) AS t
+    WHERE name != ''
+    GROUP BY name
+    ORDER BY visitors DESC, visits DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/pageviews/getPageviewMetrics.ts
+++ b/src/queries/sql/pageviews/getPageviewMetrics.ts
@@ -215,8 +215,7 @@ async function oceanbaseQuery(
       { joinSession: SESSION_COLUMNS.includes(type) },
     );
 
-  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
-
+  let entryExitParams: any[] = [];
   let entryExitQuery = '';
   let excludeDomain = '';
 
@@ -228,6 +227,7 @@ async function oceanbaseQuery(
   if (type === 'entry' || type === 'exit') {
     const order = type === 'entry' ? 'ASC' : 'DESC';
     column = `x.${column}`;
+    entryExitParams = [websiteId, filters.startDate, filters.endDate];
 
     entryExitQuery = `
       JOIN (
@@ -245,6 +245,8 @@ async function oceanbaseQuery(
       ON x.visit_id = website_event.visit_id
     `;
   }
+
+  const params = buildParams([...entryExitParams, websiteId, filters.startDate, filters.endDate]);
 
   return rawQuery(
     `

--- a/src/queries/sql/pageviews/getPageviewMetrics.ts
+++ b/src/queries/sql/pageviews/getPageviewMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -22,6 +23,7 @@ export async function getPageviewMetrics(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -194,4 +196,77 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, { ...queryParams, ...parameters }, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: PageviewMetricsParameters,
+  filters: QueryFilters,
+): Promise<PageviewMetricsData[]> {
+  const { type, limit = 500, offset = 0 } = parameters;
+  let column = FILTER_COLUMNS[type] || type;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters(
+      {
+        ...filters,
+        websiteId,
+      },
+      { joinSession: SESSION_COLUMNS.includes(type) },
+    );
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  let entryExitQuery = '';
+  let excludeDomain = '';
+
+  if (column === 'referrer_domain') {
+    excludeDomain = `AND website_event.referrer_domain != REGEXP_REPLACE(website_event.hostname, '^www.', '')
+      AND website_event.referrer_domain != ''`;
+  }
+
+  if (type === 'entry' || type === 'exit') {
+    const order = type === 'entry' ? 'ASC' : 'DESC';
+    column = `x.${column}`;
+
+    entryExitQuery = `
+      JOIN (
+        SELECT visit_id, url_path
+        FROM (
+          SELECT visit_id, url_path,
+            ROW_NUMBER() OVER (PARTITION BY visit_id ORDER BY created_at ${order}) AS rn
+          FROM website_event
+          WHERE website_event.website_id = ?
+            AND website_event.created_at BETWEEN ? AND ?
+            AND website_event.event_type NOT IN (2, 5)
+        ) ranked
+        WHERE rn = 1
+      ) x
+      ON x.visit_id = website_event.visit_id
+    `;
+  }
+
+  return rawQuery(
+    `
+    SELECT ${column} x,
+      COUNT(DISTINCT website_event.session_id) AS y
+    FROM website_event
+    ${cohortQuery}
+    ${excludeBounceQuery}
+    ${joinSessionQuery}
+    ${entryExitQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+      AND ${column} != ''
+      ${excludeDomain}
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/pageviews/getPageviewStats.ts
+++ b/src/queries/sql/pageviews/getPageviewStats.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -9,6 +10,7 @@ const FUNCTION_NAME = 'getPageviewStats';
 export async function getPageviewStats(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -99,4 +101,36 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, queryParams, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { timezone = 'utc', unit = 'day' } = filters;
+  const { getDateSQL, parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, cohortQuery, excludeBounceQuery, joinSessionQuery, buildParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      ${getDateSQL('website_event.created_at', unit, timezone)} x,
+      COUNT(*) y
+    FROM website_event
+    ${cohortQuery}
+    ${excludeBounceQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 1
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/performance/getPerformanceStats.ts
+++ b/src/queries/sql/performance/getPerformanceStats.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -15,6 +16,7 @@ export interface PerformanceStatsResult {
 export async function getPerformanceStats(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -76,6 +78,41 @@ async function clickhouseQuery(
       ${filterQuery}
     `,
     queryParams,
+  );
+
+  return result?.[0] || { lcp: 0, inp: 0, cls: 0, fcp: 0, ttfb: 0, count: 0 };
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<PerformanceStatsResult> {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  const result = await rawQuery(
+    `
+    SELECT
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY lcp) AS lcp,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY inp) AS inp,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY cls) AS cls,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY fcp) AS fcp,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ttfb) AS ttfb,
+      COUNT(*) AS count
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.event_type = 5
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    `,
+    params,
   );
 
   return result?.[0] || { lcp: 0, inp: 0, cls: 0, fcp: 0, ttfb: 0, count: 0 };

--- a/src/queries/sql/replays/getReplayChunks.ts
+++ b/src/queries/sql/replays/getReplayChunks.ts
@@ -1,6 +1,7 @@
 import { gunzipSync } from 'node:zlib';
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 const FUNCTION_NAME = 'getReplayChunks';
@@ -18,6 +19,7 @@ export interface ReplayChunk {
 export async function getReplayChunks(websiteId: string, visitId: string): Promise<ReplayChunk[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(websiteId, visitId),
+    [OCEANBASE]: () => oceanbaseQuery(websiteId, visitId),
     [CLICKHOUSE]: () => clickhouseQuery(websiteId, visitId),
   });
 }
@@ -98,5 +100,41 @@ async function clickhouseQuery(websiteId: string, visitId: string): Promise<Repl
     eventCount: row.event_count,
     startedAt: new Date(row.started_at),
     endedAt: new Date(row.ended_at),
+  }));
+}
+
+async function oceanbaseQuery(websiteId: string, visitId: string): Promise<ReplayChunk[]> {
+  const { rawQuery } = oceanbase;
+
+  const chunks: {
+    sessionId: string;
+    visitId: string;
+    events: Buffer;
+    chunkIndex: number;
+    eventCount: number;
+    startedAt: Date;
+    endedAt: Date;
+  }[] = await rawQuery(
+    `
+    SELECT
+      session_id AS sessionId,
+      visit_id AS visitId,
+      events,
+      chunk_index AS chunkIndex,
+      event_count AS eventCount,
+      started_at AS startedAt,
+      ended_at AS endedAt
+    FROM session_replay
+    WHERE website_id = ?
+      AND visit_id = ?
+    ORDER BY chunk_index ASC
+    `,
+    [websiteId, visitId],
+    FUNCTION_NAME,
+  );
+
+  return chunks.map(chunk => ({
+    ...chunk,
+    events: JSON.parse(gunzipSync(Buffer.from(chunk.events)).toString('utf-8')),
   }));
 }

--- a/src/queries/sql/replays/getSessionReplays.ts
+++ b/src/queries/sql/replays/getSessionReplays.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -10,6 +11,7 @@ export function getSessionReplays(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -142,6 +144,82 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters, session
     order by max(created_at) desc
     `,
     { ...queryParams, sessionId },
+    filters,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters, sessionId?: string) {
+  const { pagedRawQuery, parseFilters } = oceanbase;
+  const { search } = filters;
+  const { filterQuery, cohortQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    search: search ? `%${search}%` : undefined,
+  });
+
+  const joinQuery =
+    filterQuery || cohortQuery
+      ? `JOIN (SELECT DISTINCT website_event.website_id, website_event.session_id, website_event.visit_id
+               FROM website_event
+               ${cohortQuery}
+               WHERE website_event.website_id = ?
+                  AND website_event.created_at BETWEEN ? AND ?
+                  ${filterQuery}) website_event
+        ON website_event.website_id = sr.website_id
+          AND website_event.session_id = sr.session_id
+          AND website_event.visit_id = sr.visit_id`
+      : '';
+
+  const sessionFilter = sessionId ? 'AND sr.session_id = ?' : '';
+
+  const searchQuery = search
+    ? `AND (LOWER(session.distinct_id) LIKE ?
+           OR LOWER(session.city) LIKE ?
+           OR LOWER(session.browser) LIKE ?
+           OR LOWER(session.os) LIKE ?
+           OR LOWER(session.device) LIKE ?)`
+    : '';
+
+  // Build parameters array with sessionId appended if needed
+  const params = sessionId ? [...queryParams, sessionId] : queryParams;
+
+  return pagedRawQuery(
+    `
+    SELECT
+      sr.visit_id AS id,
+      sr.session_id AS sessionId,
+      sr.website_id AS websiteId,
+      session.browser,
+      session.os,
+      session.device,
+      session.country,
+      session.city,
+      SUM(sr.event_count) AS eventCount,
+      COUNT(sr.replay_id) AS chunkCount,
+      MIN(sr.started_at) AS startedAt,
+      MAX(sr.ended_at) AS endedAt,
+      SUM(TIMESTAMPDIFF(MICROSECOND, sr.started_at, sr.ended_at) / 1000) AS duration,
+      MAX(sr.created_at) AS createdAt
+    FROM session_replay sr
+    JOIN session ON session.session_id = sr.session_id
+      AND session.website_id = sr.website_id
+    ${joinQuery}
+    WHERE sr.website_id = ?
+      AND sr.created_at BETWEEN ? AND ?
+    ${sessionFilter}
+    ${searchQuery}
+    GROUP BY sr.visit_id,
+      sr.session_id,
+      sr.website_id,
+      session.browser,
+      session.os,
+      session.device,
+      session.country,
+      session.city
+    ORDER BY MAX(sr.created_at) DESC
+    `,
+    params,
     filters,
     FUNCTION_NAME,
   );

--- a/src/queries/sql/reports/getAttribution.ts
+++ b/src/queries/sql/reports/getAttribution.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -28,6 +29,7 @@ export async function getAttribution(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -458,6 +460,206 @@ async function clickhouseQuery(
         ${filterQuery}
     `,
     queryParams,
+  ).then(result => result?.[0]);
+
+  return {
+    referrer: referrerRes,
+    paidAds: paidAdsres,
+    utm_source: sourceRes,
+    utm_medium: mediumRes,
+    utm_campaign: campaignRes,
+    utm_content: contentRes,
+    utm_term: termRes,
+    total: totalRes,
+  };
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: AttributionParameters,
+  filters: QueryFilters,
+): Promise<AttributionResult> {
+  const { model, type, startDate, endDate, step } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const eventType = type === 'path' ? EVENT_TYPE.pageView : EVENT_TYPE.customEvent;
+  const column = type === 'path' ? 'url_path' : 'event_name';
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    ...parameters,
+    websiteId,
+    eventType,
+  });
+
+  const params = buildParams([websiteId, startDate, endDate, step]);
+
+  function getUTMQuery(utmColumn: string) {
+    return `
+    SELECT
+        COALESCE(we.${utmColumn}, '') AS name,
+        COUNT(DISTINCT we.session_id) AS value
+    FROM model m
+    JOIN website_event we
+    ON we.created_at = m.created_at
+        AND we.session_id = m.session_id
+    WHERE we.website_id = ?
+          AND we.created_at BETWEEN ? AND ?
+          AND we.${utmColumn} != ''
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 20`;
+  }
+
+  const eventQuery = `WITH events AS (
+        SELECT DISTINCT
+            website_event.session_id,
+            MAX(website_event.created_at) AS max_dt
+        FROM website_event
+        ${cohortQuery}
+        ${joinSessionQuery}
+        WHERE website_event.website_id = ?
+          AND website_event.created_at BETWEEN ? AND ?
+          AND website_event.${column} = ?
+          ${filterQuery}
+        GROUP BY 1),`;
+
+  function getModelQuery(model: string) {
+    return model === 'first-click'
+      ? `\n
+    model AS (SELECT e.session_id,
+        MIN(we.created_at) AS created_at
+    FROM events e
+    JOIN website_event we
+    ON we.session_id = e.session_id
+    WHERE we.website_id = ?
+          AND we.created_at BETWEEN ? AND ?
+    GROUP BY e.session_id)`
+      : `\n
+    model AS (SELECT e.session_id,
+        MAX(we.created_at) AS created_at
+    FROM events e
+    JOIN website_event we
+    ON we.session_id = e.session_id
+    WHERE we.website_id = ?
+          AND we.created_at BETWEEN ? AND ?
+          AND we.created_at < e.max_dt
+    GROUP BY e.session_id)`;
+  }
+
+  const referrerRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    SELECT COALESCE(we.referrer_domain, '') AS name,
+        COUNT(DISTINCT we.session_id) AS value
+    FROM model m
+    JOIN website_event we
+    ON we.created_at = m.created_at
+        AND we.session_id = m.session_id
+    JOIN session s
+    ON s.session_id = m.session_id
+    WHERE we.website_id = ?
+          AND we.created_at BETWEEN ? AND ?
+          AND we.referrer_domain != REPLACE(we.hostname, 'www.', '')
+          AND we.referrer_domain != ''
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 20
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const paidAdsres = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)},
+
+    results AS (
+    SELECT CASE
+            WHEN COALESCE(gclid, '') != '' THEN 'Google Ads'
+            WHEN COALESCE(fbclid, '') != '' THEN 'Facebook / Meta'
+            WHEN COALESCE(msclkid, '') != '' THEN 'Microsoft Ads'
+            WHEN COALESCE(ttclid, '') != '' THEN 'TikTok Ads'
+            WHEN COALESCE(li_fat_id, '') != '' THEN 'LinkedIn Ads'
+            WHEN COALESCE(twclid, '') != '' THEN 'Twitter Ads (X)'
+            ELSE ''
+          END AS name,
+        COUNT(DISTINCT we.session_id) AS value
+    FROM model m
+    JOIN website_event we
+    ON we.created_at = m.created_at
+        AND we.session_id = m.session_id
+    WHERE we.website_id = ?
+          AND we.created_at BETWEEN ? AND ?
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 20)
+    SELECT *
+    FROM results
+    WHERE name != ''
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const sourceRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    ${getUTMQuery('utm_source')}
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const mediumRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    ${getUTMQuery('utm_medium')}
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const campaignRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    ${getUTMQuery('utm_campaign')}
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const contentRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    ${getUTMQuery('utm_content')}
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const termRes = await rawQuery<{ name: string; value: number }[]>(
+    `
+    ${eventQuery}
+    ${getModelQuery(model)}
+    ${getUTMQuery('utm_term')}
+    `,
+    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const totalRes = await rawQuery<{ pageviews: number; visitors: number; visits: number }[]>(
+    `
+    SELECT
+        COUNT(*) AS pageviews,
+        COUNT(DISTINCT website_event.session_id) AS visitors,
+        COUNT(DISTINCT website_event.visit_id) AS visits
+    FROM website_event
+    ${joinSessionQuery}
+    ${cohortQuery}
+    WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        AND website_event.${column} = ?
+        ${filterQuery}
+    `,
+    params,
   ).then(result => result?.[0]);
 
   return {

--- a/src/queries/sql/reports/getAttribution.ts
+++ b/src/queries/sql/reports/getAttribution.ts
@@ -559,7 +559,7 @@ async function oceanbaseQuery(
     ON s.session_id = m.session_id
     WHERE we.website_id = ?
           AND we.created_at BETWEEN ? AND ?
-          AND we.referrer_domain != REPLACE(we.hostname, 'www.', '')
+          AND we.referrer_domain != REGEXP_REPLACE(we.hostname, '^www.', '')
           AND we.referrer_domain != ''
     GROUP BY 1
     ORDER BY 2 DESC

--- a/src/queries/sql/reports/getAttribution.ts
+++ b/src/queries/sql/reports/getAttribution.ts
@@ -483,14 +483,22 @@ async function oceanbaseQuery(
   const { rawQuery, parseFilters } = oceanbase;
   const eventType = type === 'path' ? EVENT_TYPE.pageView : EVENT_TYPE.customEvent;
   const column = type === 'path' ? 'url_path' : 'event_name';
-  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters({
     ...filters,
     ...parameters,
     websiteId,
     eventType,
   });
 
-  const params = buildParams([websiteId, startDate, endDate, step]);
+  // eventQuery placeholders: cohortQuery(0|3) + WHERE(websiteId, startDate, endDate, step) + filterQuery(N)
+  const eventQueryParams = [
+    ...(cohortQuery ? [websiteId, startDate, endDate] : []),
+    websiteId, startDate, endDate, step,
+    ...queryParams,
+  ];
+
+  // modelQuery placeholders: websiteId, startDate, endDate
+  const modelParams = [websiteId, startDate, endDate];
 
   function getUTMQuery(utmColumn: string) {
     return `
@@ -545,6 +553,9 @@ async function oceanbaseQuery(
     GROUP BY e.session_id)`;
   }
 
+  // All CTE queries share the same param structure: eventQuery + modelQuery + final(3)
+  const cteParams = [...eventQueryParams, ...modelParams, websiteId, startDate, endDate];
+
   const referrerRes = await rawQuery<{ name: string; value: number }[]>(
     `
     ${eventQuery}
@@ -565,7 +576,7 @@ async function oceanbaseQuery(
     ORDER BY 2 DESC
     LIMIT 20
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const paidAdsres = await rawQuery<{ name: string; value: number }[]>(
@@ -597,7 +608,7 @@ async function oceanbaseQuery(
     FROM results
     WHERE name != ''
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const sourceRes = await rawQuery<{ name: string; value: number }[]>(
@@ -606,7 +617,7 @@ async function oceanbaseQuery(
     ${getModelQuery(model)}
     ${getUTMQuery('utm_source')}
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const mediumRes = await rawQuery<{ name: string; value: number }[]>(
@@ -615,7 +626,7 @@ async function oceanbaseQuery(
     ${getModelQuery(model)}
     ${getUTMQuery('utm_medium')}
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const campaignRes = await rawQuery<{ name: string; value: number }[]>(
@@ -624,7 +635,7 @@ async function oceanbaseQuery(
     ${getModelQuery(model)}
     ${getUTMQuery('utm_campaign')}
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const contentRes = await rawQuery<{ name: string; value: number }[]>(
@@ -633,7 +644,7 @@ async function oceanbaseQuery(
     ${getModelQuery(model)}
     ${getUTMQuery('utm_content')}
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const termRes = await rawQuery<{ name: string; value: number }[]>(
@@ -642,8 +653,15 @@ async function oceanbaseQuery(
     ${getModelQuery(model)}
     ${getUTMQuery('utm_term')}
     `,
-    [...params, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
+
+  // totalRes: cohort(0|3) + WHERE(websiteId, startDate, endDate, step) + filterQuery(N)
+  const totalParams = [
+    ...(cohortQuery ? [websiteId, startDate, endDate] : []),
+    websiteId, startDate, endDate, step,
+    ...queryParams,
+  ];
 
   const totalRes = await rawQuery<{ pageviews: number; visitors: number; visits: number }[]>(
     `
@@ -659,7 +677,7 @@ async function oceanbaseQuery(
         AND website_event.${column} = ?
         ${filterQuery}
     `,
-    params,
+    totalParams,
   ).then(result => result?.[0]);
 
   return {

--- a/src/queries/sql/reports/getBreakdown.ts
+++ b/src/queries/sql/reports/getBreakdown.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -20,6 +21,7 @@ export async function getBreakdown(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -62,12 +64,12 @@ async function relationalQuery(
         min(website_event.created_at) as "min_time",
         max(website_event.created_at) as "max_time"
       from website_event
-      ${cohortQuery}  
+      ${cohortQuery}
       ${joinSessionQuery}
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         ${filterQuery}
-      group by ${parseFieldsByName(fields)}, 
+      group by ${parseFieldsByName(fields)},
         website_event.session_id, website_event.visit_id
     ) as t
     group by ${parseFieldsByName(fields)}
@@ -115,7 +117,7 @@ async function clickhouseQuery(
       where website_id = {websiteId:UUID}
         and created_at between {startDate:DateTime64} and {endDate:DateTime64}
         ${filterQuery}
-      group by ${parseFieldsByName(fields)}, 
+      group by ${parseFieldsByName(fields)},
         session_id, visit_id
     ) as t
     group by ${parseFieldsByName(fields)}
@@ -126,8 +128,64 @@ async function clickhouseQuery(
   );
 }
 
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: BreakdownParameters,
+  filters: QueryFilters,
+): Promise<BreakdownData[]> {
+  const { getTimestampDiffSQL, parseFilters, rawQuery } = oceanbase;
+  const { startDate, endDate, fields } = parameters;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters(
+    {
+      ...filters,
+      websiteId,
+      startDate,
+      endDate,
+      eventType: EVENT_TYPE.pageView,
+    },
+    {
+      joinSession: !!fields.find((name: string) => SESSION_COLUMNS.includes(name)),
+    },
+  );
+
+  const params = buildParams([websiteId, startDate, endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      SUM(t.c) AS views,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      SUM(CASE WHEN t.c = 1 THEN 1 ELSE 0 END) AS bounces,
+      SUM(${getTimestampDiffSQL('t.min_time', 't.max_time')}) AS totaltime,
+      ${parseFieldsByName(fields)}
+    FROM (
+      SELECT
+        ${parseFields(fields)},
+        website_event.session_id,
+        website_event.visit_id,
+        COUNT(*) AS c,
+        MIN(website_event.created_at) AS min_time,
+        MAX(website_event.created_at) AS max_time
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        ${filterQuery}
+      GROUP BY ${parseFieldsByName(fields)},
+        website_event.session_id, website_event.visit_id
+    ) AS t
+    GROUP BY ${parseFieldsByName(fields)}
+    ORDER BY 2 DESC, 1 DESC
+    LIMIT 500
+    `,
+    params,
+  );
+}
+
 function parseFields(fields: string[]) {
-  return fields.map(name => `${FILTER_COLUMNS[name]} as "${name}"`).join(',');
+  return fields.map(name => `${FILTER_COLUMNS[name]} AS "${name}"`).join(',');
 }
 
 function parseFieldsByName(fields: string[]) {

--- a/src/queries/sql/reports/getFunnel.ts
+++ b/src/queries/sql/reports/getFunnel.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -36,6 +37,7 @@ export async function getFunnel(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -344,6 +346,112 @@ async function clickhouseQuery(
       ...params,
       ...queryParams,
     },
+  ).then(formatResults(steps));
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: FunnelParameters,
+  filters: QueryFilters,
+): Promise<Array<FunnelResult>> {
+  const { startDate, endDate, window, steps } = parameters;
+  const { rawQuery, getAddIntervalQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+  });
+
+  const extraParams: string[] = [];
+  let levelOneQuery = '';
+  let levelQuery = '';
+  let sumQuery = '';
+
+  for (let i = 0; i < steps.length; i++) {
+    const cv = steps[i];
+    const levelNumber = i + 1;
+    const startSum = i > 0 ? 'UNION ' : '';
+    const isURL = cv.type === 'path';
+    const column = isURL ? 'url_path' : 'event_name';
+
+    let operator = '=';
+    let paramValue = cv.value;
+
+    if (cv.value.startsWith('*') || cv.value.endsWith('*')) {
+      operator = 'LIKE';
+      paramValue = cv.value.replace(/^\*|\*$/g, '%');
+    }
+
+    const existsClause =
+      !isURL && cv.filters?.length
+        ? cv.filters
+            .map((f, fi) => {
+              extraParams.push(f.property);
+              let op = '=';
+              let val = f.value;
+              if (f.operator === 'neq') op = '!=';
+              else if (f.operator === 'c') {
+                op = 'LIKE';
+                val = `%${val}%`;
+              } else if (f.operator === 'dnc') {
+                op = 'NOT LIKE';
+                val = `%${val}%`;
+              }
+              extraParams.push(val);
+              const eventAlias = levelNumber === 1 ? 'website_event' : 'we';
+              return `AND EXISTS (
+                SELECT 1 FROM event_data _ed${i}_${fi}
+                WHERE _ed${i}_${fi}.website_event_id = ${eventAlias}.event_id
+                  AND _ed${i}_${fi}.website_id = ?
+                  AND _ed${i}_${fi}.created_at BETWEEN ? AND ?
+                  AND _ed${i}_${fi}.data_key = ?
+                  AND CASE WHEN _ed${i}_${fi}.data_type = 2 THEN REPLACE(_ed${i}_${fi}.string_value, '.0000', '') ELSE _ed${i}_${fi}.string_value END ${op} ?
+              )`;
+            })
+            .join('\n')
+        : '';
+
+    if (levelNumber === 1) {
+      levelOneQuery = `
+        WITH level1 AS (
+          SELECT DISTINCT website_event.session_id, website_event.created_at
+          FROM website_event
+          ${cohortQuery}
+          ${joinSessionQuery}
+          WHERE website_event.website_id = ?
+            AND website_event.created_at BETWEEN ? AND ?
+            AND ${column} ${operator} ?
+            ${filterQuery}
+            ${existsClause}
+        )`;
+    } else {
+      levelQuery += `
+        , level${levelNumber} AS (
+          SELECT DISTINCT we.session_id, we.created_at
+          FROM level${i} l
+          JOIN website_event we
+              ON l.session_id = we.session_id
+          WHERE we.website_id = ?
+              AND we.created_at BETWEEN l.created_at AND ${getAddIntervalQuery('l.created_at', `${window} minute`)}
+              AND we.${column} ${operator} ?
+              AND we.created_at <= ?
+              ${existsClause}
+        )`;
+    }
+
+    sumQuery += `\n${startSum}SELECT ${levelNumber} AS level, COUNT(DISTINCT session_id) AS count FROM level${levelNumber}`;
+    extraParams.push(paramValue);
+  }
+
+  return rawQuery(
+    `
+    ${levelOneQuery}
+    ${levelQuery}
+    ${sumQuery}
+    ORDER BY level
+    `,
+    [websiteId, startDate, endDate, ...extraParams, ...queryParams],
   ).then(formatResults(steps));
 }
 

--- a/src/queries/sql/reports/getFunnel.ts
+++ b/src/queries/sql/reports/getFunnel.ts
@@ -387,7 +387,8 @@ async function oceanbaseQuery(
       !isURL && cv.filters?.length
         ? cv.filters
             .map((f, fi) => {
-              extraParams.push(f.property);
+              // Push params in order: website_id, startDate, endDate, data_key, value
+              extraParams.push(websiteId, startDate, endDate, f.property);
               let op = '=';
               let val = f.value;
               if (f.operator === 'neq') op = '!=';

--- a/src/queries/sql/reports/getGoal.ts
+++ b/src/queries/sql/reports/getGoal.ts
@@ -149,7 +149,7 @@ async function oceanbaseQuery(
     paramValue = value.replace(/^\*|\*$/g, '%');
   }
 
-  const { filterQuery, dateQuery, joinSessionQuery, cohortQuery, buildParams, getDateParams, queryParams } = parseFilters({
+  const { filterQuery, dateQuery, joinSessionQuery, cohortQuery, queryParams, getDateParams } = parseFilters({
     ...filters,
     websiteId,
     value: paramValue,
@@ -158,19 +158,33 @@ async function oceanbaseQuery(
     eventType,
   });
 
-  const excludeEventTypeFilterQuery = filterQuery
-    .split('\n')
-    .filter(filter => !filter.includes('event_type'))
-    .join('\n')
-    .trim();
+  // Parse filters again without eventType to get clean SQL and params for the subquery
+  const { filterQuery: subFilterQuery, queryParams: subQueryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    value: paramValue,
+    startDate,
+    endDate,
+  });
 
   const dateParams = getDateParams();
 
-  // Build params for subquery: cohortQuery + websiteId + dateQuery + excludeFilter
-  const subqueryParams = buildParams([websiteId, ...dateParams]);
+  // Subquery: cohort(0|3) + websiteId + dateQuery + subFilterQuery (no event_type)
+  const subqueryParams = [
+    ...(cohortQuery ? [websiteId, startDate, endDate] : []),
+    websiteId,
+    ...dateParams,
+    ...subQueryParams,
+  ];
 
-  // Build params for main query: cohortQuery + websiteId + paramValue + dateQuery + filterQuery
-  const mainQueryParams = buildParams([websiteId, paramValue, ...dateParams]);
+  // Main query: cohort(0|3) + websiteId + paramValue + dateQuery + filterQuery
+  const mainQueryParams = [
+    ...(cohortQuery ? [websiteId, startDate, endDate] : []),
+    websiteId,
+    paramValue,
+    ...dateParams,
+    ...queryParams,
+  ];
 
   return rawQuery(
     `
@@ -182,7 +196,7 @@ async function oceanbaseQuery(
       ${joinSessionQuery}
       WHERE website_event.website_id = ?
       ${dateQuery}
-      ${excludeEventTypeFilterQuery}
+      ${subFilterQuery}
     ) AS total
     FROM website_event
     ${cohortQuery}

--- a/src/queries/sql/reports/getGoal.ts
+++ b/src/queries/sql/reports/getGoal.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -16,6 +17,7 @@ export async function getGoal(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -128,4 +130,68 @@ async function clickhouseQuery(
     `,
     queryParams,
   ).then(results => results?.[0]);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: GoalParameters,
+  filters: QueryFilters,
+) {
+  const { startDate, endDate, type, value } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const eventType = type === 'path' ? EVENT_TYPE.pageView : EVENT_TYPE.customEvent;
+  const column = type === 'path' ? 'url_path' : 'event_name';
+
+  let operator = '=';
+  let paramValue = value;
+  if (value.startsWith('*') || value.endsWith('*')) {
+    operator = 'LIKE';
+    paramValue = value.replace(/^\*|\*$/g, '%');
+  }
+
+  const { filterQuery, dateQuery, joinSessionQuery, cohortQuery, buildParams, getDateParams, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    value: paramValue,
+    startDate,
+    endDate,
+    eventType,
+  });
+
+  const excludeEventTypeFilterQuery = filterQuery
+    .split('\n')
+    .filter(filter => !filter.includes('event_type'))
+    .join('\n')
+    .trim();
+
+  const dateParams = getDateParams();
+
+  // Build params for subquery: cohortQuery + websiteId + dateQuery + excludeFilter
+  const subqueryParams = buildParams([websiteId, ...dateParams]);
+
+  // Build params for main query: cohortQuery + websiteId + paramValue + dateQuery + filterQuery
+  const mainQueryParams = buildParams([websiteId, paramValue, ...dateParams]);
+
+  return rawQuery(
+    `
+    SELECT COUNT(DISTINCT website_event.session_id) AS num,
+    (
+      SELECT COUNT(DISTINCT website_event.session_id)
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+      ${dateQuery}
+      ${excludeEventTypeFilterQuery}
+    ) AS total
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND ${column} ${operator} ?
+      ${dateQuery}
+      ${filterQuery}
+    `,
+    [...subqueryParams, ...mainQueryParams],
+  ).then((results: any) => results?.[0]);
 }

--- a/src/queries/sql/reports/getJourney.ts
+++ b/src/queries/sql/reports/getJourney.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -28,6 +29,7 @@ export async function getJourney(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -272,4 +274,113 @@ function parseResult(data: any) {
     items: combineSequentialDuplicates([e1, e2, e3, e4, e5, e6, e7]),
     count: +Number(count),
   }));
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: JourneyParameters,
+  filters: QueryFilters,
+): Promise<JourneyResult[]> {
+  const { startDate, endDate, steps, startStep, endStep } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { sequenceQuery, startStepQuery, endStepQuery, params } = getJourneyQuery(
+    steps,
+    startStep,
+    endStep,
+  );
+  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+  });
+
+  function getJourneyQuery(
+    steps: number,
+    startStep?: string,
+    endStep?: string,
+  ): {
+    sequenceQuery: string;
+    startStepQuery: string;
+    endStepQuery: string;
+    params: string[];
+  } {
+    const params: string[] = [];
+    let sequenceQuery = '';
+    let startStepQuery = '';
+    let endStepQuery = '';
+
+    // create sequence query
+    let selectQuery = '';
+    let maxQuery = '';
+    let groupByQuery = '';
+
+    for (let i = 1; i <= steps; i++) {
+      const endQuery = i < steps ? ',' : '';
+      selectQuery += `s.e${i},`;
+      maxQuery += `\nMAX(CASE WHEN event_number = ${i} THEN event ELSE NULL END) AS e${i}${endQuery}`;
+      groupByQuery += `s.e${i}${endQuery} `;
+    }
+
+    sequenceQuery = `\nsequences AS (
+          SELECT ${selectQuery}
+          COUNT(*) count
+      FROM (
+        SELECT visit_id,
+            ${maxQuery}
+        FROM events
+        GROUP BY visit_id) s
+      GROUP BY ${groupByQuery})
+    `;
+
+    // create start Step params query
+    if (startStep) {
+      startStepQuery = `AND e1 = ?`;
+      params.push(startStep);
+    }
+
+    // create end Step params query
+    if (endStep) {
+      for (let i = 1; i < steps; i++) {
+        const startQuery = i === 1 ? 'AND (' : '\nOR ';
+        endStepQuery += `${startQuery}(e${i} = ? AND e${i + 1} IS NULL) `;
+        params.push(endStep);
+      }
+      endStepQuery += `\nOR (e${steps} = ?))`;
+      params.push(endStep);
+    }
+
+    return {
+      sequenceQuery,
+      startStepQuery,
+      endStepQuery,
+      params,
+    };
+  }
+
+  return rawQuery(
+    `
+    WITH events AS (
+      SELECT DISTINCT
+          website_event.visit_id,
+          website_event.referrer_path,
+          COALESCE(NULLIF(website_event.event_name, ''), website_event.url_path) AS event,
+          ROW_NUMBER() OVER (PARTITION BY visit_id ORDER BY website_event.created_at) AS event_number
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        ${filterQuery}),
+    ${sequenceQuery}
+    SELECT *
+    FROM sequences
+    WHERE 1 = 1
+    ${startStepQuery}
+    ${endStepQuery}
+    ORDER BY count DESC
+    LIMIT 100
+    `,
+    [websiteId, startDate, endDate, ...params, ...queryParams],
+  ).then(parseResult);
 }

--- a/src/queries/sql/reports/getPerformance.ts
+++ b/src/queries/sql/reports/getPerformance.ts
@@ -1,4 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
+import { WEB_VITALS_THRESHOLDS } from '@/lib/constants';
 import oceanbase from '@/lib/oceanbase';
 import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
@@ -217,12 +218,18 @@ async function clickhouseQuery(
   return { chart, summary };
 }
 
+const VALID_METRICS = Object.keys(WEB_VITALS_THRESHOLDS);
+
 async function oceanbaseQuery(
   websiteId: string,
   parameters: PerformanceParameters,
   filters: QueryFilters,
 ): Promise<PerformanceResult> {
   const { startDate, endDate, unit = 'day', timezone = 'utc', metric = 'lcp' } = parameters;
+
+  if (!VALID_METRICS.includes(metric)) {
+    throw new Error(`Invalid metric: ${metric}`);
+  }
   const { getDateSQL, rawQuery, parseFilters } = oceanbase;
   const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
     ...filters,

--- a/src/queries/sql/reports/getPerformance.ts
+++ b/src/queries/sql/reports/getPerformance.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -29,6 +30,7 @@ export async function getPerformance(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -181,6 +183,102 @@ async function clickhouseQuery(
       ${filterQuery}
     `,
     { ...queryParams, startDate, endDate },
+  ).then(result => result?.[0]);
+
+  const summary = {
+    lcp: {
+      p50: Number(summaryResult?.lcp_p50 || 0),
+      p75: Number(summaryResult?.lcp_p75 || 0),
+      p95: Number(summaryResult?.lcp_p95 || 0),
+    },
+    inp: {
+      p50: Number(summaryResult?.inp_p50 || 0),
+      p75: Number(summaryResult?.inp_p75 || 0),
+      p95: Number(summaryResult?.inp_p95 || 0),
+    },
+    cls: {
+      p50: Number(summaryResult?.cls_p50 || 0),
+      p75: Number(summaryResult?.cls_p75 || 0),
+      p95: Number(summaryResult?.cls_p95 || 0),
+    },
+    fcp: {
+      p50: Number(summaryResult?.fcp_p50 || 0),
+      p75: Number(summaryResult?.fcp_p75 || 0),
+      p95: Number(summaryResult?.fcp_p95 || 0),
+    },
+    ttfb: {
+      p50: Number(summaryResult?.ttfb_p50 || 0),
+      p75: Number(summaryResult?.ttfb_p75 || 0),
+      p95: Number(summaryResult?.ttfb_p95 || 0),
+    },
+    count: Number(summaryResult?.count || 0),
+  };
+
+  return { chart, summary };
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: PerformanceParameters,
+  filters: QueryFilters,
+): Promise<PerformanceResult> {
+  const { startDate, endDate, unit = 'day', timezone = 'utc', metric = 'lcp' } = parameters;
+  const { getDateSQL, rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, startDate, endDate]);
+
+  const chart = await rawQuery<{ t: string; p50: number; p75: number; p95: number }[]>(
+    `
+    SELECT
+      ${getDateSQL('created_at', unit, timezone)} t,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${metric}) AS p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ${metric}) AS p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${metric}) AS p95
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.event_type = 5
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    GROUP BY t
+    ORDER BY t
+    `,
+    params,
+  );
+
+  const summaryResult = await rawQuery<any>(
+    `
+    SELECT
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY lcp) AS lcp_p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY lcp) AS lcp_p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY lcp) AS lcp_p95,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY inp) AS inp_p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY inp) AS inp_p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY inp) AS inp_p95,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY cls) AS cls_p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY cls) AS cls_p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY cls) AS cls_p95,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY fcp) AS fcp_p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY fcp) AS fcp_p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY fcp) AS fcp_p95,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ttfb) AS ttfb_p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ttfb) AS ttfb_p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ttfb) AS ttfb_p95,
+      COUNT(*) AS count
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.event_type = 5
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    `,
+    params,
   ).then(result => result?.[0]);
 
   const summary = {

--- a/src/queries/sql/reports/getPerformanceMetrics.ts
+++ b/src/queries/sql/reports/getPerformanceMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
+import oceanbase from '@/lib/oceanbase';
 import { SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 import type { PerformanceParameters } from './getPerformance';
@@ -25,6 +26,7 @@ export async function getPerformanceMetrics(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -95,5 +97,42 @@ async function clickhouseQuery(
     ${limit ? `limit ${limit}` : ''}
     `,
     { ...queryParams, startDate, endDate },
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: PerformanceParameters,
+  filters: QueryFilters,
+  column: string,
+  limit?: number,
+): Promise<PerformanceMetricsData[]> {
+  const { startDate, endDate, metric = 'lcp' } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters(
+    { ...filters, websiteId },
+    { joinSession: SESSION_COLUMNS.includes(column) },
+  );
+
+  return rawQuery(
+    `
+    SELECT
+      ${column} AS name,
+      PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${metric}) AS p50,
+      PERCENTILE_CONT(0.75) WITHIN GROUP (ORDER BY ${metric}) AS p75,
+      PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY ${metric}) AS p95,
+      COUNT(*) AS count
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.event_type = 5
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    GROUP BY ${column}
+    ORDER BY p75 DESC
+    ${limit ? `LIMIT ${limit}` : ''}
+    `,
+    [websiteId, startDate, endDate, ...queryParams],
   );
 }

--- a/src/queries/sql/reports/getRetention.ts
+++ b/src/queries/sql/reports/getRetention.ts
@@ -183,13 +183,17 @@ async function oceanbaseQuery(
   const { getDateSQL, getDayDiffQuery, rawQuery, parseFilters } = oceanbase;
   const unit = 'day';
 
-  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters({
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams, queryParams } = parseFilters({
     ...filters,
     websiteId,
     startDate,
     endDate,
     timezone,
   });
+
+  // Build params: cohortQuery params + cohort_items params + user_activities params
+  const cohortItemsParams = buildParams([websiteId, startDate, endDate]);
+  const userActivitiesParams = [websiteId, startDate, endDate];
 
   return rawQuery(
     `
@@ -243,6 +247,6 @@ async function oceanbaseQuery(
     ON c.cohort_date = s.cohort_date
     WHERE c.day_number <= 31
     ORDER BY 1, 2`,
-    [websiteId, startDate, endDate, ...queryParams, websiteId, startDate, endDate, ...queryParams],
+    [...cohortItemsParams, ...userActivitiesParams],
   );
 }

--- a/src/queries/sql/reports/getRetention.ts
+++ b/src/queries/sql/reports/getRetention.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -23,6 +24,7 @@ export async function getRetention(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -169,5 +171,78 @@ async function clickhouseQuery(
     where c.day_number <= 31
     order by 1, 2`,
     queryParams,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: RetentionParameters,
+  filters: QueryFilters,
+): Promise<RetentionResult[]> {
+  const { startDate, endDate, timezone } = parameters;
+  const { getDateSQL, getDayDiffQuery, rawQuery, parseFilters } = oceanbase;
+  const unit = 'day';
+
+  const { filterQuery, joinSessionQuery, cohortQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+    timezone,
+  });
+
+  return rawQuery(
+    `
+    WITH cohort_items AS (
+      SELECT
+        MIN(${getDateSQL('website_event.created_at', unit, timezone)}) AS cohort_date,
+        website_event.session_id
+      FROM website_event
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        ${filterQuery}
+      GROUP BY website_event.session_id
+    ),
+    user_activities AS (
+      SELECT DISTINCT
+        website_event.session_id,
+        ${getDayDiffQuery(getDateSQL('created_at', unit, timezone), 'cohort_items.cohort_date')} AS day_number
+      FROM website_event
+      JOIN cohort_items
+      ON website_event.session_id = cohort_items.session_id
+      WHERE website_id = ?
+          AND created_at BETWEEN ? AND ?
+    ),
+    cohort_size AS (
+      SELECT cohort_date,
+        COUNT(*) AS visitors
+      FROM cohort_items
+      GROUP BY 1
+      ORDER BY 1
+    ),
+    cohort_date AS (
+      SELECT
+        c.cohort_date,
+        a.day_number,
+        COUNT(*) AS visitors
+      FROM user_activities a
+      JOIN cohort_items c
+      ON a.session_id = c.session_id
+      GROUP BY 1, 2
+    )
+    SELECT
+      c.cohort_date AS date,
+      c.day_number AS day,
+      s.visitors,
+      c.visitors AS returnVisitors,
+      c.visitors * 100 / s.visitors AS percentage
+    FROM cohort_date c
+    JOIN cohort_size s
+    ON c.cohort_date = s.cohort_date
+    WHERE c.day_number <= 31
+    ORDER BY 1, 2`,
+    [websiteId, startDate, endDate, ...queryParams, websiteId, startDate, endDate, ...queryParams],
   );
 }

--- a/src/queries/sql/reports/getRevenue.ts
+++ b/src/queries/sql/reports/getRevenue.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -18,6 +19,7 @@ export async function getRevenue(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -117,6 +119,57 @@ async function clickhouseQuery(
     order by t
     `,
     queryParams,
+  );
+
+  return { chart };
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: RevenuParameters,
+  filters: QueryFilters,
+) {
+  const { startDate, endDate, unit = 'day', timezone = 'utc', currency } = parameters;
+  const { getDateSQL, rawQuery, parseFilters } = oceanbase;
+  const { queryParams, filterQuery, cohortQuery, joinSessionQuery } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+    currency,
+  });
+
+  const joinQuery =
+    filterQuery || cohortQuery
+      ? `JOIN (SELECT *
+               FROM website_event
+               WHERE website_id = ?
+                  AND created_at BETWEEN ? AND ?
+                  AND event_type = 2) website_event
+        ON website_event.website_id = revenue.website_id
+          AND website_event.session_id = revenue.session_id
+          AND website_event.event_id = revenue.event_id`
+      : '';
+
+  const chart = await rawQuery(
+    `
+    SELECT
+      revenue.event_name x,
+      ${getDateSQL('revenue.created_at', unit, timezone)} t,
+      SUM(revenue.revenue) y,
+      COUNT(revenue.event_id) count
+    FROM revenue
+    ${joinQuery}
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE revenue.website_id = ?
+      AND revenue.created_at BETWEEN ? AND ?
+      AND UPPER(revenue.currency) = ?
+      ${filterQuery}
+    GROUP BY x, t
+    ORDER BY t
+    `,
+    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
   );
 
   return { chart };

--- a/src/queries/sql/reports/getRevenue.ts
+++ b/src/queries/sql/reports/getRevenue.ts
@@ -151,6 +151,16 @@ async function oceanbaseQuery(
           AND website_event.event_id = revenue.event_id`
       : '';
 
+  const params: any[] = [];
+
+  // joinQuery params (if present)
+  if (filterQuery || cohortQuery) {
+    params.push(websiteId, startDate, endDate);
+  }
+
+  // Main query params
+  params.push(websiteId, startDate, endDate, currency, ...queryParams);
+
   const chart = await rawQuery(
     `
     SELECT
@@ -169,7 +179,7 @@ async function oceanbaseQuery(
     GROUP BY x, t
     ORDER BY t
     `,
-    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+    params,
   );
 
   return { chart };

--- a/src/queries/sql/reports/getRevenueMetrics.ts
+++ b/src/queries/sql/reports/getRevenueMetrics.ts
@@ -1,4 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
+import oceanbase from '@/lib/oceanbase';
 import {
   EMAIL_DOMAINS,
   PAID_AD_PARAMS,
@@ -7,7 +8,7 @@ import {
   SOCIAL_DOMAINS,
   VIDEO_DOMAINS,
 } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 import type { RevenuParameters } from './getRevenue';
@@ -25,6 +26,7 @@ export async function getRevenueMetrics(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -448,4 +450,211 @@ function toClickHouseStringArray(arr: string[]): string {
 
 function toPostgresLikeClause(column: string, arr: string[]) {
   return arr.map(val => `${column} ilike '%${val.replace(/'/g, "''")}%'`).join(' OR\n  ');
+}
+
+function toMySQLLikeClause(column: string, arr: string[]) {
+  return arr.map(val => `LOWER(${column}) LIKE LOWER('%${val.replace(/'/g, "''")}%')`).join(' OR\n  ');
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: RevenuParameters,
+  filters: QueryFilters,
+): Promise<RevenueMetricsResult> {
+  const { startDate, endDate, currency } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { queryParams, filterQuery, cohortQuery, joinSessionQuery } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+    currency,
+  });
+
+  const joinQuery =
+    filterQuery || cohortQuery
+      ? `JOIN (SELECT *
+               FROM website_event
+               WHERE website_id = ?
+                  AND created_at BETWEEN ? AND ?
+                  AND event_type = 2) website_event
+        ON website_event.website_id = revenue.website_id
+          AND website_event.session_id = revenue.session_id
+          AND website_event.event_id = revenue.event_id`
+      : '';
+
+  const country = await rawQuery<{ name: string; value: number }[]>(
+    `
+    SELECT
+      session.country AS name,
+      SUM(revenue) AS value
+    FROM revenue
+    ${joinQuery}
+    JOIN session
+      ON session.website_id = revenue.website_id
+        AND session.session_id = revenue.session_id
+    ${cohortQuery}
+    WHERE revenue.website_id = ?
+      AND revenue.created_at BETWEEN ? AND ?
+      AND UPPER(revenue.currency) = ?
+      ${filterQuery}
+    GROUP BY session.country
+    ORDER BY value DESC
+    `,
+    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+  );
+
+  const region = await rawQuery<{ name: string; value: number; country: string }[]>(
+    `
+    SELECT
+      session.country,
+      session.region AS name,
+      SUM(revenue.revenue) AS value
+    FROM revenue
+    ${joinQuery}
+    JOIN session
+      ON session.website_id = revenue.website_id
+        AND session.session_id = revenue.session_id
+    ${cohortQuery}
+    WHERE revenue.website_id = ?
+      AND revenue.created_at BETWEEN ? AND ?
+      AND UPPER(revenue.currency) = ?
+      ${filterQuery}
+    GROUP BY session.country, session.region
+    ORDER BY value DESC
+    `,
+    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+  );
+
+  const referrer = await rawQuery<{ name: string; value: number }[]>(
+    `
+    WITH events AS (
+      SELECT
+        revenue.website_id,
+        revenue.session_id,
+        SUM(revenue.revenue) AS value
+      FROM revenue
+      ${joinQuery}
+      ${cohortQuery}
+      ${joinSessionQuery}
+      WHERE revenue.website_id = ?
+        AND revenue.created_at BETWEEN ? AND ?
+        AND UPPER(revenue.currency) = ?
+        ${filterQuery}
+      GROUP BY revenue.website_id, revenue.session_id),
+
+    revenue_data AS (
+      SELECT
+        e.website_id,
+        e.session_id,
+        e.value,
+        we.min_date AS created_at
+      FROM events e
+      JOIN (
+        SELECT session_id, MIN(created_at) AS min_date
+        FROM website_event
+        WHERE website_id = ?
+          AND created_at BETWEEN ? AND ?
+        GROUP BY session_id
+      ) we ON we.session_id = e.session_id)
+
+    SELECT
+      we.referrer_domain AS name,
+      SUM(revenue_data.value) AS value
+    FROM revenue_data
+    JOIN (
+      SELECT website_id, session_id, referrer_domain, created_at
+      FROM website_event
+      WHERE website_id = ?
+        AND created_at BETWEEN ? AND ?) we
+    ON we.website_id = revenue_data.website_id
+      AND we.session_id = revenue_data.session_id
+      AND we.created_at = revenue_data.created_at
+    GROUP BY we.referrer_domain
+    ORDER BY value DESC
+    `,
+    [websiteId, startDate, endDate, currency, ...queryParams, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  const channel = await rawQuery<{ name: string; value: number }[]>(
+    `
+    WITH events AS (
+      SELECT
+        revenue.website_id,
+        revenue.session_id,
+        SUM(revenue.revenue) AS value
+      FROM revenue
+      ${joinQuery}
+        ${cohortQuery}
+        ${joinSessionQuery}
+        WHERE revenue.website_id = ?
+          AND revenue.created_at BETWEEN ? AND ?
+          AND UPPER(revenue.currency) = ?
+        ${filterQuery}
+      GROUP BY revenue.website_id, revenue.session_id),
+
+    revenue_data AS (
+      SELECT
+        e.website_id,
+        e.session_id,
+        e.value,
+        we.min_date AS created_at
+      FROM events e
+      JOIN (
+        SELECT session_id, MIN(created_at) AS min_date
+        FROM website_event
+        WHERE website_id = ?
+          AND created_at BETWEEN ? AND ?
+        GROUP BY session_id
+      ) we ON we.session_id = e.session_id),
+
+    revenue_prefix AS (
+      SELECT
+        CASE WHEN LOWER(we.utm_medium) LIKE '%cp%' OR
+              LOWER(we.utm_medium) LIKE '%ppc%' OR
+              LOWER(we.utm_medium) LIKE '%retargeting%' OR
+              LOWER(we.utm_medium) LIKE '%paid%' THEN 'paid' ELSE 'organic' END AS prefix,
+        we.referrer_domain,
+        we.url_query,
+        we.utm_medium,
+        we.utm_source,
+        we.hostname,
+        r.value
+      FROM revenue_data r
+      JOIN (
+        SELECT website_id, session_id, referrer_domain, url_query, utm_medium, utm_source, hostname, created_at
+        FROM website_event
+        WHERE website_id = ?
+          AND created_at BETWEEN ? AND ?) we
+      ON we.website_id = r.website_id
+        AND we.session_id = r.session_id
+        AND we.created_at = r.created_at),
+
+    channels AS (
+      SELECT
+        CASE
+          WHEN referrer_domain = '' AND url_query = '' THEN 'direct'
+          WHEN ${toMySQLLikeClause('url_query', PAID_AD_PARAMS)} THEN 'paidAds'
+          WHEN ${toMySQLLikeClause('utm_medium', ['referral', 'app', 'link'])} THEN 'referral'
+          WHEN LOWER(utm_medium) LIKE '%affiliate%' THEN 'affiliate'
+          WHEN LOWER(utm_medium) LIKE '%sms%' OR LOWER(utm_source) LIKE '%sms%' THEN 'sms'
+          WHEN ${toMySQLLikeClause('referrer_domain', SEARCH_DOMAINS)} OR LOWER(utm_medium) LIKE '%organic%' THEN CONCAT(prefix, 'Search')
+          WHEN ${toMySQLLikeClause('referrer_domain', SOCIAL_DOMAINS)} THEN CONCAT(prefix, 'Social')
+          WHEN ${toMySQLLikeClause('referrer_domain', EMAIL_DOMAINS)} OR LOWER(utm_medium) LIKE '%mail%' THEN 'email'
+          WHEN ${toMySQLLikeClause('referrer_domain', SHOPPING_DOMAINS)} OR LOWER(utm_medium) LIKE '%shop%' THEN CONCAT(prefix, 'Shopping')
+          WHEN ${toMySQLLikeClause('referrer_domain', VIDEO_DOMAINS)} OR LOWER(utm_medium) LIKE '%video%' THEN CONCAT(prefix, 'Video')
+          WHEN referrer_domain != REGEXP_REPLACE(hostname, '^www.', '') AND referrer_domain != '' THEN 'referral'
+        ELSE 'Unknown' END AS name,
+        value
+      FROM revenue_prefix)
+
+    SELECT name, SUM(value) AS value
+    FROM channels
+    GROUP BY name
+    ORDER BY value DESC
+    `,
+    [websiteId, startDate, endDate, currency, ...queryParams, websiteId, startDate, endDate, websiteId, startDate, endDate],
+  );
+
+  return { country, region, referrer, channel };
 }

--- a/src/queries/sql/reports/getRevenueMetrics.ts
+++ b/src/queries/sql/reports/getRevenueMetrics.ts
@@ -471,8 +471,9 @@ async function oceanbaseQuery(
     currency,
   });
 
-  const joinQuery =
-    filterQuery || cohortQuery
+  const hasJoinQuery = !!(filterQuery || cohortQuery);
+
+  const joinQuery = hasJoinQuery
       ? `JOIN (SELECT *
                FROM website_event
                WHERE website_id = ?
@@ -482,6 +483,18 @@ async function oceanbaseQuery(
           AND website_event.session_id = revenue.session_id
           AND website_event.event_id = revenue.event_id`
       : '';
+
+  // joinQuery adds 3 params when present
+  const joinParams = hasJoinQuery ? [websiteId, startDate, endDate] : [];
+  const cohortParams = cohortQuery ? [websiteId, startDate, endDate] : [];
+
+  // country: joinQuery(0|3) + cohort(0|3) + WHERE(websiteId, startDate, endDate, currency) + filterQuery(N)
+  const countryRegionParams = [
+    ...joinParams,
+    ...cohortParams,
+    websiteId, startDate, endDate, currency,
+    ...queryParams,
+  ];
 
   const country = await rawQuery<{ name: string; value: number }[]>(
     `
@@ -501,7 +514,7 @@ async function oceanbaseQuery(
     GROUP BY session.country
     ORDER BY value DESC
     `,
-    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+    countryRegionParams,
   );
 
   const region = await rawQuery<{ name: string; value: number; country: string }[]>(
@@ -523,8 +536,18 @@ async function oceanbaseQuery(
     GROUP BY session.country, session.region
     ORDER BY value DESC
     `,
-    [websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+    countryRegionParams,
   );
+
+  // referrer & channel: joinQuery(0|3) + cohort(0|3) + WHERE(4) + filterQuery(N) + 2 subqueries(3+3)
+  const cteParams = [
+    ...joinParams,
+    ...cohortParams,
+    websiteId, startDate, endDate, currency,
+    ...queryParams,
+    websiteId, startDate, endDate,
+    websiteId, startDate, endDate,
+  ];
 
   const referrer = await rawQuery<{ name: string; value: number }[]>(
     `
@@ -573,7 +596,7 @@ async function oceanbaseQuery(
     GROUP BY we.referrer_domain
     ORDER BY value DESC
     `,
-    [websiteId, startDate, endDate, currency, ...queryParams, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   const channel = await rawQuery<{ name: string; value: number }[]>(
@@ -653,7 +676,7 @@ async function oceanbaseQuery(
     GROUP BY name
     ORDER BY value DESC
     `,
-    [websiteId, startDate, endDate, currency, ...queryParams, websiteId, startDate, endDate, websiteId, startDate, endDate],
+    cteParams,
   );
 
   return { country, region, referrer, channel };

--- a/src/queries/sql/reports/getRevenueSessions.ts
+++ b/src/queries/sql/reports/getRevenueSessions.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -11,6 +12,7 @@ export async function getRevenueSessions(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -140,6 +142,100 @@ async function clickhouseQuery(websiteId: string, currency: string, filters: Que
     order by max(created_at) desc
     `,
     queryParams,
+    filters,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, currency: string, filters: QueryFilters) {
+  const { pagedRawQuery, parseFilters } = oceanbase;
+  const { search } = filters;
+  const { filterQuery, dateQuery, cohortQuery, queryParams, buildParams, getDateParams } = parseFilters({
+    ...filters,
+    websiteId,
+    currency,
+    search: search ? `%${search}%` : undefined,
+  });
+
+  const searchQuery = search
+    ? `AND (LOWER(session.browser) LIKE LOWER(?)
+           OR LOWER(session.os) LIKE LOWER(?)
+           OR LOWER(session.device) LIKE LOWER(?)
+           OR LOWER(session.city) LIKE LOWER(?))`
+    : '';
+
+  const dateParams = getDateParams();
+
+  // Build params: cohortQuery + subquery(websiteId,startDate,endDate,currency) + websiteId + dateQuery + filterQuery + searchQuery
+  const params: any[] = [];
+
+  // cohortQuery params (if present)
+  if (cohortQuery) {
+    params.push(websiteId, filters.startDate, filters.endDate);
+  }
+
+  // Subquery params: website_id, start_date, end_date, currency
+  params.push(websiteId, filters.startDate, filters.endDate, currency);
+
+  // Main query params: website_id + dateQuery + filterQuery
+  params.push(websiteId, ...dateParams, ...queryParams);
+
+  // searchQuery params
+  if (search) {
+    params.push(search, search, search, search);
+  }
+
+  return pagedRawQuery(
+    `
+    SELECT
+      session.session_id AS id,
+      session.website_id AS websiteId,
+      website_event.hostname,
+      session.browser,
+      session.os,
+      session.device,
+      session.screen,
+      session.language,
+      session.country,
+      session.region,
+      session.city,
+      MIN(website_event.created_at) AS firstAt,
+      MAX(website_event.created_at) AS lastAt,
+      COUNT(DISTINCT website_event.visit_id) AS visits,
+      SUM(CASE WHEN website_event.event_type = 1 THEN 1 ELSE 0 END) AS views,
+      SUM(CASE WHEN website_event.event_type = 2 THEN 1 ELSE 0 END) AS events,
+      MAX(website_event.created_at) AS createdAt
+    FROM website_event
+    ${cohortQuery}
+    JOIN session
+      ON session.session_id = website_event.session_id
+      AND session.website_id = website_event.website_id
+    JOIN (
+      SELECT DISTINCT session_id
+      FROM revenue
+      WHERE website_id = ?
+        AND revenue.created_at BETWEEN ? AND ?
+        AND UPPER(currency) = ?
+    ) rev ON rev.session_id = website_event.session_id
+    WHERE website_event.website_id = ?
+    ${dateQuery}
+    ${filterQuery}
+    ${searchQuery}
+    GROUP BY
+      session.session_id,
+      session.website_id,
+      website_event.hostname,
+      session.browser,
+      session.os,
+      session.device,
+      session.screen,
+      session.language,
+      session.country,
+      session.region,
+      session.city
+    ORDER BY MAX(website_event.created_at) DESC
+    `,
+    params,
     filters,
     FUNCTION_NAME,
   );

--- a/src/queries/sql/reports/getRevenueSessions.ts
+++ b/src/queries/sql/reports/getRevenueSessions.ts
@@ -180,9 +180,9 @@ async function oceanbaseQuery(websiteId: string, currency: string, filters: Quer
   // Main query params: website_id + dateQuery + filterQuery
   params.push(websiteId, ...dateParams, ...queryParams);
 
-  // searchQuery params
+  // searchQuery params (LIKE requires % wildcards)
   if (search) {
-    params.push(search, search, search, search);
+    params.push(`%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`);
   }
 
   return pagedRawQuery(

--- a/src/queries/sql/reports/getRevenueStats.ts
+++ b/src/queries/sql/reports/getRevenueStats.ts
@@ -164,6 +164,19 @@ async function oceanbaseQuery(
           AND website_event.event_id = revenue.event_id`
       : '';
 
+  const params: any[] = [];
+
+  // Subquery params (total_sessions)
+  params.push(websiteId, startDate, endDate);
+
+  // joinQuery params (if present)
+  if (filterQuery || cohortQuery) {
+    params.push(websiteId, startDate, endDate);
+  }
+
+  // Main query params
+  params.push(websiteId, startDate, endDate, currency, ...queryParams);
+
   const total = await rawQuery<{
     sum: number;
     count: number;
@@ -188,7 +201,7 @@ async function oceanbaseQuery(
       AND UPPER(revenue.currency) = ?
       ${filterQuery}
   `,
-    [websiteId, startDate, endDate, websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+    params,
   ).then(result => result?.[0]);
 
   return {

--- a/src/queries/sql/reports/getRevenueStats.ts
+++ b/src/queries/sql/reports/getRevenueStats.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 import type { RevenuParameters } from './getRevenue';
@@ -18,6 +19,7 @@ export async function getRevenueStats(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -133,4 +135,67 @@ async function clickhouseQuery(
   total.arpu = total.total_sessions > 0 ? total.sum / total.total_sessions : 0;
 
   return total;
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: RevenuParameters,
+  filters: QueryFilters,
+): Promise<RevenueStatsResult> {
+  const { startDate, endDate, currency } = parameters;
+  const { rawQuery, parseFilters } = oceanbase;
+  const { queryParams, filterQuery, cohortQuery, joinSessionQuery } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+    currency,
+  });
+
+  const joinQuery =
+    filterQuery || cohortQuery
+      ? `JOIN (SELECT *
+               FROM website_event
+               WHERE website_id = ?
+                  AND created_at BETWEEN ? AND ?
+                  AND event_type = 2) website_event
+        ON website_event.website_id = revenue.website_id
+          AND website_event.session_id = revenue.session_id
+          AND website_event.event_id = revenue.event_id`
+      : '';
+
+  const total = await rawQuery<{
+    sum: number;
+    count: number;
+    unique_count: number;
+    total_sessions: number;
+  }[]>(
+    `
+    SELECT
+      SUM(revenue.revenue) AS sum,
+      COUNT(DISTINCT revenue.event_id) AS count,
+      COUNT(DISTINCT revenue.session_id) AS unique_count,
+      (SELECT COUNT(DISTINCT session_id)
+       FROM website_event
+       WHERE website_id = ?
+         AND created_at BETWEEN ? AND ?) AS total_sessions
+    FROM revenue
+    ${joinQuery}
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE revenue.website_id = ?
+      AND revenue.created_at BETWEEN ? AND ?
+      AND UPPER(revenue.currency) = ?
+      ${filterQuery}
+  `,
+    [websiteId, startDate, endDate, websiteId, startDate, endDate, websiteId, startDate, endDate, currency, ...queryParams],
+  ).then(result => result?.[0]);
+
+  return {
+    sum: Number(total?.sum || 0),
+    count: Number(total?.count || 0),
+    average: total && total.count > 0 ? Number(total.sum) / Number(total.count) : 0,
+    unique_count: Number(total?.unique_count || 0),
+    arpu: total && total.total_sessions > 0 ? Number(total.sum) / Number(total.total_sessions) : 0,
+  };
 }

--- a/src/queries/sql/reports/getUTM.ts
+++ b/src/queries/sql/reports/getUTM.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
+import oceanbase from '@/lib/oceanbase';
 import { EVENT_TYPE } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -16,6 +17,7 @@ export async function getUTM(
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
   });
 }
 
@@ -82,5 +84,40 @@ async function clickhouseQuery(
     limit 50
     `,
     queryParams,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: UTMParameters,
+  filters: QueryFilters,
+) {
+  const { column, startDate, endDate } = parameters;
+  const { parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+    startDate,
+    endDate,
+    eventType: EVENT_TYPE.pageView,
+  });
+
+  const params = buildParams([websiteId, startDate, endDate]);
+
+  return rawQuery(
+    `
+    SELECT website_event.${column} utm, COUNT(*) AS views
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND COALESCE(website_event.${column}, '') != ''
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 50
+    `,
+    params,
   );
 }

--- a/src/queries/sql/sessions/getSessionActivity.ts
+++ b/src/queries/sql/sessions/getSessionActivity.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -10,6 +11,7 @@ export async function getSessionActivity(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -62,19 +64,51 @@ async function clickhouseQuery(websiteId: string, sessionId: string, filters: Qu
       event_name as eventName,
       visit_id as visitId,
       hostname,
-      event_id IN (select event_id 
-                   from event_data 
-                   where website_id = {websiteId:UUID} 
+      event_id IN (select event_id
+                   from event_data
+                   where website_id = {websiteId:UUID}
                     and session_id = {sessionId:UUID}
                     and created_at between {startDate:DateTime64} and {endDate:DateTime64}) AS hasData
     from website_event
     where website_id = {websiteId:UUID}
-      and session_id = {sessionId:UUID} 
+      and session_id = {sessionId:UUID}
       and created_at between {startDate:DateTime64} and {endDate:DateTime64}
     order by created_at desc
     limit 500
     `,
     { websiteId, sessionId, startDate, endDate },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, sessionId: string, filters: QueryFilters) {
+  const { rawQuery } = oceanbase;
+  const { startDate, endDate } = filters;
+
+  return rawQuery(
+    `
+    SELECT
+      created_at AS createdAt,
+      url_path AS urlPath,
+      url_query AS urlQuery,
+      referrer_domain AS referrerDomain,
+      event_id AS eventId,
+      event_type AS eventType,
+      event_name AS eventName,
+      visit_id AS visitId,
+      hostname,
+      event_id IN (SELECT website_event_id
+                   FROM event_data
+                   WHERE website_id = ?
+                      AND created_at BETWEEN ? AND ?) AS hasData
+    FROM website_event
+    WHERE website_id = ?
+      AND session_id = ?
+      AND created_at BETWEEN ? AND ?
+    ORDER BY created_at DESC
+    LIMIT 500
+    `,
+    [websiteId, startDate, endDate, websiteId, sessionId, startDate, endDate],
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/sessions/getSessionData.ts
+++ b/src/queries/sql/sessions/getSessionData.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 const FUNCTION_NAME = 'getSessionData';
@@ -7,6 +8,7 @@ const FUNCTION_NAME = 'getSessionData';
 export async function getSessionData(...args: [websiteId: string, sessionId: string]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -55,6 +57,30 @@ async function clickhouseQuery(websiteId: string, sessionId: string) {
     order by data_key asc
     `,
     { websiteId, sessionId },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, sessionId: string) {
+  const { rawQuery } = oceanbase;
+
+  return rawQuery(
+    `
+    SELECT
+        website_id AS websiteId,
+        session_id AS sessionId,
+        data_key AS dataKey,
+        data_type AS dataType,
+        REPLACE(string_value, '.0000', '') AS stringValue,
+        number_value AS numberValue,
+        date_value AS dateValue,
+        created_at AS createdAt
+    FROM session_data
+    WHERE website_id = ?
+      AND session_id = ?
+    ORDER BY data_key ASC
+    `,
+    [websiteId, sessionId],
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/sessions/getSessionDataProperties.ts
+++ b/src/queries/sql/sessions/getSessionDataProperties.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -10,6 +11,7 @@ export async function getSessionDataProperties(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -70,6 +72,38 @@ async function clickhouseQuery(
     limit 500
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      data_key AS propertyName,
+      COUNT(DISTINCT session_data.session_id) AS total
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    JOIN session_data
+      ON session_data.session_id = website_event.session_id
+        AND session_data.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 500
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/sessions/getSessionDataValues.ts
+++ b/src/queries/sql/sessions/getSessionDataValues.ts
@@ -1,15 +1,15 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
 const FUNCTION_NAME = 'getSessionDataValues';
 
-export async function getSessionDataValues(
-  ...args: [websiteId: string, filters: QueryFilters & { propertyName?: string }]
-) {
+export async function getSessionDataValues(...args: [websiteId: string, filters: QueryFilters & { propertyName?: string }]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -80,6 +80,46 @@ async function clickhouseQuery(
     limit 100
     `,
     queryParams,
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters & { propertyName?: string },
+) {
+  const { rawQuery, parseFilters, getDateSQL } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, buildParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate, filters.propertyName]);
+
+  return rawQuery(
+    `
+    SELECT
+      CASE
+        WHEN data_type = 2 THEN REPLACE(string_value, '.0000', '')
+        WHEN data_type = 4 THEN ${getDateSQL('date_value', 'hour')}
+        ELSE string_value
+      END AS value,
+      COUNT(DISTINCT session_data.session_id) AS total
+    FROM website_event
+    ${cohortQuery}
+    ${joinSessionQuery}
+    JOIN session_data
+        ON session_data.session_id = website_event.session_id
+          AND session_data.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND session_data.data_key = ?
+    ${filterQuery}
+    GROUP BY value
+    ORDER BY 2 DESC
+    LIMIT 100
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/sessions/getSessionExpandedMetrics.ts
+++ b/src/queries/sql/sessions/getSessionExpandedMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -26,6 +27,7 @@ export async function getSessionExpandedMetrics(
 ): Promise<SessionExpandedMetricsData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -144,13 +146,81 @@ async function clickhouseQuery(
       group by name, session_id, visit_id
       ${includeCountry ? ', country' : ''}
     ) as t
-    group by name 
+    group by name
     ${includeCountry ? ', country' : ''}
     order by visitors desc, visits desc
     limit ${limit}
     offset ${offset}
     `,
     { ...queryParams, ...parameters },
+    FUNCTION_NAME,
+  );
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: SessionExpandedMetricsParameters,
+  filters: QueryFilters,
+): Promise<SessionExpandedMetricsData[]> {
+  const { type, limit = 500, offset = 0 } = parameters;
+  let column = FILTER_COLUMNS[type] || type;
+  const { parseFilters, rawQuery, getTimestampDiffSQL } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters(
+      {
+        ...filters,
+        websiteId,
+      },
+      {
+        joinSession: SESSION_COLUMNS.includes(type),
+      },
+    );
+  const includeCountry = column === 'city' || column === 'region';
+
+  if (type === 'language') {
+    column = `LOWER(LEFT(${type}, 2))`;
+  }
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      name,
+      ${includeCountry ? 'country,' : ''}
+      SUM(t.c) AS pageviews,
+      COUNT(DISTINCT t.session_id) AS visitors,
+      COUNT(DISTINCT t.visit_id) AS visits,
+      SUM(CASE WHEN t.c = 1 THEN 1 ELSE 0 END) AS bounces,
+      SUM(${getTimestampDiffSQL('t.min_time', 't.max_time')}) AS totaltime
+    FROM (
+      SELECT
+        ${column} AS name,
+        ${includeCountry ? 'country,' : ''}
+        website_event.session_id,
+        website_event.visit_id,
+        COUNT(*) AS c,
+        MIN(website_event.created_at) AS min_time,
+        MAX(website_event.created_at) AS max_time
+      FROM website_event
+      ${cohortQuery}
+      ${excludeBounceQuery}
+      ${joinSessionQuery}
+      WHERE website_event.website_id = ?
+        AND website_event.created_at BETWEEN ? AND ?
+        AND website_event.event_type NOT IN (2, 5)
+        ${filterQuery}
+      GROUP BY name, website_event.session_id, website_event.visit_id
+      ${includeCountry ? ', country' : ''}
+    ) AS t
+    WHERE name != ''
+    GROUP BY name
+    ${includeCountry ? ', country' : ''}
+    ORDER BY visitors DESC, visits DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
     FUNCTION_NAME,
   );
 }

--- a/src/queries/sql/sessions/getSessionMetrics.ts
+++ b/src/queries/sql/sessions/getSessionMetrics.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -17,6 +18,7 @@ export async function getSessionMetrics(
 ) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -134,4 +136,56 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, { ...queryParams, ...parameters }, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  parameters: SessionMetricsParameters,
+  filters: QueryFilters,
+) {
+  const { type, limit = 500, offset = 0 } = parameters;
+  let column = FILTER_COLUMNS[type] || type;
+  const { parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters(
+      {
+        ...filters,
+        websiteId,
+      },
+      {
+        joinSession: SESSION_COLUMNS.includes(type),
+      },
+    );
+  const includeCountry = column === 'city' || column === 'region';
+
+  if (type === 'language') {
+    column = `LOWER(LEFT(${type}, 2))`;
+  }
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      ${column} x,
+      COUNT(DISTINCT website_event.session_id) y
+      ${includeCountry ? ', country' : ''}
+    FROM website_event
+    ${cohortQuery}
+    ${excludeBounceQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+      AND ${column} != ''
+    ${filterQuery}
+    GROUP BY 1
+    ${includeCountry ? ', 3' : ''}
+    ORDER BY 2 DESC
+    LIMIT ${limit}
+    OFFSET ${offset}
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/sessions/getSessionStats.ts
+++ b/src/queries/sql/sessions/getSessionStats.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -9,6 +10,7 @@ const FUNCTION_NAME = 'getSessionStats';
 export async function getSessionStats(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -99,4 +101,36 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, queryParams, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { timezone = 'utc', unit = 'day' } = filters;
+  const { getDateSQL, parseFilters, rawQuery } = oceanbase;
+  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, buildParams } =
+    parseFilters({
+      ...filters,
+      websiteId,
+    });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      ${getDateSQL('website_event.created_at', unit, timezone)} x,
+      COUNT(DISTINCT website_event.session_id) y
+    FROM website_event
+    ${cohortQuery}
+    ${excludeBounceQuery}
+    ${joinSessionQuery}
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      AND website_event.event_type NOT IN (2, 5)
+      ${filterQuery}
+    GROUP BY 1
+    ORDER BY 1
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/sessions/getWebsiteSession.ts
+++ b/src/queries/sql/sessions/getWebsiteSession.ts
@@ -1,5 +1,6 @@
 import clickhouse from '@/lib/clickhouse';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 
 const FUNCTION_NAME = 'getWebsiteSession';
@@ -7,6 +8,7 @@ const FUNCTION_NAME = 'getWebsiteSession';
 export async function getWebsiteSession(...args: [websiteId: string, sessionId: string]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -108,6 +110,57 @@ async function clickhouseQuery(websiteId: string, sessionId: string) {
     group by id, websiteId, distinctId, browser, os, device, screen, language, country, region, city;
     `,
     { websiteId, sessionId },
+    FUNCTION_NAME,
+  ).then(result => result?.[0]);
+}
+
+async function oceanbaseQuery(websiteId: string, sessionId: string) {
+  const { rawQuery, getTimestampDiffSQL } = oceanbase;
+
+  return rawQuery(
+    `
+    SELECT id,
+      distinct_id AS distinctId,
+      website_id AS websiteId,
+      browser,
+      os,
+      device,
+      screen,
+      language,
+      country,
+      region,
+      city,
+      MIN(min_time) AS firstAt,
+      MAX(max_time) AS lastAt,
+      COUNT(DISTINCT visit_id) AS visits,
+      SUM(views) AS views,
+      SUM(events) AS events,
+      SUM(${getTimestampDiffSQL('min_time', 'max_time')}) AS totaltime
+    FROM (SELECT
+          session.session_id AS id,
+          session.distinct_id,
+          website_event.visit_id,
+          session.website_id,
+          session.browser,
+          session.os,
+          session.device,
+          session.screen,
+          session.language,
+          session.country,
+          session.region,
+          session.city,
+          MIN(website_event.created_at) AS min_time,
+          MAX(website_event.created_at) AS max_time,
+          SUM(CASE WHEN website_event.event_type = 1 THEN 1 ELSE 0 END) AS views,
+          SUM(CASE WHEN website_event.event_type = 2 THEN 1 ELSE 0 END) AS events
+    FROM session
+    JOIN website_event ON website_event.session_id = session.session_id
+    WHERE session.website_id = ?
+      AND session.session_id = ?
+    GROUP BY session.session_id, session.distinct_id, visit_id, session.website_id, session.browser, session.os, session.device, session.screen, session.language, session.country, session.region, session.city) t
+    GROUP BY id, distinct_id, website_id, browser, os, device, screen, language, country, region, city;
+    `,
+    [websiteId, sessionId],
     FUNCTION_NAME,
   ).then(result => result?.[0]);
 }

--- a/src/queries/sql/sessions/getWebsiteSessionStats.ts
+++ b/src/queries/sql/sessions/getWebsiteSessionStats.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -19,6 +20,7 @@ export async function getWebsiteSessionStats(
 ): Promise<WebsiteSessionStatsData[]> {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -94,4 +96,34 @@ async function clickhouseQuery(
   }
 
   return rawQuery(sql, queryParams, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(
+  websiteId: string,
+  filters: QueryFilters,
+): Promise<WebsiteSessionStatsData[]> {
+  const { rawQuery, parseFilters } = oceanbase;
+  const { filterQuery, cohortQuery, buildParams } = parseFilters({ ...filters, websiteId });
+
+  const params = buildParams([websiteId, filters.startDate, filters.endDate]);
+
+  return rawQuery(
+    `
+    SELECT
+      COUNT(*) AS pageviews,
+      COUNT(DISTINCT website_event.session_id) AS visitors,
+      COUNT(DISTINCT website_event.visit_id) AS visits,
+      COUNT(DISTINCT session.country) AS countries,
+      SUM(CASE WHEN website_event.event_type = 2 THEN 1 ELSE 0 END) AS events
+    FROM website_event
+    ${cohortQuery}
+    JOIN session ON website_event.session_id = session.session_id
+      AND website_event.website_id = session.website_id
+    WHERE website_event.website_id = ?
+      AND website_event.created_at BETWEEN ? AND ?
+      ${filterQuery}
+    `,
+    params,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -1,6 +1,7 @@
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_COLUMNS } from '@/lib/constants';
-import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { CLICKHOUSE, OCEANBASE, PRISMA, runQuery } from '@/lib/db';
+import oceanbase from '@/lib/oceanbase';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
 
@@ -9,6 +10,7 @@ const FUNCTION_NAME = 'getWebsiteSessions';
 export async function getWebsiteSessions(...args: [websiteId: string, filters: QueryFilters]) {
   return runQuery({
     [PRISMA]: () => relationalQuery(...args),
+    [OCEANBASE]: () => oceanbaseQuery(...args),
     [CLICKHOUSE]: () => clickhouseQuery(...args),
   });
 }
@@ -156,4 +158,74 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
   }
 
   return pagedRawQuery(sql, queryParams, filters, FUNCTION_NAME);
+}
+
+async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
+  const { pagedRawQuery, parseFilters } = oceanbase;
+  const { search } = filters;
+  const { filterQuery, dateQuery, cohortQuery, buildParams, getDateParams } = parseFilters({
+    ...filters,
+    websiteId,
+    search: search ? `%${search}%` : undefined,
+  });
+
+  // SQL order: cohortQuery, websiteId, dateQuery, filterQuery, searchQuery
+  const params = buildParams([websiteId, ...getDateParams()]);
+
+  // Add search params if needed
+  const searchParams = search ? [search, search, search, search, search] : [];
+
+  const searchQuery = search
+    ? `AND (LOWER(distinct_id) LIKE ?
+           OR LOWER(city) LIKE ?
+           OR LOWER(browser) LIKE ?
+           OR LOWER(os) LIKE ?
+           OR LOWER(device) LIKE ?)`
+    : '';
+
+  return pagedRawQuery(
+    `
+    SELECT
+      session.session_id AS id,
+      session.website_id AS websiteId,
+      website_event.hostname,
+      session.browser,
+      session.os,
+      session.device,
+      session.screen,
+      session.language,
+      session.country,
+      session.region,
+      session.city,
+      MIN(website_event.created_at) AS firstAt,
+      MAX(website_event.created_at) AS lastAt,
+      COUNT(DISTINCT website_event.visit_id) AS visits,
+      SUM(CASE WHEN website_event.event_type = 1 THEN 1 ELSE 0 END) AS views,
+      SUM(CASE WHEN website_event.event_type = 2 THEN 1 ELSE 0 END) AS events,
+      MAX(website_event.created_at) AS createdAt
+    FROM website_event
+    ${cohortQuery}
+    JOIN session ON session.session_id = website_event.session_id
+      AND session.website_id = website_event.website_id
+    WHERE website_event.website_id = ?
+    ${dateQuery}
+    ${filterQuery}
+    ${searchQuery}
+    GROUP BY session.session_id,
+      session.website_id,
+      website_event.hostname,
+      session.browser,
+      session.os,
+      session.device,
+      session.screen,
+      session.language,
+      session.country,
+      session.region,
+      session.city
+    ORDER BY MAX(website_event.created_at) DESC
+    `,
+    [...params, ...searchParams],
+    filters,
+    FUNCTION_NAME,
+  );
 }

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -172,8 +172,8 @@ async function oceanbaseQuery(websiteId: string, filters: QueryFilters) {
   // SQL order: cohortQuery, websiteId, dateQuery, filterQuery, searchQuery
   const params = buildParams([websiteId, ...getDateParams()]);
 
-  // Add search params if needed
-  const searchParams = search ? [search, search, search, search, search] : [];
+  // Add search params if needed (LIKE requires % wildcards)
+  const searchParams = search ? [`%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`, `%${search}%`] : [];
 
   const searchQuery = search
     ? `AND (LOWER(distinct_id) LIKE ?


### PR DESCRIPTION
## Summary

- Add OceanBase as an alternative Analytics Processing (AP) database option
- Implement OceanBase adapter following existing ClickHouse/PostgreSQL patterns
- Support all 52 query files with OceanBase implementations
- Fix conditional parameter building for revenue queries

## Changes

### Core Implementation
- `src/lib/oceanbase.ts` - OceanBase database adapter with connection pooling, query execution, and filter parsing
- `src/lib/db.ts` - Add OCEANBASE database type
- `package.json` - Add mysql2 dependency

### Query Implementations
- All query files under `src/queries/sql/` now support OceanBase
- Revenue queries fixed to correctly handle conditional JOIN parameters

### Database Schema
- `db/oceanbase/schema.sql` - Complete schema with proper indexes and foreign keys
- `db/oceanbase/init.sql` - Initialization script

### Docker Support
- `docker-compose.oceanbase.yml` - Local development environment with OceanBase CE

## Test Plan

- [x] OceanBase connection and schema creation
- [x] Basic CRUD operations
- [x] JOIN queries with conditional parameters
- [x] Revenue query parameter building (with/without filterQuery)
- [x] Date functions (DATE_FORMAT, CONVERT_TZ)
- [x] Pagination queries
- [x] All 20 end-to-end tests passed