### PR TITLE
feat: add data-auto-pageview attribute to tracker script

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -37,6 +37,7 @@
   const domain = config('domains') || '';
   const credentials = config('fetch-credentials') || 'omit';
   const perf = config('performance') === _true;
+  const autoPageview = config('auto-pageview') !== _false;
 
   const domains = domain.split(',').map(n => n.trim());
   const host =
@@ -197,7 +198,7 @@
   const init = () => {
     if (!initialized) {
       initialized = true;
-      track();
+      if (autoPageview) track();
       handlePathChanges();
       handleClicks();
       if (perf) initPerformance();

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -91,7 +91,7 @@
     currentRef = currentUrl;
     currentUrl = normalize(new URL(url, location.href).toString());
 
-    if (currentUrl !== currentRef) {
+    if (currentUrl !== currentRef && autoPageview) {
       setTimeout(track, delayDuration);
     }
   };


### PR DESCRIPTION
Allow disabling the automatic pageview tracking while keeping performance tracking, click handling, and path change detection active.