### PR TITLE
fix: normalize autofill styles across browsers

### DIFF
--- a/src/app/global.css
+++ b/src/app/global.css
@@ -41,19 +41,25 @@ html[style*="padding-right"] {
   background-clip: padding-box;
 }
 
-/* Fix autofill background color to match dark theme */
-input:-webkit-autofill,
-input:-webkit-autofill:hover,
-input:-webkit-autofill:focus,
-input:-webkit-autofill:active,
-textarea:-webkit-autofill,
-textarea:-webkit-autofill:hover,
-textarea:-webkit-autofill:focus,
-select:-webkit-autofill,
-select:-webkit-autofill:hover,
-select:-webkit-autofill:focus {
-  -webkit-box-shadow: 0 0 0 1000px var(--background-color) inset !important;
-  transition: color 5000s ease-in-out 0s;
+/* Fix autofill background color to match theme */
+input:is(:-webkit-autofill, :autofill),
+input:is(:-webkit-autofill, :autofill):hover,
+input:is(:-webkit-autofill, :autofill):focus,
+input:is(:-webkit-autofill, :autofill):active,
+textarea:is(:-webkit-autofill, :autofill),
+textarea:is(:-webkit-autofill, :autofill):hover,
+textarea:is(:-webkit-autofill, :autofill):focus,
+select:is(:-webkit-autofill, :autofill),
+select:is(:-webkit-autofill, :autofill):hover,
+select:is(:-webkit-autofill, :autofill):focus {
+  color: var(--text-primary) !important;
+  caret-color: var(--text-primary);
+  box-shadow: 0 0 0 1000px var(--surface-base) inset !important;
+  -webkit-box-shadow: 0 0 0 1000px var(--surface-base) inset !important;
+  -webkit-text-fill-color: var(--text-primary) !important;
+  transition:
+    background-color 5000s ease-in-out 0s,
+    color 5000s ease-in-out 0s;
 }
 
 /* Code snippet textareas */


### PR DESCRIPTION
## Summary

Fixes #4171.

This updates the global autofill styles to support Firefox by targeting the standard `:autofill` pseudo-class in addition to `:-webkit-autofill`.

It also replaces the missing `--background-color` token with existing theme tokens so autofilled fields match the current Umami theme instead of showing the browser default gold/yellow fill.

## Changes

- Add `:autofill` support for Firefox autofilled form fields
- Keep existing `:-webkit-autofill` coverage for Chromium/WebKit browsers
- Use `--surface-base` and `--text-primary` for theme-aware autofill styling
- Preserve autofill text/caret color in themed inputs


## Screenshots

### Before

<!-- Firefox autofill showing gold/yellow fields -->
<img width="905" height="600" alt="image" src="https://github.com/user-attachments/assets/bfadc16f-0135-47f3-8b6e-c7f6de56639c" />



### After 

<!-- Firefox autofill matching Umami theme -->

### Fire Fox
<img width="1364" height="825" alt="image" src="https://github.com/user-attachments/assets/51eeeda3-b8d7-4821-9fc5-da03923ba31c" />



### Chromium Check

<!-- Optional: Chrome/Edge/Brave autofill after the fix -->
### Chrome 
<img width="1812" height="995" alt="image" src="https://github.com/user-attachments/assets/ae5c091b-0dca-4e2f-b5be-4f01f10aecb1" />


### Brave
<img width="1862" height="976" alt="image" src="https://github.com/user-attachments/assets/6c33cdf2-382e-4c02-adb7-627ca139f284" />


### Microsoft Edge
<img width="2408" height="913" alt="image" src="https://github.com/user-attachments/assets/6934784a-5692-42ce-85b5-84981564dca0" />




## Testing

- Logged in locally with PostgreSQL Docker setup
- Saved credentials in Firefox
- Reloaded `/login` and triggered browser autofill
- Confirmed autofilled username/password fields no longer show the gold Firefox autofill background
- Ran `pnpm exec biome lint src/app/global.css`

