### PR TITLE
fix: clean up link, pixel, board rows on user/team deletion

### DIFF
--- a/src/app/(collect)/p/[slug]/route.ts
+++ b/src/app/(collect)/p/[slug]/route.ts
@@ -21,6 +21,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
         return findPixel({
           where: {
             slug,
+            deletedAt: null,
           },
         });
       },
@@ -34,6 +35,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     pixel = await findPixel({
       where: {
         slug,
+        deletedAt: null,
       },
     });
 

--- a/src/app/(collect)/q/[slug]/route.ts
+++ b/src/app/(collect)/q/[slug]/route.ts
@@ -19,6 +19,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
         return findLink({
           where: {
             slug,
+            deletedAt: null,
           },
         });
       },
@@ -32,6 +33,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     link = await findLink({
       where: {
         slug,
+        deletedAt: null,
       },
     });
 

--- a/src/queries/prisma/team.ts
+++ b/src/queries/prisma/team.ts
@@ -146,13 +146,20 @@ export async function deleteTeam(teamId: string) {
   const cloudMode = !!process.env.CLOUD_MODE;
 
   const [links, pixels, boards] = await Promise.all([
-    client.link.findMany({ where: { teamId }, select: { id: true, slug: true } }),
-    client.pixel.findMany({ where: { teamId }, select: { id: true, slug: true } }),
+    client.link.findMany({
+      where: { teamId },
+      select: { id: true, slug: true, deletedAt: true },
+    }),
+    client.pixel.findMany({
+      where: { teamId },
+      select: { id: true, slug: true, deletedAt: true },
+    }),
     client.board.findMany({ where: { teamId }, select: { id: true } }),
   ]);
   const entityIds = [...links.map(l => l.id), ...pixels.map(p => p.id), ...boards.map(b => b.id)];
-  const linkSlugs = links.map(l => l.slug);
-  const pixelSlugs = pixels.map(p => p.slug);
+  // Only invalidate Redis cache for slugs that are still live (not already soft-deleted).
+  const linkSlugs = links.filter(l => !l.deletedAt).map(l => l.slug);
+  const pixelSlugs = pixels.filter(p => !p.deletedAt).map(p => p.slug);
 
   const invalidateRedis = async () => {
     if (redis.enabled && (linkSlugs.length || pixelSlugs.length)) {
@@ -174,8 +181,15 @@ export async function deleteTeam(teamId: string) {
         },
       }),
       client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
-      client.link.updateMany({ data: { deletedAt: new Date() }, where: { teamId } }),
-      client.pixel.updateMany({ data: { deletedAt: new Date() }, where: { teamId } }),
+      // deletedAt: null avoids restamping rows that were already soft-deleted earlier.
+      client.link.updateMany({
+        data: { deletedAt: new Date() },
+        where: { teamId, deletedAt: null },
+      }),
+      client.pixel.updateMany({
+        data: { deletedAt: new Date() },
+        where: { teamId, deletedAt: null },
+      }),
       client.board.deleteMany({ where: { teamId } }),
     ]).then(async result => {
       await invalidateRedis();

--- a/src/queries/prisma/team.ts
+++ b/src/queries/prisma/team.ts
@@ -2,6 +2,7 @@ import { Prisma, type Team } from '@/generated/prisma/client';
 import { ROLES } from '@/lib/constants';
 import { uuid } from '@/lib/crypto';
 import prisma from '@/lib/prisma';
+import redis from '@/lib/redis';
 import type { PageResult, QueryFilters } from '@/lib/types';
 
 import TeamFindManyArgs = Prisma.TeamFindManyArgs;
@@ -144,6 +145,24 @@ export async function deleteTeam(teamId: string) {
   const { client, transaction } = prisma;
   const cloudMode = !!process.env.CLOUD_MODE;
 
+  const [links, pixels, boards] = await Promise.all([
+    client.link.findMany({ where: { teamId }, select: { id: true, slug: true } }),
+    client.pixel.findMany({ where: { teamId }, select: { id: true, slug: true } }),
+    client.board.findMany({ where: { teamId }, select: { id: true } }),
+  ]);
+  const entityIds = [...links.map(l => l.id), ...pixels.map(p => p.id), ...boards.map(b => b.id)];
+  const linkSlugs = links.map(l => l.slug);
+  const pixelSlugs = pixels.map(p => p.slug);
+
+  const invalidateRedis = async () => {
+    if (redis.enabled && (linkSlugs.length || pixelSlugs.length)) {
+      await Promise.all([
+        ...linkSlugs.map(slug => redis.client.del(`link:${slug}`)),
+        ...pixelSlugs.map(slug => redis.client.del(`pixel:${slug}`)),
+      ]);
+    }
+  };
+
   if (cloudMode) {
     return transaction([
       client.team.update({
@@ -154,7 +173,14 @@ export async function deleteTeam(teamId: string) {
           id: teamId,
         },
       }),
-    ]);
+      client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
+      client.link.updateMany({ data: { deletedAt: new Date() }, where: { teamId } }),
+      client.pixel.updateMany({ data: { deletedAt: new Date() }, where: { teamId } }),
+      client.board.deleteMany({ where: { teamId } }),
+    ]).then(async result => {
+      await invalidateRedis();
+      return result;
+    });
   }
 
   return transaction([
@@ -163,10 +189,17 @@ export async function deleteTeam(teamId: string) {
         teamId,
       },
     }),
+    client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
+    client.link.deleteMany({ where: { teamId } }),
+    client.pixel.deleteMany({ where: { teamId } }),
+    client.board.deleteMany({ where: { teamId } }),
     client.team.delete({
       where: {
         id: teamId,
       },
     }),
-  ]);
+  ]).then(async result => {
+    await invalidateRedis();
+    return result;
+  });
 }

--- a/src/queries/prisma/user.ts
+++ b/src/queries/prisma/user.ts
@@ -135,13 +135,20 @@ export async function deleteUser(userId: string) {
     : { OR: [{ userId }, { teamId: { in: teamIds } }] };
 
   const [links, pixels, boards] = await Promise.all([
-    client.link.findMany({ where: ownedFilter, select: { id: true, slug: true } }),
-    client.pixel.findMany({ where: ownedFilter, select: { id: true, slug: true } }),
+    client.link.findMany({
+      where: ownedFilter,
+      select: { id: true, slug: true, deletedAt: true },
+    }),
+    client.pixel.findMany({
+      where: ownedFilter,
+      select: { id: true, slug: true, deletedAt: true },
+    }),
     client.board.findMany({ where: ownedFilter, select: { id: true } }),
   ]);
   const entityIds = [...links.map(l => l.id), ...pixels.map(p => p.id), ...boards.map(b => b.id)];
-  const linkSlugs = links.map(l => l.slug);
-  const pixelSlugs = pixels.map(p => p.slug);
+  // Only invalidate Redis cache for slugs that are still live (not already soft-deleted).
+  const linkSlugs = links.filter(l => !l.deletedAt).map(l => l.slug);
+  const pixelSlugs = pixels.filter(p => !p.deletedAt).map(p => p.slug);
 
   const invalidateRedis = async () => {
     if (redis.enabled && (linkSlugs.length || pixelSlugs.length)) {
@@ -170,8 +177,15 @@ export async function deleteUser(userId: string) {
         },
       }),
       client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
-      client.link.updateMany({ data: { deletedAt: new Date() }, where: { userId } }),
-      client.pixel.updateMany({ data: { deletedAt: new Date() }, where: { userId } }),
+      // deletedAt: null avoids restamping rows that were already soft-deleted earlier.
+      client.link.updateMany({
+        data: { deletedAt: new Date() },
+        where: { userId, deletedAt: null },
+      }),
+      client.pixel.updateMany({
+        data: { deletedAt: new Date() },
+        where: { userId, deletedAt: null },
+      }),
       client.board.deleteMany({ where: { userId } }),
     ]).then(async result => {
       await invalidateRedis();

--- a/src/queries/prisma/user.ts
+++ b/src/queries/prisma/user.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@/generated/prisma/client';
 import { ROLES } from '@/lib/constants';
 import { getRandomChars } from '@/lib/generate';
 import prisma from '@/lib/prisma';
+import redis from '@/lib/redis';
 import type { QueryFilters, Role } from '@/lib/types';
 
 import UserFindManyArgs = Prisma.UserFindManyArgs;
@@ -126,6 +127,31 @@ export async function deleteUser(userId: string) {
 
   const teamIds = teams.map(a => a.id);
 
+  // Cloud mode keeps owned teams (and their team-owned content), so cleanup
+  // only covers user-direct rows. Non-cloud hard-deletes owned teams below,
+  // so we must also clean up team-owned content.
+  const ownedFilter = cloudMode
+    ? { userId }
+    : { OR: [{ userId }, { teamId: { in: teamIds } }] };
+
+  const [links, pixels, boards] = await Promise.all([
+    client.link.findMany({ where: ownedFilter, select: { id: true, slug: true } }),
+    client.pixel.findMany({ where: ownedFilter, select: { id: true, slug: true } }),
+    client.board.findMany({ where: ownedFilter, select: { id: true } }),
+  ]);
+  const entityIds = [...links.map(l => l.id), ...pixels.map(p => p.id), ...boards.map(b => b.id)];
+  const linkSlugs = links.map(l => l.slug);
+  const pixelSlugs = pixels.map(p => p.slug);
+
+  const invalidateRedis = async () => {
+    if (redis.enabled && (linkSlugs.length || pixelSlugs.length)) {
+      await Promise.all([
+        ...linkSlugs.map(slug => redis.client.del(`link:${slug}`)),
+        ...pixelSlugs.map(slug => redis.client.del(`pixel:${slug}`)),
+      ]);
+    }
+  };
+
   if (cloudMode) {
     return transaction([
       client.website.updateMany({
@@ -143,7 +169,14 @@ export async function deleteUser(userId: string) {
           id: userId,
         },
       }),
-    ]);
+      client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
+      client.link.updateMany({ data: { deletedAt: new Date() }, where: { userId } }),
+      client.pixel.updateMany({ data: { deletedAt: new Date() }, where: { userId } }),
+      client.board.deleteMany({ where: { userId } }),
+    ]).then(async result => {
+      await invalidateRedis();
+      return result;
+    });
   }
 
   return transaction([
@@ -194,6 +227,10 @@ export async function deleteUser(userId: string) {
         ],
       },
     }),
+    client.share.deleteMany({ where: { entityId: { in: entityIds } } }),
+    client.link.deleteMany({ where: ownedFilter }),
+    client.pixel.deleteMany({ where: ownedFilter }),
+    client.board.deleteMany({ where: ownedFilter }),
     client.website.deleteMany({
       where: { id: { in: websiteIds } },
     }),
@@ -202,5 +239,8 @@ export async function deleteUser(userId: string) {
         id: userId,
       },
     }),
-  ]);
+  ]).then(async result => {
+    await invalidateRedis();
+    return result;
+  });
 }


### PR DESCRIPTION
Fixes #4242.

## Summary

- **`deleteUser`** / **`deleteTeam`**: clean up `link`, `pixel`, `board`, and their `share` rows for the deleted user/team. Mirrors the `deleteWebsite` cleanup pattern.
- **Cloud mode**: soft-delete link + pixel (have `deletedAt`); hard-delete board (no `deletedAt` column); always hard-delete shares (matches `deleteWebsite`).
- **Non-cloud**: hard-delete everything.
- **Cloud-vs-non-cloud asymmetry in `deleteUser`**: cloud only cleans `userId`-direct rows (cloud doesn't delete owned teams). Non-cloud uses `OR { userId } { teamId IN ownedTeamIds }` because it does delete owned teams.
- **`/q/<slug>` and `/p/<slug>`**: add `deletedAt: null` filter so soft-deleted entries return 404. Filter applied at the call sites (not in `findLink` / `findPixel` helpers) to avoid breaking permission checks at `src/permissions/link.ts` / `pixel.ts` that deref `getLink` / `getPixel` results without null guards.
- Post-transaction Redis invalidation (`link:${slug}`, `pixel:${slug}`) mirrors `deleteWebsite`.

## Test plan

- [x] `pnpm lint` clean for changed files (1 pre-existing warning in `not-found.tsx` is on `dev` already)
- [x] `pnpm build-app` (Next build) — zero errors / warnings
- [x] **E2E delete user**: created test user with link + pixel, deleted user → 0 orphan rows, `/q/<slug>` returns 404
- [x] **E2E delete team**: created team with team-owned link + pixel + board, deleted team → 0 orphan rows (incl. share), `/q/<slug>` returns 404

## Out of scope (can file separately)

- ClickHouse cleanup on delete — no path in the codebase touches CH today (also affects `deleteWebsite`)
- `getUserPixels` / `getTeamPixels` / `getTeamLinks` don't filter `deletedAt: null`
- `deleteTeam` orphans websites with that `team_id`
- `board` has no `deletedAt` column (cloud-mode soft-delete needs migration)