### PR TITLE
fix(tracker): track clicks on annotated containers + handle invalid pushState URLs

### DIFF
--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -89,7 +89,7 @@
     }
 
     currentRef = currentUrl;
-    currentUrl = normalize(new URL(url, location.href).toString());
+    currentUrl = normalize(url);
 
     if (currentUrl !== currentRef && autoPageview) {
       setTimeout(track, delayDuration);
@@ -100,8 +100,9 @@
     const hook = (_this, method, callback) => {
       const orig = _this[method];
       return (...args) => {
+        const result = orig.apply(_this, args);
         callback.apply(null, args);
-        return orig.apply(_this, args);
+        return result;
       };
     };
 
@@ -123,18 +124,13 @@
         return track(eventName, eventData);
       }
     };
-    const onClick = async e => {
+    const onClick = e => {
       const el = e.target;
-      const parentElement = el.closest('a,button');
-      if (!parentElement) return trackElement(el);
+      const eventEl = el.closest(`[${eventNameAttribute}]`);
+      if (!eventEl) return;
 
-      const { href, target } = parentElement;
-      if (!parentElement.getAttribute(eventNameAttribute)) return;
-
-      if (parentElement.tagName === 'BUTTON') {
-        return trackElement(parentElement);
-      }
-      if (parentElement.tagName === 'A' && href) {
+      if (eventEl.tagName === 'A' && eventEl.href) {
+        const { href, target } = eventEl;
         const external =
           target === '_blank' ||
           e.ctrlKey ||
@@ -142,12 +138,14 @@
           e.metaKey ||
           (e.button && e.button === 1);
         if (!external) e.preventDefault();
-        return trackElement(parentElement).then(() => {
+        return trackElement(eventEl).then(() => {
           if (!external) {
             (target === '_top' ? top.location : location).href = href;
           }
         });
       }
+
+      return trackElement(eventEl);
     };
     document.addEventListener('click', onClick, true);
   };


### PR DESCRIPTION
Three bugs in `src/tracker/index.js`, all empirically reproduced before fix and verified after fix.

## Bug 1: clicks on annotated container elements were missed

`handleClicks()` used `el.closest('a,button')`, which can't find an annotated `<div>` / `<section>` / `<article>` ancestor. A click on any descendant of `<div data-umami-event="card-click">` went untracked.

**Reproduction** (10 scenarios, ran in real Chrome against upstream `dev`):

| Click target | Before | After |
|---|---|---|
| `<button data-umami-event>` | TRACKED | TRACKED |
| `<span>` inside `<button data-umami-event>` | TRACKED | TRACKED |
| `<a data-umami-event>` (with href) | TRACKED | TRACKED |
| `<span>` inside `<a data-umami-event>` | TRACKED | TRACKED |
| `<div data-umami-event>` direct | TRACKED | TRACKED |
| **`<span>` inside `<div data-umami-event>`** | **MISSED** | **TRACKED** |
| **deep `<span>` inside `<div data-umami-event>`** | **MISSED** | **TRACKED** |
| `<span data-umami-event>` direct | TRACKED | TRACKED |
| **`<a data-umami-event>` with no href** | **MISSED** | **TRACKED** |
| **`<button>` inside `<a data-umami-event>`** | **MISSED** | **TRACKED** |

Note also `src/app/(main)/console/[websiteId]/TestConsolePage.tsx:184-186` already shows nested `<div data-umami-event=...>` test cases that this PR makes work.

**Fix**: replace `closest('a,button')` with `closest('[data-umami-event]')`. Special link-handling (`preventDefault` + track + navigate) still applies when the matched element is an `<a>` with an `href`.

## Bug 2: `handlePush()` could throw into host site's router

The wrapper around `history.pushState`/`replaceState` called `handlePush(url)`, which did `new URL(url, location.href).toString()` outside `normalize()`'s try/catch. A host page calling `history.pushState({}, '', invalidUrl)` would have umami's wrapper throw a `TypeError: Failed to construct 'URL'` into the host's router.

`normalize(url)` already does base resolution AND wraps the parse in a try/catch returning the raw value on failure.

**Fix**: drop the redundant outer parse — `currentUrl = normalize(url)`.

## Bug 3 (related to #2): hook ran callback before native call, mutating state on failed pushState

The history hook ran the umami callback BEFORE the native `pushState`/`replaceState`:

```js
return (...args) => {
  callback.apply(null, args);     // <- handlePush mutates state
  return orig.apply(_this, args); // <- THEN native call (may throw)
};
```

So when native `pushState` threw `SecurityError` (invalid URL) or any other exception, umami had already mutated `currentUrl` and scheduled a phantom pageview. **Fix**: run native first; only call `handlePush` if it didn't throw. State stays consistent across failed navigations.

**Verified empirically**: `pushState({}, '', invalidUrl)` after fix leaves tracker `currentUrl` unchanged and no pageview scheduled.

## Bonus

- Removed `async` from `onClick` (no awaits — was wrapping in unnecessary Promise).
- Bundle size: 4636 → 4554 bytes (**−82 bytes**).

## Behavior change worth noting

For the rare nested case `<a href="/page" data-umami-event="link"><span data-umami-event="inner">x</span></a>`, clicking the span now tracks `"inner"` (closest match) and lets the browser navigate naturally. Before this PR, the inner annotation was silently ignored and the outer link's event was tracked instead. The new behavior matches "closest annotation wins".

## Test plan

- [x] 10/10 click scenarios tracked correctly (was 6/10)
- [x] Invalid `pushState` URL no longer mutates tracker state
- [x] `pnpm build-tracker` succeeds