### PR TITLE
fix: stabilize event chart colors per label

### DIFF
--- a/src/components/metrics/EventsChart.tsx
+++ b/src/components/metrics/EventsChart.tsx
@@ -61,11 +61,12 @@ export function EventsChart({ websiteId, focusLabel, limit }: EventsChartProps) 
       // (the FNV prime is close to 2^24).
       const colorByKey: Record<string, string> = {};
       const used = new Set<string>();
-      const orderedKeys = [...Object.keys(map)].sort(
-        (a, b) => parseInt(hex6(a), 16) - parseInt(hex6(b), 16),
+      const hashOf = Object.fromEntries(
+        Object.keys(map).map(key => [key, parseInt(hex6(key), 16)]),
       );
+      const orderedKeys = [...Object.keys(map)].sort((a, b) => hashOf[a] - hashOf[b]);
       for (const key of orderedKeys) {
-        const start = (parseInt(hex6(key), 16) >>> 4) % CHART_COLORS.length;
+        const start = (hashOf[key] >>> 4) % CHART_COLORS.length;
         let chosen = CHART_COLORS[start];
         for (let i = 0; i < CHART_COLORS.length; i++) {
           const candidate = CHART_COLORS[(start + i) % CHART_COLORS.length];

--- a/src/components/metrics/EventsChart.tsx
+++ b/src/components/metrics/EventsChart.tsx
@@ -9,6 +9,7 @@ import {
   useWebsiteEventsSeriesQuery,
 } from '@/components/hooks';
 import { renderDateLabels } from '@/lib/charts';
+import { hex6 } from '@/lib/colors';
 import { CHART_COLORS } from '@/lib/constants';
 import { generateTimeSeries } from '@/lib/date';
 
@@ -51,9 +52,35 @@ export function EventsChart({ websiteId, focusLabel, limit }: EventsChartProps) 
         ],
       };
     } else {
+      // Each label has a preferred palette slot derived from a hash of the
+      // label, so the same event tends to get the same color across reloads
+      // and date-range changes. We walk labels in hash order and, when two
+      // labels prefer the same slot, the later one steps to the next free
+      // slot, so the visible set of <=12 events all get distinct colors.
+      // The right shift on hex6 sidesteps the FNV-1a low-bit bias mod 12
+      // (the FNV prime is close to 2^24).
+      const colorByKey: Record<string, string> = {};
+      const used = new Set<string>();
+      const orderedKeys = [...Object.keys(map)].sort(
+        (a, b) => parseInt(hex6(a), 16) - parseInt(hex6(b), 16),
+      );
+      for (const key of orderedKeys) {
+        const start = (parseInt(hex6(key), 16) >>> 4) % CHART_COLORS.length;
+        let chosen = CHART_COLORS[start];
+        for (let i = 0; i < CHART_COLORS.length; i++) {
+          const candidate = CHART_COLORS[(start + i) % CHART_COLORS.length];
+          if (!used.has(candidate)) {
+            chosen = candidate;
+            break;
+          }
+        }
+        used.add(chosen);
+        colorByKey[key] = chosen;
+      }
+
       return {
-        datasets: Object.keys(map).map((key, index) => {
-          const color = colord(CHART_COLORS[index % CHART_COLORS.length]);
+        datasets: Object.keys(map).map(key => {
+          const color = colord(colorByKey[key]);
           return {
             label: key,
             data: generateTimeSeries(map[key], startDate, endDate, unit, dateLocale),


### PR DESCRIPTION
## Why

The events tab assigns dataset colors by array index of `Object.keys(map)`, where `map` is built from the `/events/series` API response. The API orders events by frequency, which depends on the active date range, so changing the range or reloading the page reshuffles the order and gives the same event a different color each time.

This makes the chart visually unstable for any user comparing two date ranges, sharing a screenshot, or just reloading.

## What changes

Pick the palette slot deterministically from a hash of the label name (`hex6`, the FNV-1a helper already in `src/lib/colors.ts`), and walk the 12-color palette greedily in hash-sorted order. Two labels that prefer the same slot resolve in a deterministic, set-dependent order rather than by API insertion order.

Properties:

- **Stable across reload / range change**: same label keeps its color when the visible set is unchanged.
- **Robust to new events arriving**: a new label slots in at its preferred index. Existing labels are unaffected unless the new label genuinely competes for an in-use slot, in which case displacement is local rather than global.
- **Up to 12 unique colors**: when the visible set has 12 or fewer labels, every label gets a distinct palette color. With more than 12, the palette wraps the same way it always did.

## Scope

- `src/components/metrics/EventsChart.tsx` only.
- Reuses `hex6()` from `src/lib/colors.ts`. No new utilities, no API changes, no schema changes, no UI changes.
- The sibling `RevenueChart.tsx` has the same index-based pattern but is intentionally out of scope for this PR.

## Validation

- Verified visually on the seeded `Demo SaaS` data: 7 events render with 7 distinct colors; switching range from `Last 24 hours` to `Last 7 days` and hard-reloading both produce the same color per label.
- Determinism is independent of input order: feeding the same label set in reverse produces an identical mapping (verified out of band).
- Distribution sanity check: with the naive `parseInt(hex6(key), 16) % 12`, ~88% of 1000 random labels packed into 3 of the 12 slots because the FNV prime is close to 2^24 and biases the low bits mod 12. The right-shifted hash gives a near-uniform distribution (min/max bucket spread is ~10% over 5000 samples).
- `biome check` clean on the touched file.

## Notes

- Stability across set changes is best-effort: if a brand-new event arrives whose preferred slot is already in use by an existing label that was itself displaced, the displacement chain may shift one or two existing colors. Eliminating this would require a per-website persisted color mapping, which is out of scope for this fix.
- A natural follow-up is to expose the per-label color (as a swatch on the events table) and let users pin it manually. That would also fully resolve the residual instability above. Tracked as a separate workstream.