### PR TITLE
fix: keep hidden events hidden across date-range changes

### DIFF
--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -18,6 +18,8 @@ export interface ChartProps extends BoxProps {
   updateMode?: UpdateMode;
   animationDuration?: number;
   onTooltip?: (model: any) => void;
+  hiddenLabels?: Set<string>;
+  onLegendClick?: (label: string, willBeHidden: boolean) => void;
 }
 
 export function Chart({
@@ -27,6 +29,8 @@ export function Chart({
   updateMode,
   onTooltip,
   chartOptions,
+  hiddenLabels,
+  onLegendClick,
   ...props
 }: ChartProps) {
   const canvas = useRef(null);
@@ -61,6 +65,15 @@ export function Chart({
   }, [chartOptions]);
 
   const handleLegendClick = (item: LegendItem) => {
+    if (onLegendClick && type === 'bar') {
+      // Controlled mode: caller owns the hidden state. We report the click
+      // and let the parent push a new hiddenLabels set on the next render.
+      const { datasetIndex } = item;
+      const ds = chart.current.data.datasets[datasetIndex];
+      onLegendClick(ds.label, !ds.hidden);
+      return;
+    }
+
     if (type === 'bar') {
       const { datasetIndex } = item;
       const meta = chart.current.getDatasetMeta(datasetIndex);
@@ -111,13 +124,24 @@ export function Chart({
         });
       }
 
+      // Re-apply caller-driven hidden flags after focusLabel handling so a
+      // dataset stays hidden across data changes (e.g. date-range switches)
+      // even though Chart.js regenerates dataset meta on every replace.
+      if (hiddenLabels) {
+        chart.current.data.datasets.forEach((ds: { hidden: boolean; label: any }) => {
+          if (hiddenLabels.has(ds.label)) {
+            ds.hidden = true;
+          }
+        });
+      }
+
       chart.current.options = options;
 
       chart.current.update(updateMode);
 
       setLegendItems(chart.current.legend.legendItems);
     }
-  }, [chartData, options, updateMode]);
+  }, [chartData, options, updateMode, hiddenLabels]);
 
   return (
     <Column gap="6">

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -131,6 +131,10 @@ export function Chart({
         chart.current.data.datasets.forEach((ds: { hidden: boolean; label: any }) => {
           if (hiddenLabels.has(ds.label)) {
             ds.hidden = true;
+          } else if (!chartData.focusLabel) {
+            // Explicitly reset so un-hiding a label is always reflected,
+            // regardless of whether the focusLabel pass ran above.
+            ds.hidden = false;
           }
         });
       }

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -70,7 +70,7 @@ export function Chart({
       // and let the parent push a new hiddenLabels set on the next render.
       const { datasetIndex } = item;
       const ds = chart.current.data.datasets[datasetIndex];
-      onLegendClick(ds.label, !ds.hidden);
+      onLegendClick(ds.label, !hiddenLabels?.has(ds.label));
       return;
     }
 

--- a/src/components/metrics/EventsChart.tsx
+++ b/src/components/metrics/EventsChart.tsx
@@ -26,6 +26,16 @@ export function EventsChart({ websiteId, focusLabel, limit }: EventsChartProps) 
   const { locale, dateLocale } = useLocale();
   const { data, isLoading, error } = useWebsiteEventsSeriesQuery(websiteId, { limit });
   const [label, setLabel] = useState<string>(focusLabel);
+  const [hiddenLabels, setHiddenLabels] = useState<Set<string>>(() => new Set());
+
+  const handleLegendClick = useCallback((legendLabel: string, willBeHidden: boolean) => {
+    setHiddenLabels(prev => {
+      const next = new Set(prev);
+      if (willBeHidden) next.add(legendLabel);
+      else next.delete(legendLabel);
+      return next;
+    });
+  }, []);
 
   const chartData: any = useMemo(() => {
     if (!data) return;
@@ -87,6 +97,8 @@ export function EventsChart({ websiteId, focusLabel, limit }: EventsChartProps) 
           stacked={true}
           renderXLabel={renderXLabel}
           height="400px"
+          hiddenLabels={hiddenLabels}
+          onLegendClick={handleLegendClick}
         />
       )}
     </LoadingPanel>


### PR DESCRIPTION
## Why

On the events tab of a website, clicking a legend item to hide a series works as expected, but the hidden state is lost as soon as the date range changes. The user has to re-click every previously-hidden event after every range switch, which makes comparing periods with a stable subset of events tedious.

The state lives on Chart.js's per-dataset *meta* object (`chart.current.getDatasetMeta(idx).hidden`). When `chartData` changes, `Chart.tsx` replaces `chart.current.data.datasets` wholesale; Chart.js regenerates the meta on the new datasets, and every hidden flag is reset to `false`.

## What changes

Lift the hidden state into React. `EventsChart` owns a `Set<string>` of hidden labels and threads it down to the chart through two new optional props on `Chart`:

- `hiddenLabels?: Set<string>`: applied after the existing `focusLabel` pass on every update, so the hidden flags survive any data refresh.
- `onLegendClick?: (label: string, willBeHidden: boolean) => void`: controlled toggling. When provided, the legend click reports the new state to the parent instead of mutating Chart.js meta directly.

When `onLegendClick` is not provided, the existing meta-based path stays exactly as it was, so the website-overview chart (Visitors / Views) and the revenue chart keep their current behaviour. This PR only opts the events chart into the new flow.

## Scope

- `src/components/charts/Chart.tsx`: two new optional props, controlled-mode branch in `handleLegendClick`, post-focus re-apply of hidden flags in the update `useEffect`.
- `src/components/metrics/EventsChart.tsx`: `useState<Set<string>>` for hidden labels, a `useCallback` toggle, plus the two props passed down to `BarChart`.

No new dependencies, no API changes, no schema changes, no UI changes outside of the already-existing legend disabled state.

## Validation

Verified end-to-end with the seeded `Demo SaaS` data:

1. Baseline: 7 events visible, Last 24 hours, Y axis tops out at 40.
2. Hide `signup_started`: it greys out in the legend, the pink stack disappears, Y axis drops to ~30.
3. Switch range to Last 7 days: `signup_started` stays greyed, no pink in the daily bars.
4. Switch range to Last 30 days (second range change): `signup_started` still greyed.
5. Click the greyed `signup_started`: it returns, cyan stack reappears on every bar, Y axis jumps to 600.

Reload of the page resets the hidden set to empty (component-scoped state). That is intentional for v1.

## Notes

- Persistence beyond the page (URL, localStorage, server-side preferences) is intentionally out of scope. URL becomes ugly with many hidden labels, and localStorage adds invisible state that is hard to discover. Either can be added later as an additive feature.
- Sticky entries: a hidden label that disappears from the data (e.g. zero events in the new range) stays in the hidden set, so it remains hidden when it reappears. This is the predictable behaviour.
- Other charts (website overview, revenue) are untouched. They still go through the original meta-based path because they do not pass `onLegendClick`, which keeps this PR purely additive on the shared `Chart` component.

## Screenshots
01. Baseline, Last 24 hours, all 7 events visible
baseline
<img width="940" height="992" alt="hidden-01-initial-24h" src="https://github.com/user-attachments/assets/4b7f4cd5-20a6-4397-8e88-be1e2540320e" />


02. signup_started hidden on Last 24 hours
hidden 24h
<img width="940" height="992" alt="hidden-02-signup-started-hidden-24h" src="https://github.com/user-attachments/assets/f1ae468c-b06f-4cf9-a312-1afd93a94a0a" />


03. Range switched to Last 7 days, still hidden
hidden 7d
<img width="940" height="992" alt="hidden-03-after-switch-to-7d" src="https://github.com/user-attachments/assets/a2ba9ecc-196a-4bbf-8d22-3d7c342dee68" />


04. Range switched to Last 30 days, still hidden
hidden 30d
<img width="940" height="992" alt="hidden-04-after-switch-to-30d" src="https://github.com/user-attachments/assets/98031853-e6dd-41b8-899e-395983575bba" />


05. Click again to restore signup_started, Last 30 days
restored
<img width="940" height="992" alt="hidden-05-after-unhide-30d" src="https://github.com/user-attachments/assets/dca25333-82c0-4a8e-883a-063d02ebe370" />
