### PR TITLE
fix: keep charts responsive when the viewport resizes

### DIFF
--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -133,7 +133,7 @@ export function Chart({
           wrapper sizes purely from its parent (width: 100%, height: 100%)
           and Chart.js' ResizeObserver picks up viewport changes.
         */}
-        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+        <div style={{ position: 'relative', width: '100%', height: '100%', overflow: 'hidden' }}>
           <canvas ref={canvas} style={{ position: 'absolute', top: 0, left: 0 }} />
         </div>
       </Box>

--- a/src/components/charts/Chart.tsx
+++ b/src/components/charts/Chart.tsx
@@ -122,7 +122,20 @@ export function Chart({
   return (
     <Column gap="6">
       <Box {...props}>
-        <canvas ref={canvas} />
+        {/*
+          Position the canvas absolutely inside a relative-positioned
+          wrapper. Chart.js writes inline pixel sizes onto the canvas, and
+          while it lives in the normal flow that pixel width propagates up
+          as min/max-content through every flex parent into the surrounding
+          CSS Grid track, pinning the chart's column at its widest measured
+          size and only resetting on a full page reload. Taking the canvas
+          out of flow with position: absolute breaks that propagation; the
+          wrapper sizes purely from its parent (width: 100%, height: 100%)
+          and Chart.js' ResizeObserver picks up viewport changes.
+        */}
+        <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+          <canvas ref={canvas} style={{ position: 'absolute', top: 0, left: 0 }} />
+        </div>
       </Box>
       <Legend items={legendItems} onClick={handleLegendClick} />
     </Column>


### PR DESCRIPTION
## Why

Resizing the browser window made the chart canvas (events tab, website overview, revenue) keep its previously measured pixel width instead of tracking the viewport. The chart could grow on resize but could not shrink, so a window narrowed below the original render width left the chart overflowing its card. A full page reload was the only way to recover.

The canvas is rendered directly inside the Box wrapper. Chart.js writes inline pixel sizes onto the canvas, and while the canvas lives in the normal flow that pixel width propagates up as min and max content through every flex parent and into the surrounding CSS Grid track on the Tabs panel. The track is auto-sized, so it adopts that pixel width and stays there until the canvas is recreated on reload.

## What changes

Wrap the canvas in a position-relative div and position the canvas absolutely inside it. Out-of-flow elements do not contribute to ancestor intrinsic sizing, so the wrapper now takes its size purely from the parent layout (Box / Column / Panel / Grid). Chart.js' ResizeObserver still observes the wrapper, picks up viewport changes, and resizes the canvas to fit in both directions without a reload.

This is the pattern Chart.js' own docs recommend for responsive charts inside flex / grid layouts.

## Scope

- `src/components/charts/Chart.tsx`: a small wrapper around the canvas. No prop changes, no API changes, no schema changes, no new dependencies.
- Affects every chart that goes through the shared `Chart` component: events tab, website overview (Visitors / Views), revenue, etc. All of them benefit from the fix.

## Validation

Verified end-to-end in Playwright on the seeded `Demo SaaS` data, all without reload between steps:

- Reload at 800x700: canvas, wrapper, Box, and the Tabs grid track all measure 699px (no overflow).
- Resize 800x700 to 1280x800: canvas grows from 699 to 925, in step with the parent.
- Resize 1280x800 back to 800x700: canvas shrinks from 925 to 699 (this was the broken case before the fix).
- Resize again to 1400x800: canvas grows to 1117.
- Spot-checked the website overview (Visitors / Views) chart on the same dev server: bars and tooltip render normally, legend toggles still work.

## Notes

- The fix is purely a layout change. The Chart.js options (`responsive: true`, `maintainAspectRatio: false`) are unchanged.
- Existing legend / focusLabel behaviour is unaffected because the wrapper does not interfere with mouse events or the canvas itself; Chart.js is still the one writing canvas dimensions.
- This is a sibling fix to the events-tab improvements in #4257 and #4259 but is independent (different concern, different file region) and can land in any order.

## Screenshots

### Baseline at 1280x800 (chart fills its container, no overflow)
<img width="1280" height="800" alt="resize-bug-01-baseline-1280" src="https://github.com/user-attachments/assets/7e4f1263-c04e-413a-9390-25bee13ad18c" />


### Bug: shrink to 800x700 without reload, canvas stuck at 925px and overflowing the card
<img width="800" height="700" alt="resize-bug-02-overflow-800" src="https://github.com/user-attachments/assets/ae2288f7-a958-4e88-bdd7-40985be20180" />


### Bug recovery: page reload at 800x700 fixes it (canvas 699px)
<img width="800" height="700" alt="resize-bug-03-after-refresh-800" src="https://github.com/user-attachments/assets/48a11b2b-ae64-4f24-b55b-d5d251f3c438" />


### After fix: shrink 1280 to 800 without reload, canvas tracks (699px)
<img width="800" height="700" alt="resize-fix-01-shrink-800" src="https://github.com/user-attachments/assets/a05f7a4c-a1d5-495f-ad1f-e77b7c46b071" />

### After fix: grow 800 to 1400 without reload, canvas tracks (1117px)
<img width="1400" height="800" alt="resize-fix-02-grow-1400" src="https://github.com/user-attachments/assets/78955155-2fd5-432f-8e43-eebd70461931" />