### PR TITLE
fix: use IF EXISTS in migrations 15 and 17 to handle pre-existing schema state

### DIFF
--- a/prisma/migrations/15_add_share/migration.sql
+++ b/prisma/migrations/15_add_share/migration.sql
@@ -19,16 +19,20 @@ CREATE UNIQUE INDEX IF NOT EXISTS "share_slug_key" ON "share"("slug");
 CREATE INDEX IF NOT EXISTS "share_entity_id_idx" ON "share"("entity_id");
 
 -- MigrateData
-INSERT INTO "share" (share_id, entity_id, name, share_type, slug, parameters, created_at)
-SELECT gen_random_uuid(),
-       website_id,
-       name,
-       1,
-       share_id,
-       '{"overview":true}'::jsonb,
-       now()
-FROM "website"
-WHERE share_id IS NOT NULL;
+DO $$
+BEGIN
+    INSERT INTO "share" (share_id, entity_id, name, share_type, slug, parameters, created_at)
+    SELECT gen_random_uuid(),
+        website_id,
+        name,
+        1,
+        share_id,
+        '{"overview":true}'::jsonb,
+        now()
+    FROM "website"
+    WHERE share_id IS NOT NULL;
+EXCEPTION WHEN undefined_column THEN NULL;
+END $$;
 
 -- DropIndex
 DROP INDEX IF EXISTS "website_share_id_idx";

--- a/prisma/migrations/15_add_share/migration.sql
+++ b/prisma/migrations/15_add_share/migration.sql
@@ -13,10 +13,10 @@ CREATE TABLE "share" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "share_slug_key" ON "share"("slug");
+CREATE UNIQUE INDEX IF NOT EXISTS "share_slug_key" ON "share"("slug");
 
 -- CreateIndex
-CREATE INDEX "share_entity_id_idx" ON "share"("entity_id");
+CREATE INDEX IF NOT EXISTS "share_entity_id_idx" ON "share"("entity_id");
 
 -- MigrateData
 INSERT INTO "share" (share_id, entity_id, name, share_type, slug, parameters, created_at)

--- a/prisma/migrations/15_add_share/migration.sql
+++ b/prisma/migrations/15_add_share/migration.sql
@@ -31,10 +31,10 @@ FROM "website"
 WHERE share_id IS NOT NULL;
 
 -- DropIndex
-DROP INDEX "website_share_id_idx";
+DROP INDEX IF EXISTS "website_share_id_idx";
 
 -- DropIndex
-DROP INDEX "website_share_id_key";
+DROP INDEX IF EXISTS "website_share_id_key";
 
 -- AlterTable
-ALTER TABLE "website" DROP COLUMN "share_id";
+ALTER TABLE "website" DROP COLUMN IF EXISTS "share_id";

--- a/prisma/migrations/17_remove_duplicate_key/migration.sql
+++ b/prisma/migrations/17_remove_duplicate_key/migration.sql
@@ -1,29 +1,29 @@
 -- DropIndex
-DROP INDEX "link_link_id_key";
+DROP INDEX IF EXISTS "link_link_id_key";
 
 -- DropIndex
-DROP INDEX "pixel_pixel_id_key";
+DROP INDEX IF EXISTS "pixel_pixel_id_key";
 
 -- DropIndex
-DROP INDEX "report_report_id_key";
+DROP INDEX IF EXISTS "report_report_id_key";
 
 -- DropIndex
-DROP INDEX "revenue_revenue_id_key";
+DROP INDEX IF EXISTS "revenue_revenue_id_key";
 
 -- DropIndex
-DROP INDEX "segment_segment_id_key";
+DROP INDEX IF EXISTS "segment_segment_id_key";
 
 -- DropIndex
-DROP INDEX "session_session_id_key";
+DROP INDEX IF EXISTS "session_session_id_key";
 
 -- DropIndex
-DROP INDEX "team_team_id_key";
+DROP INDEX IF EXISTS "team_team_id_key";
 
 -- DropIndex
-DROP INDEX "team_user_team_user_id_key";
+DROP INDEX IF EXISTS "team_user_team_user_id_key";
 
 -- DropIndex
-DROP INDEX "user_user_id_key";
+DROP INDEX IF EXISTS "user_user_id_key";
 
 -- DropIndex
-DROP INDEX "website_website_id_key";
+DROP INDEX IF EXISTS "website_website_id_key";


### PR DESCRIPTION
ref: https://github.com/umami-software/umami/issues/4186

Migrations `15_add_share` and `17_remove_duplicate_key` fail for users upgrading from certain older versions because they assume a specific schema state that may not match reality.

`15_add_share` fails with column "share_id" does not exist on the website table. the column was already dropped in a prior manual or automated cleanup on some deployments.

`17_remove_duplicate_key` fails with index "report_report_id_key" does not exist (and similarly for other indexes in the same script). these indexes were already absent in some database states.

logs:

15:
```plain
Database error:                                                                                                                                                                                                                                                                                                                                                        +
| ERROR: index "website_share_id_idx" does not exist                                                                                                                                                                                                                                                                                                                     +
|                                                                                                                                                                                                                                                                                                                                                                        +
| DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42704), message: "index \"website_share_id_idx\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("tablecmds.c"), line: Some(1491), routine: Some("DropErrorMsgNonExistent") }+
|                                                                                                                                                                                                                                                                                                                                                                        +
|    0: sql_schema_connector::apply_migration::apply_script                                                                                                                                                                                                                                                                                                              +
|            with migration_name="15_add_share"                                                                                                                                                                                                                                                                                                                          +
|              at schema-engine/connectors/sql-schema-connector/src/apply_migration.rs:113                                                                                                                                                                                                                                                                               +
|    1: schema_commands::commands::apply_migrations::Applying migration
```

17:
```plain
umami-1  | Migration name: 17_remove_duplicate_key
umami-1  |
umami-1  | Database error code: 42704
umami-1  |
umami-1  | Database error:
umami-1  | ERROR: index "report_report_id_key" does not exist
umami-1  |
umami-1  | DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E42704), message: "index \"report_report_id_key\" does not exist", detail: None, hint: None, position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: Some("tablecmds.c"), line: Some(1491), routine: Some("DropErrorMsgNonExistent") }
```
