### PR TITLE
fix: evaluate login mode env at runtime

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,6 +1,8 @@
 import { parseRequest } from '@/lib/request';
 import { json } from '@/lib/response';
 
+export const dynamic = 'force-dynamic';
+
 export async function GET(request: Request) {
   const { error } = await parseRequest(request, null, { skipAuth: true });
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { LoginPage } from './LoginPage';
 
+export const dynamic = 'force-dynamic';
+
 export default async function () {
   if (process.env.DISABLE_LOGIN || process.env.CLOUD_MODE) {
     return null;

--- a/src/app/logout/page.tsx
+++ b/src/app/logout/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import { LogoutPage } from './LogoutPage';
 
+export const dynamic = 'force-dynamic';
+
 export default function () {
   if (process.env.DISABLE_LOGIN || process.env.CLOUD_MODE) {
     return null;


### PR DESCRIPTION
## Summary
- mark login and logout pages as dynamic so DISABLE_LOGIN and CLOUD_MODE are read at runtime
- mark the config API route as dynamic so Docker runtime CLOUD_MODE is reflected in client config

Fixes #3549

## Testing
- pnpm install --frozen-lockfile
- pnpm exec biome check src/app/login/page.tsx src/app/logout/page.tsx src/app/api/config/route.ts
- git diff --check