### PR TITLE
Send credentials when fetching the web app manifest (crossorigin="use-credentials")

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,7 @@ export default function ({ children }) {
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-        <link rel="manifest" href="/site.webmanifest" />
+        <link rel="manifest" href="/site.webmanifest" crossOrigin="use-credentials" />
         <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5" />
         <meta name="msapplication-TileColor" content="#da532c" />
         <meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />


### PR DESCRIPTION
## What

Add `crossOrigin="use-credentials"` to the web app manifest `<link>` so the browser sends cookies when fetching `/site.webmanifest`.

## Why

We run Umami as an internal-only service behind an AWS ALB with OIDC authentication (`authenticate` on unauthenticated requests). Everything works except the manifest.

Browsers fetch the web app manifest **without credentials by default**, unless the link tag opts in with `crossorigin="use-credentials"` (`crossOrigin` in JSX). So the manifest request arrives at our auth proxy with no session cookie, the proxy treats it as logged-out and 302-redirects it to the identity provider, and the browser then blocks the cross-origin redirect against Umami's own CSP (`default-src 'self'`):

```
Loading a manifest from 'https://accounts.google.com/o/oauth2/v2/auth?...'
violates the following Content Security Policy directive: "default-src 'self'".
```

The dashboard itself is fine — this is just the manifest failing to load on every page — but it's a console error on every authenticated deployment behind a cookie-based auth proxy (OAuth2 Proxy, Cloudflare Access, ALB OIDC, Authelia, etc.).

`use-credentials` makes the browser include cookies, the proxy sees the session, and the manifest loads same-origin. It's a no-op for installs without an auth proxy.

## Prior art

The same one-line fix has been adopted by other self-hosted projects that hit this behind auth proxies:

- Sonarr — https://github.com/Sonarr/Sonarr/issues/4305
- Radarr — https://github.com/Radarr/Radarr/issues/5863
- Home Assistant — https://github.com/home-assistant/frontend/issues/940
- Dashy — https://github.com/Lissy93/dashy/issues/2102
- karma — https://github.com/prymitive/karma/issues/1341

## Fix

```diff
-        <link rel="manifest" href="/site.webmanifest" />
+        <link rel="manifest" href="/site.webmanifest" crossOrigin="use-credentials" />
```
