### PR TITLE
docker: pin pnpm dependency to v10 to avoid ERR_PNPM_IGNORED_BUILDS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM node:${NODE_IMAGE_VERSION} AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
-RUN npm install -g pnpm
+# pnpm version pinned at 10 due to ERR_PNPM_IGNORED_BUILDS error with v11
+RUN npm install -g pnpm@10
 RUN pnpm install --frozen-lockfile
 
 # Rebuild the source code only when needed
@@ -37,9 +38,10 @@ ENV NODE_OPTIONS=$NODE_OPTIONS
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
+# pnpm version pinned at 10 due to ERR_PNPM_IGNORED_BUILDS error with v11
 RUN set -x \
     && apk add --no-cache curl \
-    && npm install -g pnpm
+    && npm install -g pnpm@10
 
 # Script dependencies
 RUN pnpm --allow-build='@prisma/engines' add npm-run-all dotenv chalk semver \


### PR DESCRIPTION
The docker build has started failing for me since the update of `pnpm` to version 11. Pinning `pnpm` to version 10 fixes the build.

Ideally the dependencies should not be pinned, but fixated with a lockfile. There are several other dependencies that could silently update and fail the build.

This is just a quick fix to get the docker build working again.

```
20.46 Progress: resolved 188, reused 0, downloaded 188, added 188, done
20.51 .../node_modules/@prisma/engines postinstall$ node scripts/postinstall.js
28.80 .../node_modules/@prisma/engines postinstall: Done
29.00 
29.00 dependencies:
29.00 + @prisma/adapter-pg 6.19.0 (7.8.0 is available)
29.00 + chalk 5.6.2
29.00 + dotenv 17.4.2
29.00 + npm-run-all 4.1.5
29.00 + prisma 6.19.0 (7.8.0 is available)
29.00 + semver 7.8.1
29.00 
29.05 [ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: prisma@6.19.0
29.05 
29.05 Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782587125&installation_id=134563449&pr_number=4305&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4305&signature=1cb9dc87cd9f7aeb6b71fa498bde5eaf618b7766c8a484a50a8fc476f0800902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->