### PR TITLE
--

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ tmpclaude*
 CLAUDE.md
 nul
 
+.vercel
+backups/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,8 +313,6 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
-  dist: {}
-
 packages:
 
   '@ampproject/remapping@2.3.0':

--- a/src/app/(main)/MobileNav.tsx
+++ b/src/app/(main)/MobileNav.tsx
@@ -78,7 +78,7 @@ export function MobileNav() {
       </MobileMenuButton>
       <Row alignItems="center" justifyContent="center" flexGrow={1}>
         <IconLabel icon={<Logo />} style={{ width: 'auto' }}>
-          <Text weight="bold">umami</Text>
+          <Text weight="bold">shumami</Text>
         </IconLabel>
       </Row>
     </Grid>

--- a/src/app/(main)/SideNav.tsx
+++ b/src/app/(main)/SideNav.tsx
@@ -93,7 +93,7 @@ export function SideNav(props: any) {
         <Row paddingX="3" alignItems="center" justifyContent="space-between" flexGrow="1">
           {!isCollapsed && (
             <IconLabel icon={<Logo />}>
-              <Text weight="bold">umami</Text>
+              <Text weight="bold">shumami</Text>
             </IconLabel>
           )}
           <PanelButton />


### PR DESCRIPTION
Rebase fork onto upstream v3.1.0 (from 2.8.0). Re-apply the "shumami" brand text in SideNav and MobileNav (old NavBar.js no longer exists in 3.x). Ignore .vercel and backups/.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782597999&installation_id=134563449&pr_number=4306&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4306&signature=7d2d4df65aa024cc9ca1f7c788e05947df325f0aadd6be06c5791b60575d9eb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->