### PR TITLE
fix: ensure UTC session timezone in PrismaPg connections (#4285)

### DIFF
--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -15,6 +15,14 @@ if (process.env.SKIP_DB_CHECK) {
 
 const url = new URL(process.env.DATABASE_URL);
 
+const existingOptions = url.searchParams.get('options') || '';
+if (!existingOptions.includes('timezone')) {
+  url.searchParams.set(
+    'options',
+    existingOptions ? `${existingOptions} -c timezone=UTC` : '-c timezone=UTC',
+  );
+}
+
 const adapter = new PrismaPg(
   { connectionString: url.toString() },
   { schema: url.searchParams.get('schema') },

--- a/scripts/seed/index.ts
+++ b/scripts/seed/index.ts
@@ -291,7 +291,15 @@ function createPrismaClient(): PrismaClient {
     );
   }
 
-  const adapter = new PrismaPg({ connectionString: url }, { schema });
+  const existingOptions = connectionUrl.searchParams.get('options') || '';
+  if (!existingOptions.includes('timezone')) {
+    connectionUrl.searchParams.set(
+      'options',
+      existingOptions ? `${existingOptions} -c timezone=UTC` : '-c timezone=UTC',
+    );
+  }
+
+  const adapter = new PrismaPg({ connectionString: connectionUrl.toString() }, { schema });
 
   return new PrismaClient({
     adapter,

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -551,7 +551,21 @@ function getClient() {
 
   const schema = getSchema();
 
-  const baseAdapter = new PrismaPg({ connectionString: url }, { schema });
+  // Ensure consistent UTC session timezone so that TIMESTAMPTZ values
+  // written by @prisma/adapter-pg are not mis-interpreted by PostgreSQL.
+  // The adapter's formatDateTime omits the timezone offset, causing
+  // PostgreSQL to assume the session timezone (default: server timezone).
+  // See https://github.com/umami-software/umami/issues/4285
+  const connectionUrl = new URL(url);
+  const existingOptions = connectionUrl.searchParams.get('options') || '';
+  if (!existingOptions.includes('timezone')) {
+    connectionUrl.searchParams.set(
+      'options',
+      existingOptions ? `${existingOptions} -c timezone=UTC` : '-c timezone=UTC',
+    );
+  }
+
+  const baseAdapter = new PrismaPg({ connectionString: connectionUrl.toString() }, { schema });
 
   const baseClient = new PrismaClient({
     adapter: baseAdapter,
@@ -569,7 +583,18 @@ function getClient() {
     return baseClient;
   }
 
-  const replicaAdapter = new PrismaPg({ connectionString: replicaUrl }, { schema });
+  const replicaConnectionUrl = new URL(replicaUrl);
+  const replicaExistingOptions = replicaConnectionUrl.searchParams.get('options') || '';
+  if (!replicaExistingOptions.includes('timezone')) {
+    replicaConnectionUrl.searchParams.set(
+      'options',
+      replicaExistingOptions
+        ? `${replicaExistingOptions} -c timezone=UTC`
+        : '-c timezone=UTC',
+    );
+  }
+
+  const replicaAdapter = new PrismaPg({ connectionString: replicaConnectionUrl.toString() }, { schema });
 
   const replicaClient = new PrismaClient({
     adapter: replicaAdapter,

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -558,7 +558,7 @@ function getClient() {
   // See https://github.com/umami-software/umami/issues/4285
   const connectionUrl = new URL(url);
   const existingOptions = connectionUrl.searchParams.get('options') || '';
-  if (!existingOptions.includes('timezone')) {
+  if (!/(^|\s)-c\s+timezone=/i.test(existingOptions)) {
     connectionUrl.searchParams.set(
       'options',
       existingOptions ? `${existingOptions} -c timezone=UTC` : '-c timezone=UTC',


### PR DESCRIPTION
## Summary

Fixes #4285

## Root Cause

@prisma/adapter-pg's internal ormatDateTime function converts JavaScript Date objects to PostgreSQL TIMESTAMPTZ strings **without appending a timezone offset**. For example:

`
2024-01-15 10:30:00   ← no UTC offset
`

When the PostgreSQL session timezone is not UTC (e.g. UTC+8), the database interprets the timezone-naive string as being in the **session timezone** rather than UTC. This causes the stored timestamp to be shifted backward by the timezone offset.

## Fix

Append options=-c timezone=UTC to the PostgreSQL connection URL in all three places that create a PrismaPg adapter:

- src/lib/prisma.ts — main and replica connections
- scripts/check-db.js
- scripts/seed/index.ts

This tells PostgreSQL to set the session timezone to UTC for every connection, ensuring timezone-naive TIMESTAMPTZ strings from the adapter are correctly interpreted as UTC.

Closes #4285

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783207539&installation_id=134563449&pr_number=4321&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4321&signature=94b8023c909b2a6d575aeebd427576eeb0581b738be43537e1d2c4b8cc199473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->