### PR TITLE
Skip private/internal IPs when detecting the client IP from headers

### DIFF
--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -20,3 +20,26 @@ test('getIpAddress: Standard header', () => {
 test('getIpAddress: No header', () => {
   expect(getIpAddress(new Headers())).toEqual(undefined);
 });
+
+test('getIpAddress: skips private/internal IP for the public client IP', () => {
+  delete process.env.CLIENT_IP_HEADER;
+
+  expect(
+    getIpAddress(
+      new Headers({
+        'x-real-ip': '10.0.0.8',
+        'x-forwarded-for': '79.127.237.104, 10.0.0.8',
+      }),
+    ),
+  ).toEqual('79.127.237.104');
+});
+
+test('getIpAddress: custom x-forwarded-for header extracts the first IP', () => {
+  process.env.CLIENT_IP_HEADER = 'x-forwarded-for';
+
+  expect(getIpAddress(new Headers({ 'x-forwarded-for': '79.127.237.104, 10.0.0.8' }))).toEqual(
+    '79.127.237.104',
+  );
+
+  delete process.env.CLIENT_IP_HEADER;
+});

--- a/src/lib/ip.ts
+++ b/src/lib/ip.ts
@@ -58,31 +58,86 @@ function resolveIp(ip?: string | null) {
   }
 }
 
-export function getIpAddress(headers: Headers) {
-  const customHeader = process.env.CLIENT_IP_HEADER;
+/**
+ * Detect private/internal addresses (RFC1918, loopback, link-local, CGNAT,
+ * IPv6 unique-local) which can be injected by internal proxies or load
+ * balancers and should not be treated as the real client IP.
+ */
+function isPrivateIp(ip: string) {
+  try {
+    const range = ipaddr.parse(ip).range();
 
-  if (customHeader && headers.get(customHeader)) {
-    return resolveIp(headers.get(customHeader));
+    return (
+      range === 'private' ||
+      range === 'loopback' ||
+      range === 'linkLocal' ||
+      range === 'carrierGradeNat' ||
+      range === 'uniqueLocal'
+    );
+  } catch {
+    return false;
   }
+}
 
-  const header = IP_ADDRESS_HEADERS.find(name => headers.get(name));
-  if (!header) {
-    return undefined;
-  }
-
-  const ip = headers.get(header);
-
+/**
+ * Extract a single candidate IP from a header value, handling the
+ * comma-separated `x-forwarded-for` list and the `forwarded` syntax.
+ */
+function extractIp(header: string, value: string) {
   if (header === 'x-forwarded-for') {
-    return resolveIp(ip?.split(',')?.[0]?.trim());
+    return value.split(',')?.[0]?.trim();
   }
 
   if (header === 'forwarded') {
-    const match = ip.match(/for=(\[?[0-9a-fA-F:.]+]?)/);
+    const match = value.match(/for=(\[?[0-9a-fA-F:.]+]?)/);
 
-    return match ? resolveIp(match[1]) : undefined;
+    return match ? match[1] : undefined;
   }
 
-  return resolveIp(ip);
+  return value;
+}
+
+export function getIpAddress(headers: Headers) {
+  const customHeader = process.env.CLIENT_IP_HEADER;
+
+  if (customHeader) {
+    const value = headers.get(customHeader);
+
+    if (value) {
+      return resolveIp(extractIp(customHeader, value));
+    }
+  }
+
+  // Check candidate headers in priority order. Skip private/internal addresses,
+  // which can appear (e.g. in x-real-ip or forwarded) when a request passes
+  // through internal proxies or load balancers, and fall through to the next
+  // header that carries a public client IP.
+  let fallback: string | null | undefined;
+
+  for (const name of IP_ADDRESS_HEADERS) {
+    const value = headers.get(name);
+
+    if (!value) {
+      continue;
+    }
+
+    const ip = resolveIp(extractIp(name, value));
+
+    if (!ip) {
+      continue;
+    }
+
+    if (isPrivateIp(ip)) {
+      // Keep the first private match as a last resort, in case every candidate
+      // header only carries a private address.
+      fallback ??= ip;
+      continue;
+    }
+
+    return ip;
+  }
+
+  return fallback;
 }
 
 export function stripPort(ip?: string | null) {


### PR DESCRIPTION
## Summary

When a request reaches umami through more than one proxy/load balancer, `getIpAddress()` could return an **internal** address (e.g. `10.0.0.8`) instead of the real client IP, which then breaks geolocation and IP-based filtering.

The previous logic picked the **first candidate header that was merely present** (`IP_ADDRESS_HEADERS.find(...)`) and never checked whether the value was an internal/proxy address. This change iterates the candidate headers in priority order, normalizes each value, and **skips private/internal addresses**, falling through to the first header that carries a public client IP.

## Root cause

In a multi-proxy chain (in our case `client → cloud load balancer → fabio → fabio → umami`), only the **leftmost entry of `X-Forwarded-For`** reliably holds the original client. Other headers carry the *previous hop*, not the originator:

- **`X-Forwarded-For` is append-only.** Per MDN, "the rightmost IP address is the IP address of the most recent proxy and the leftmost IP address is the address of the originating client." So the internal proxy hops legitimately appear in the list alongside the client.
- **The `Forwarded` header's `for=` is the immediate peer.** RFC 7239 defines `for=` as "the node making the request to the proxy" — i.e. the previous hop. Proxies such as [fabio](https://github.com/fabiolb/fabio/blob/master/proxy/http_headers.go) set both `Forwarded: for=` and `X-Real-Ip` from the incoming connection's `RemoteAddr`:

  ```go
  remoteIP, _, err := net.SplitHostPort(r.RemoteAddr)
  ...
  if r.Header.Get("X-Real-Ip") == "" { r.Header.Set("X-Real-Ip", remoteIP) }
  ...
  fwd = "for=" + remoteIP + "; proto=" + proto
  ```

  By the time the request reaches such a proxy, `RemoteAddr` is an **internal** node (e.g. `10.0.0.8`), so that internal IP ends up in `Forwarded` (always) and in `X-Real-Ip` (whenever an upstream hasn't already stamped the real client).

Because `forwarded`/`x-real-ip` can therefore legitimately contain an internal address, selecting the first present header without inspecting its value yields the wrong IP. This is a generic multi-proxy artifact rather than a single-proxy misconfiguration.

## The fix

- Walk `IP_ADDRESS_HEADERS` in order; for each, extract the candidate IP (first entry for `x-forwarded-for`, `for=` for `forwarded`), `resolveIp()` it, and **skip it if it is private/internal** (RFC1918, loopback, link-local, CGNAT, IPv6 unique-local — detected via `ipaddr.range()`).
- Return the first **public** address found.
- If every candidate is private (e.g. local/dev setups), the first one is still returned as a last resort, so existing behavior is preserved.
- The `CLIENT_IP_HEADER` path now goes through the same extraction, so a custom header pointed at a multi-IP `x-forwarded-for` list resolves the first entry instead of the raw comma-separated string.

Header **priority order is unchanged** — the fix is purely additive (skip-private), so setups whose first header is already public behave exactly as before.

## Tests

Added two cases to `src/lib/detect.test.ts`:
- an internal `x-real-ip` with a public `x-forwarded-for` resolves to the public client IP;
- `CLIENT_IP_HEADER=x-forwarded-for` with a multi-IP list extracts the first IP.

Existing `getIpAddress` tests continue to pass.

## References

- [MDN — X-Forwarded-For](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For)
- [RFC 7239 — Forwarded HTTP Extension](https://www.rfc-editor.org/rfc/rfc7239)
- [fabio — `proxy/http_headers.go`](https://github.com/fabiolb/fabio/blob/master/proxy/http_headers.go)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783540402&installation_id=134563449&pr_number=4329&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4329&signature=0df73699fcd94e2ca80f2a78c863fc2a1a987bc9f881d05940fdb529b3ad1f0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->