### PR TITLE
Use Expiring Auth JWTs

### DIFF
--- a/prisma/migrations/21_add_user_auth_session/migration.sql
+++ b/prisma/migrations/21_add_user_auth_session/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "user_auth_session" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "refreshHash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "revoked_at" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_auth_session_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_auth_session_refreshHash_key" ON "user_auth_session"("refreshHash");
+
+-- CreateIndex
+CREATE INDEX "user_auth_session_userId_idx" ON "user_auth_session"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,23 @@ model User {
   teams     TeamUser[]
   reports   Report[]
   boards    Board[]    @relation("user")
+  userAuthSessions UserAuthSession[]
 
   @@map("user")
+}
+
+model UserAuthSession {
+  id          String    @id @default(uuid())
+  userId      String
+  refreshHash String    @unique
+  expiresAt   DateTime  @map("expires_at")
+  revokedAt   DateTime? @map("revoked_at")
+  createdAt   DateTime  @default(now())
+
+  user User @relation(fields: [userId], references: [id])
+
+  @@index([userId])
+  @@map("user_auth_session")
 }
 
 model Session {

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { saveAuth, saveRefreshToken } from '@/lib/auth';
 import { ROLES } from '@/lib/constants';
 import { secret, createRefreshToken } from '@/lib/crypto';
-import { createSecureToken, getAccessExpiry, getRefreshExpiry, refreshTokensEnabled } from '@/lib/jwt';
+import { createSecureToken, getAccessExpiry, refreshTokensEnabled } from '@/lib/jwt';
 import { checkPassword } from '@/lib/password';
 import redis from '@/lib/redis';
 import { parseRequest } from '@/lib/request';

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,8 +1,8 @@
 import { z } from 'zod';
-import { saveAuth } from '@/lib/auth';
+import { saveAuth, saveRefreshToken } from '@/lib/auth';
 import { ROLES } from '@/lib/constants';
-import { secret } from '@/lib/crypto';
-import { createSecureToken } from '@/lib/jwt';
+import { secret, createRefreshToken } from '@/lib/crypto';
+import { createSecureToken, getAccessExpiry, getRefreshExpiry, refreshTokensEnabled } from '@/lib/jwt';
 import { checkPassword } from '@/lib/password';
 import redis from '@/lib/redis';
 import { parseRequest } from '@/lib/request';
@@ -31,18 +31,38 @@ export async function POST(request: Request) {
 
   const { id, role, createdAt } = user;
 
-  let token: string;
+  const teams = await getAllUserTeams(id);
 
   if (redis.enabled) {
-    token = await saveAuth({ userId: id, role });
-  } else {
-    token = createSecureToken({ userId: user.id, role }, secret());
+    const token = await saveAuth({ userId: id, role });
+
+    return json({
+      token,
+      user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
+    });
   }
 
-  const teams = await getAllUserTeams(id);
+  // auth tokens live forever unless refresh tokens are enabled.
+  const token = createSecureToken({ userId: user.id, role }, secret(), { expiresIn: getAccessExpiry() });
+
+  console.log(token);
+
+  if (!refreshTokensEnabled()) {
+    console.log('no refresh config found');
+    return json({
+      token,
+      user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
+    })
+  }
+
+  const refreshToken = createRefreshToken();
+
+  console.log('refreshToken: ' + refreshToken);
+  await saveRefreshToken(id, refreshToken);
 
   return json({
     token,
+    refreshToken,
     user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
   });
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -45,10 +45,7 @@ export async function POST(request: Request) {
   // auth tokens live forever unless refresh tokens are enabled.
   const token = createSecureToken({ userId: user.id, role }, secret(), { expiresIn: getAccessExpiry() });
 
-  console.log(token);
-
   if (!refreshTokensEnabled()) {
-    console.log('no refresh config found');
     return json({
       token,
       user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
@@ -57,7 +54,6 @@ export async function POST(request: Request) {
 
   const refreshToken = createRefreshToken();
 
-  console.log('refreshToken: ' + refreshToken);
   await saveRefreshToken(id, refreshToken);
 
   return json({

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -42,16 +42,16 @@ export async function POST(request: Request) {
     });
   }
 
-  // auth tokens live forever unless refresh tokens are enabled.
-  const token = createSecureToken({ userId: user.id, role }, secret(), { expiresIn: getAccessExpiry() });
-
   if (!refreshTokensEnabled()) {
+    const token = createSecureToken({ userId: user.id, role }, secret(), {});
+
     return json({
       token,
       user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
     })
   }
 
+  const token = createSecureToken({ userId: user.id, role }, secret(), { expiresIn: getAccessExpiry() });
   const refreshToken = createRefreshToken();
 
   await saveRefreshToken(id, refreshToken);

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -27,9 +27,9 @@ export async function POST(request: Request) {
     }
 
     await revokeRefreshToken(body.refreshToken);
-    removeClientAuthToken();
   }
 
+  removeClientAuthToken();
   removeClientRefreshToken();
 
   return ok();

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { hash } from '@/lib/crypto';
 import { refreshTokensEnabled } from '@/lib/jwt';
 import redis from '@/lib/redis';
 import { parseRequest } from '@/lib/request';

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -5,6 +5,7 @@ import redis from '@/lib/redis';
 import { parseRequest } from '@/lib/request';
 import { badRequest, ok } from '@/lib/response';
 import { revokeRefreshToken } from '@/lib/auth';
+import { removeClientAuthToken, removeClientRefreshToken } from '@/lib/client';
 
 export async function POST(request: Request) {
   const schema = z.object({
@@ -27,7 +28,10 @@ export async function POST(request: Request) {
     }
 
     await revokeRefreshToken(body.refreshToken);
+    removeClientAuthToken();
   }
+
+  removeClientRefreshToken();
 
   return ok();
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -29,8 +29,5 @@ export async function POST(request: Request) {
     await revokeRefreshToken(body.refreshToken);
   }
 
-  removeClientAuthToken();
-  removeClientRefreshToken();
-
   return ok();
 }

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,9 +1,17 @@
+import { z } from 'zod';
+import { hash } from '@/lib/crypto';
+import { refreshTokensEnabled } from '@/lib/jwt';
 import redis from '@/lib/redis';
 import { parseRequest } from '@/lib/request';
-import { ok } from '@/lib/response';
+import { badRequest, ok } from '@/lib/response';
+import { revokeRefreshToken } from '@/lib/auth';
 
 export async function POST(request: Request) {
-  const { auth, error } = await parseRequest(request);
+  const schema = z.object({
+    refreshToken: z.string(),
+  }).optional();
+
+  const { auth, body, error } = await parseRequest(request, schema);
 
   if (error) {
     return error();
@@ -11,6 +19,14 @@ export async function POST(request: Request) {
 
   if (redis.enabled && auth?.authKey) {
     await redis.client.del(auth.authKey);
+  }
+
+  if (refreshTokensEnabled()) {
+    if (!body) {
+      return badRequest({ code: 'refresh-token-required' });
+    }
+
+    await revokeRefreshToken(body.refreshToken);
   }
 
   return ok();

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,70 @@
+import { z } from 'zod';
+import { saveAuth } from '@/lib/auth';
+import { ROLES } from '@/lib/constants';
+import { secret } from '@/lib/crypto';
+import { createSecureToken, getAccessExpiry, getRefreshExpiry, refreshTokensEnabled } from '@/lib/jwt';
+import redis from '@/lib/redis';
+import { parseRequest } from '@/lib/request';
+import { badRequest, json, unauthorized } from '@/lib/response';
+import { getAllUserTeams, getUser, getUserAuthSessionByRefreshHash, updateUserAuthSession } from '@/queries/prisma';
+import { hash, createRefreshToken } from '@/lib/crypto';
+
+export async function POST(request: Request) {
+  const schema = z.object({
+    refreshToken: z.string(),
+  });
+
+  const { body, error } = await parseRequest(request, schema, { skipAuth: true });
+
+  if (error) {
+    return error();
+  }
+
+  if (!refreshTokensEnabled()) {
+    return badRequest({ code: 'refresh-tokens-disabled' })
+  }
+
+  if (redis.enabled) {
+    return badRequest({ code: 'not-to-be-used-with-redis'})
+  }
+
+  const { refreshToken } = body;
+
+  const session = await getUserAuthSessionByRefreshHash(hash(refreshToken));
+
+  if (!session || session.revokedAt || session.expiresAt < new Date()) {
+    return unauthorized({ code: 'invalid-refresh-token' });
+  }
+
+  const user = await getUser(session.userId);
+
+  if (!user) {
+    return unauthorized({ code: 'invalid-refresh-token' });
+  }
+
+  const { id, username, role, createdAt } = user;
+
+  const token = createSecureToken({ userId: id, role }, secret(), { expiresIn: getAccessExpiry() });
+
+  const newRefreshToken = createRefreshToken();
+
+  await updateUserAuthSession(session.id, {
+    refreshHash: hash(newRefreshToken),
+    expiresAt: new Date(Date.now() + (getRefreshExpiry() * 24 * 60 * 60 * 1000)),
+  });
+
+  const teams = await getAllUserTeams(id);
+
+  return json({
+    token,
+    refreshToken: newRefreshToken,
+    user: {
+      id,
+      username,
+      role,
+      createdAt,
+      isAdmin: role === ROLES.admin,
+      teams,
+    },
+  });
+}

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { saveAuth } from '@/lib/auth';
 import { ROLES } from '@/lib/constants';
 import { secret } from '@/lib/crypto';
 import { createSecureToken, getAccessExpiry, getRefreshExpiry, refreshTokensEnabled } from '@/lib/jwt';

--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -12,7 +12,7 @@ import {
 import { useRouter } from 'next/navigation';
 import { useMessages, useUpdateQuery } from '@/components/hooks';
 import { Logo } from '@/components/svg';
-import { setClientAuthToken } from '@/lib/client';
+import { setClientAuthToken, setClientRefreshToken } from '@/lib/client';
 import { setUser } from '@/store/app';
 
 export function LoginForm() {
@@ -22,8 +22,11 @@ export function LoginForm() {
 
   const handleSubmit = async (data: any) => {
     await mutateAsync(data, {
-      onSuccess: async ({ token, user }) => {
+      onSuccess: async ({ token, user, refreshToken }) => {
         setClientAuthToken(token);
+        if (refreshToken) {
+          setClientRefreshToken(refreshToken)
+        }
         setUser(user);
         router.push('/');
       },

--- a/src/app/logout/LogoutPage.tsx
+++ b/src/app/logout/LogoutPage.tsx
@@ -2,7 +2,7 @@
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useApi } from '@/components/hooks';
-import { removeClientAuthToken } from '@/lib/client';
+import { removeClientAuthToken, removeClientRefreshToken } from '@/lib/client';
 import { setUser } from '@/store/app';
 
 export function LogoutPage() {
@@ -17,6 +17,7 @@ export function LogoutPage() {
     }
 
     removeClientAuthToken();
+    removeClientRefreshToken();
     setUser(null);
     logout();
   }, [router, post]);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -6,11 +6,13 @@ import {
   SHARE_TOKEN_HEADER,
   SHARE_TOKEN_TYPE,
 } from '@/lib/constants';
-import { createAuthKey, secret } from '@/lib/crypto';
-import { createSecureToken, parseSecureToken, parseToken } from '@/lib/jwt';
+import { createAuthKey, secret, hash } from '@/lib/crypto';
+import { createSecureToken, getRefreshExpiry, parseSecureToken, parseToken } from '@/lib/jwt';
 import redis from '@/lib/redis';
 import { ensureArray } from '@/lib/utils';
 import { getUser } from '@/queries/prisma/user';
+import prisma from './prisma';
+import { getUserAuthSessionByRefreshHash, updateUserAuthSession } from '@/queries/prisma';
 
 const log = debug('umami:auth');
 
@@ -99,4 +101,20 @@ export function parseShareToken(request: Request) {
     log(e);
     return null;
   }
+}
+
+export async function saveRefreshToken(userId: string, refreshToken: string) {
+  await prisma.client.userAuthSession.create({
+    data: {
+      userId,
+      refreshHash: hash(refreshToken),
+      expiresAt: new Date(Date.now() + (getRefreshExpiry() * 24 * 60 * 60 * 1000)),
+    },
+  });
+}
+
+export async function revokeRefreshToken(refreshToken: string) {
+  const session = await getUserAuthSessionByRefreshHash(hash(refreshToken));
+
+  await updateUserAuthSession(session.id, { revokedAt: new Date() });
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -116,5 +116,9 @@ export async function saveRefreshToken(userId: string, refreshToken: string) {
 export async function revokeRefreshToken(refreshToken: string) {
   const session = await getUserAuthSessionByRefreshHash(hash(refreshToken));
 
+  if (!session) {
+    return;
+  }
+
   await updateUserAuthSession(session.id, { revokedAt: new Date() });
 }

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,14 +1,43 @@
 import { getItem, removeItem, setItem } from '@/lib/storage';
-import { AUTH_TOKEN } from './constants';
+import { AUTH_TOKEN, REFRESH_TOKEN } from './constants';
+import { refreshTokensEnabled } from './jwt';
+
+let accessToken: string | null = null;
 
 export function getClientAuthToken() {
+  if (refreshTokensEnabled()) {
+    return accessToken;
+  }
+
   return getItem(AUTH_TOKEN);
 }
 
 export function setClientAuthToken(token: string) {
+  if (refreshTokensEnabled()) {
+    accessToken = token;
+    return;
+  }
+
   setItem(AUTH_TOKEN, token);
 }
 
 export function removeClientAuthToken() {
+  if (refreshTokensEnabled()) {
+    accessToken = null;
+    return;
+  }
+
   removeItem(AUTH_TOKEN);
+}
+
+export function getClientRefreshToken() {
+  return getItem(REFRESH_TOKEN);
+}
+
+export function setClientRefreshToken(token: string) {
+  setItem(REFRESH_TOKEN, token)
+}
+
+export function removeClientRefreshToken() {
+  removeItem(REFRESH_TOKEN);
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,6 @@
 export const CURRENT_VERSION = process.env.currentVersion;
 export const AUTH_TOKEN = 'umami.auth';
+export const REFRESH_TOKEN = 'umami.refresh'
 export const LOCALE_CONFIG = 'umami.locale';
 export const TIMEZONE_CONFIG = 'umami.timezone';
 export const DATE_RANGE_CONFIG = 'umami.date-range';

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -76,3 +76,7 @@ export function getSalt(saltRotation: string, createdAt: Date): string {
     ).toUTCString(),
   );
 }
+
+export function createRefreshToken() {
+  return crypto.randomBytes(64).toString('hex');
+}

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,4 +1,6 @@
 import { buildPath } from '@/lib/url';
+import { getApiUrl } from './api-url';
+import { getClientRefreshToken, setClientAuthToken, setClientRefreshToken } from './client';
 
 export interface ErrorResponse {
   error: {
@@ -33,12 +35,41 @@ export async function request(
   }).then(async res => {
     const data = await res.json();
 
+    console.log('fetch.ts res.status: ', res.status);
+    console.log('fetch.ts data.error.code: ', data?.error?.code);
+
+    if (res.status === 401 && data?.error?.code === 'expired-token') {
+      console.log('trying to refresh tokens');
+      const token = await refreshTokens();
+      return request(method, url, body, {
+        ...headers,
+        authorization: `Bearer ${token}`
+      }); //todo the auth header needs to be changed
+    }
+
     return {
       ok: res.ok,
       status: res.status,
       data,
     };
   });
+}
+
+export async function refreshTokens() {
+  const res = await request('POST', getApiUrl('/auth/refresh'), JSON.stringify({
+    refreshToken: getClientRefreshToken(),
+  }), { 'Content-Type' : 'application/json' });
+
+  if (res.data?.refreshToken) {
+    setClientRefreshToken(res.data.refreshToken);
+  }
+
+  if (res.data?.token) {
+    setClientAuthToken(res.data.token);
+    return res.data.token;
+  }
+
+  throw new Error('Failed token refresh');
 }
 
 export async function httpGet(path: string, params: object = {}, headers: object = {}) {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -40,7 +40,7 @@ export async function request(
       return request(method, url, body, {
         ...headers,
         authorization: `Bearer ${token}`
-      }); //todo the auth header needs to be changed
+      });
     }
 
     return {

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -35,11 +35,7 @@ export async function request(
   }).then(async res => {
     const data = await res.json();
 
-    console.log('fetch.ts res.status: ', res.status);
-    console.log('fetch.ts data.error.code: ', data?.error?.code);
-
     if (res.status === 401 && data?.error?.code === 'expired-token') {
-      console.log('trying to refresh tokens');
       const token = await refreshTokens();
       return request(method, url, body, {
         ...headers,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -22,6 +22,7 @@ export async function request(
   url: string,
   body?: string,
   headers: object = {},
+  skipRefresh: boolean = false
 ): Promise<FetchResponse> {
   return fetch(url, {
     method,
@@ -35,7 +36,7 @@ export async function request(
   }).then(async res => {
     const data = await res.json();
 
-    if (res.status === 401 && data?.error?.code === 'expired-token') {
+    if (!skipRefresh && res.status === 401 && data?.error?.code === 'expired-token') {
       const token = await refreshTokens();
       return request(method, url, body, {
         ...headers,
@@ -54,7 +55,7 @@ export async function request(
 export async function refreshTokens() {
   const res = await request('POST', getApiUrl('/auth/refresh'), JSON.stringify({
     refreshToken: getClientRefreshToken(),
-  }), { 'Content-Type' : 'application/json' });
+  }), { 'Content-Type' : 'application/json' }, true);
 
   if (res.data?.refreshToken) {
     setClientRefreshToken(res.data.refreshToken);

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import jwt, { TokenExpiredError } from 'jsonwebtoken';
 import { decrypt, encrypt } from '@/lib/crypto';
 
 export function createToken(payload: any, secret: any, options?: any) {
@@ -20,7 +20,10 @@ export function createSecureToken(payload: any, secret: any, options?: any) {
 export function parseSecureToken(token: string, secret: any) {
   try {
     return jwt.verify(decrypt(token, secret), secret);
-  } catch {
+  } catch (error) {
+    if (error instanceof TokenExpiredError) {
+      throw error;
+    }
     return null;
   }
 }
@@ -33,4 +36,26 @@ export async function parseAuthToken(req: Request, secret: string) {
   } catch {
     return null;
   }
+}
+
+export function refreshTokensEnabled() {
+  return process.env.AUTH_REFRESH_TOKEN_ENABLED === 'true';
+}
+
+export function getAccessExpiry() {
+  if (refreshTokensEnabled) {
+    return process.env.AUTH_ACCESS_TOKEN_EXPIRY || '15m';
+  }
+
+  return undefined;
+}
+
+export function getRefreshExpiry() {
+  const expiryDays = process.env.AUTH_REFRESH_TOKEN_EXPIRY_DAYS || '30';
+
+  if (refreshTokensEnabled && !Number.isNaN(expiryDays)) {
+    return Number(expiryDays);
+  }
+
+  return undefined;
 }

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -52,8 +52,9 @@ export function getAccessExpiry() {
 
 export function getRefreshExpiry() {
   const expiryDays = process.env.AUTH_REFRESH_TOKEN_EXPIRY_DAYS || '30';
+  const expiryDaysParsed = Number(expiryDays);
 
-  if (refreshTokensEnabled() && !Number.isNaN(expiryDays)) {
+  if (refreshTokensEnabled() && !Number.isNaN(expiryDaysParsed)) {
     return Number(expiryDays);
   }
 

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -43,7 +43,7 @@ export function refreshTokensEnabled() {
 }
 
 export function getAccessExpiry() {
-  if (refreshTokensEnabled) {
+  if (refreshTokensEnabled()) {
     return process.env.AUTH_ACCESS_TOKEN_EXPIRY || '15m';
   }
 
@@ -53,7 +53,7 @@ export function getAccessExpiry() {
 export function getRefreshExpiry() {
   const expiryDays = process.env.AUTH_REFRESH_TOKEN_EXPIRY_DAYS || '30';
 
-  if (refreshTokensEnabled && !Number.isNaN(expiryDays)) {
+  if (refreshTokensEnabled() && !Number.isNaN(expiryDays)) {
     return Number(expiryDays);
   }
 

--- a/src/lib/request.ts
+++ b/src/lib/request.ts
@@ -8,6 +8,7 @@ import { filtersArrayToObject } from '@/lib/params';
 import { badRequest, unauthorized } from '@/lib/response';
 import type { QueryFilters } from '@/lib/types';
 import { getWebsiteSegment } from '@/queries/prisma';
+import { TokenExpiredError } from 'jsonwebtoken'
 
 export async function parseRequest(
   request: Request,
@@ -42,11 +43,20 @@ export async function parseRequest(
   }
 
   if (!options?.skipAuth && !error) {
-    auth = await checkAuth(request);
+    try {
+      auth = await checkAuth(request);
 
-    if (!auth) {
-      error = () => unauthorized();
+      if (!auth) {
+        error = () => unauthorized();
+      }
+    } catch (err) {
+      if (err instanceof TokenExpiredError) {
+        error = () => unauthorized({ code: 'expired-token' });
+      } else {
+        error = () => unauthorized();
+      }
     }
+
   }
 
   return { url, query, body, auth, error };

--- a/src/queries/prisma/index.ts
+++ b/src/queries/prisma/index.ts
@@ -8,4 +8,5 @@ export * from './share';
 export * from './team';
 export * from './teamUser';
 export * from './user';
+export * from './userAuthSession';
 export * from './website';

--- a/src/queries/prisma/userAuthSession.ts
+++ b/src/queries/prisma/userAuthSession.ts
@@ -1,0 +1,26 @@
+import { Prisma } from '@/generated/prisma/client';
+import prisma from '@/lib/prisma';
+
+export async function findUserAuthSession(criteria: Prisma.UserAuthSessionFindUniqueArgs) {
+  return prisma.client.userAuthSession.findUnique(criteria);
+}
+
+export async function getUserAuthSessionByRefreshHash(refreshHash: string) {
+  return findUserAuthSession({
+    where: {
+      refreshHash,
+    },
+  });
+}
+
+export async function updateUserAuthSession(
+  userAuthSessionId: string,
+  data: Prisma.UserAuthSessionUpdateInput,
+) {
+  return prisma.client.userAuthSession.update({
+    where: {
+      id: userAuthSessionId,
+    },
+    data,
+  });
+}


### PR DESCRIPTION
# Use Expiring Auth JWTs
I wanted to add the ability to set an expiry on the JWTs created by the auth system. Using never dying JWTs is not secure (I give examples below). By using unexpiring JWTs, we are practically swapping a password for a more secure password; but a password nonetheless that is attached with every request. We now have to manage every access token created to make sure that they aren't exposed. The better workflow is to protect a single password and use expiring JWTs.

## Why
For example: if I sell my laptop and don't clear my browser history or storage, someone could log into my analytics dashboard since the JWT is still valid a year later. This way there is a time limit on how long someone can use the system before they need to reauthenticate. The default is 30 days.

Another more practical example:
Everyone is using coding agents and an agent uses console.log() on a production access token. The developer finds out later on that their access tokens have been broadcast. They now have to go in and change the app secret in order to invalidate the sessions, instead of the sessions being expiring in the first place.

## Refreshing tokens
When a request fails due to an expired token, the system automatically refreshes the Access Token. When refresh tokens are enabled in the ENV VARs, the system starts saving the access token in browser memory and saves the refresh token in the localStorage.

## Environment Variables
3 new environment variables were added:
* AUTH_REFRESH_TOKEN_ENABLED -> 'true' | 'false'
* AUTH_ACCESS_TOKEN_EXPIRY -> drop in for: jsonwebtoken -> `sign()` -> `expiresIn` property 
* AUTH_REFRESH_TOKEN_EXPIRY_DAYS -> number of days the refresh token will work.

If AUTH_REFRESH_TOKEN_ENABLED is set to false, the system should act as if the changes in this PR do not exist. 

jsonwebtoken docs: https://www.npmjs.com/package/jsonwebtoken

## New API Endpoint
POST `/api/auth/refresh`
Body: 
```
{
  refreshToken: ${refreshToken},
}
```
Response:
```
{
  token: ${newAccessToken}
  refreshToken: ${newRefreshToken}
  user: { } // same as /login
}
```

## "Session Tracking"
Database tracks `UserAuthSession`. This is the source of truth for Refresh Tokens. Refresh Tokens can be revoked in the UserAuthSession. Refresh Tokens are hashed for security.

## Fixes
If you have any questions or concerns, leave a comment and I'll edit this description or respond.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784143594&installation_id=134563449&pr_number=4337&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4337&signature=8b964dab0179f014801777289e5885f7b0acb4898bde7e34767b0b0f34d9b21d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->