### PR TITLE
Resolve ALLOWED_FRAME_URLS from the runtime environment in Docker

### DIFF
--- a/docker/proxy.ts
+++ b/docker/proxy.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import { getContentSecurityPolicy } from '@/lib/csp';
 import { matchesConfiguredPath } from '@/lib/match-configured-path';
 
 export const config = {
@@ -22,6 +23,9 @@ const trackerHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Cache-Control': 'public, max-age=86400, must-revalidate',
 };
+
+// Resolved once at startup — env vars don't change after the process starts.
+const contentSecurityPolicy = getContentSecurityPolicy();
 
 function customCollectEndpoint(request: NextRequest) {
   const collectEndpoint = process.env.COLLECT_API_ENDPOINT;
@@ -69,12 +73,20 @@ function disableLogin(request: NextRequest) {
 export default function middleware(req: NextRequest) {
   const fns = [customCollectEndpoint, customScriptName, customScriptUrl, disableLogin];
 
+  let res: NextResponse | undefined;
+
   for (const fn of fns) {
-    const res = fn(req);
+    res = fn(req);
     if (res) {
-      return res;
+      break;
     }
   }
 
-  return NextResponse.next();
+  res ??= NextResponse.next();
+
+  // Set the CSP here, not only at build time in next.config.ts, so
+  // ALLOWED_FRAME_URLS is resolved from the runtime environment.
+  res.headers.set('Content-Security-Policy', contentSecurityPolicy);
+
+  return res;
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import createNextIntlPlugin from 'next-intl/plugin';
 import pkg from './package.json' with { type: 'json' };
+import { getContentSecurityPolicy } from './src/lib/csp';
 
 const withNextIntl = createNextIntlPlugin('./src/i18n/request.ts');
 
@@ -17,19 +18,10 @@ const corsMaxAge = process.env.CORS_MAX_AGE || '';
 const defaultCurrency = process.env.DEFAULT_CURRENCY || '';
 const defaultLocale = process.env.DEFAULT_LOCALE || '';
 const forceSSL = process.env.FORCE_SSL || '';
-const frameAncestors = process.env.ALLOWED_FRAME_URLS || '';
 const trackerScriptName = process.env.TRACKER_SCRIPT_NAME || '';
 const trackerScriptURL = process.env.TRACKER_SCRIPT_URL || '';
 const selfTrack = process.env.UMAMI_SELF_TRACK || '';
 const selfRecord = process.env.UMAMI_SELF_RECORD || '';
-
-function getUrlOrigin(url: string) {
-  try {
-    return new URL(url).origin;
-  } catch {
-    return '';
-  }
-}
 
 function isRelativeUrl(url: string) {
   return Boolean(url && !/^https?:\/\//i.test(url));
@@ -39,19 +31,6 @@ function normalizePath(url: string) {
   return `/${url.replace(/^\/+|\/+$/g, '')}`;
 }
 
-const apiUrlOrigin = getUrlOrigin(apiUrl);
-const connectSrc = ["'self'", 'https:', apiUrlOrigin].filter(Boolean).join(' ');
-
-const contentSecurityPolicy = `
-  default-src 'self';
-  img-src 'self' https: data: blob:;
-  script-src 'self' 'unsafe-eval' 'unsafe-inline';
-  style-src 'self' 'unsafe-inline';
-  connect-src ${connectSrc};
-  frame-src 'self' http: https:;
-  frame-ancestors 'self' ${frameAncestors};
-`;
-
 const defaultHeaders = [
   {
     key: 'X-DNS-Prefetch-Control',
@@ -59,7 +38,7 @@ const defaultHeaders = [
   },
   {
     key: 'Content-Security-Policy',
-    value: contentSecurityPolicy.replace(/\s{2,}/g, ' ').trim(),
+    value: getContentSecurityPolicy(),
   },
 ];
 

--- a/src/lib/csp.ts
+++ b/src/lib/csp.ts
@@ -1,0 +1,28 @@
+function getUrlOrigin(url: string) {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return '';
+  }
+}
+
+// Builds the Content-Security-Policy. Reads the environment when called, so it
+// can run at build time (next.config.ts) or per request in the Docker proxy,
+// where ALLOWED_FRAME_URLS and API_URL then apply without rebuilding the image.
+export function getContentSecurityPolicy() {
+  const apiUrlOrigin = getUrlOrigin(process.env.API_URL || '');
+  const connectSrc = ["'self'", 'https:', apiUrlOrigin].filter(Boolean).join(' ');
+  const frameAncestors = ["'self'", process.env.ALLOWED_FRAME_URLS || ''].filter(Boolean).join(' ');
+
+  const directives = [
+    `default-src 'self'`,
+    `img-src 'self' https: data: blob:`,
+    `script-src 'self' 'unsafe-eval' 'unsafe-inline'`,
+    `style-src 'self' 'unsafe-inline'`,
+    `connect-src ${connectSrc}`,
+    `frame-src 'self' http: https:`,
+    `frame-ancestors ${frameAncestors}`,
+  ];
+
+  return `${directives.join('; ')};`;
+}


### PR DESCRIPTION
## Problem

`ALLOWED_FRAME_URLS` is documented as the way to allow iframe embedding, but it is effectively a **build-time** variable: the CSP is built in `next.config.ts` `headers()`, which Next serializes into `routes-manifest.json` during `next build`. The published Docker images are built without it, so `frame-ancestors` is fixed at `'self'` and setting the env on the running container has no effect — embedding currently requires building a custom image.

Reported in #3793 and #2407.

## Change

- Extract the CSP into a shared `getContentSecurityPolicy()` (`src/lib/csp.ts`) that reads the environment when called.
- Set the header from the Docker proxy (`docker/proxy.ts`) on every response, alongside the other runtime env it already handles (`CORS_MAX_AGE`, `DISABLE_LOGIN`, …). This makes `ALLOWED_FRAME_URLS` (and `API_URL` in `connect-src`) resolve at runtime.
- `next.config.ts` skips the build-time CSP when the proxy is present (`src/proxy.ts`, which the Dockerfile copies in), so browsers receive exactly one CSP header — two would be intersected, dropping the runtime `frame-ancestors`.

Non-Docker builds are unchanged: `next.config.ts` still emits the build-time CSP, and `ALLOWED_FRAME_URLS` keeps working as a build-time variable there.

## Verification

Built the image once, then started the **same image** with different runtime values:

| `ALLOWED_FRAME_URLS` (runtime env) | `frame-ancestors` in response |
| --- | --- |
| `https://example.com` | `'self' https://example.com` |
| `https://example.com https://foo.example` | `'self' https://example.com https://foo.example` |
| _(unset)_ | `'self'` |

Exactly one `Content-Security-Policy` header is returned in each case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4356"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785062653&installation_id=134563449&pr_number=4356&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4356&signature=33bad411145f6c03bae7b1dfe3cb49f5997b22ce04e59331c106c7a1de417a0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->