### PR TITLE
fix(events): add GROUP BY to getEventDataEvents no-event relational branch (PostgreSQL 42803)

### DIFF
--- a/src/queries/sql/events/getEventDataEvents.ts
+++ b/src/queries/sql/events/getEventDataEvents.ts
@@ -70,6 +70,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
     where event_data.website_id = {{websiteId::uuid}}
       and event_data.created_at between {{startDate}} and {{endDate}}
     ${filterQuery}
+    group by website_event.event_name, event_data.data_key, event_data.data_type
     limit 500
     `,
     queryParams,


### PR DESCRIPTION
## Summary

The relational (Prisma) **no-event** branch of `getEventDataEvents` selects three non-aggregated columns (`event_name`, `data_key`, `data_type`) alongside `count(*)` but is missing a `GROUP BY` clause. PostgreSQL rejects this with:

```
ERROR: column "website_event.event_name" must appear in the GROUP BY clause or be used in an aggregate function (42803)
```

This surfaces as a 500 on the event-data events query for any PostgreSQL-backed instance, and also affects MySQL instances running with `ONLY_FULL_GROUP_BY` (the default in MySQL 5.7.5+).

The sibling branches are already correct: the event-filtered relational branch groups by its selected columns, and both ClickHouse branches include `GROUP BY`. Only the relational no-event branch was missing it.

Fixes #4359.

## Change

Add the matching `GROUP BY` to the no-event relational branch:

```sql
group by website_event.event_name, event_data.data_key, event_data.data_type
```

This is the minimal, single-line fix and mirrors the grouping already used by the event-filtered branch (minus `string_value`, which the no-event branch does not select).

## Reproduction

- Umami 3.2.0 on PostgreSQL 16 (also reproduces on `dev`/master).
- Call the event-data events query without an `event` filter → 500 with the `42803` error above.
- With the fix, the query returns the aggregated rows as expected.

## Notes

This is a one-line SQL change with no schema or API-surface impact. I wasn't able to run the full `pnpm build`/`pnpm lint` in my environment, but the change is confined to a SQL string literal and matches the existing pattern in the same file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4365"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785274698&installation_id=134563449&pr_number=4365&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4365&signature=6f5b8460b41e330bced9c94297b287fb0920d3ce8a3a5ad7c09c0453931c860b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->