### PR TITLE
feat: automatic session linking and identity stitching

### DIFF
--- a/db/clickhouse/migrations/13_add_identity_link.sql
+++ b/db/clickhouse/migrations/13_add_identity_link.sql
@@ -1,0 +1,117 @@
+-- add visitor_id to event tables
+ALTER TABLE umami.website_event ADD COLUMN IF NOT EXISTS visitor_id String AFTER distinct_id;
+ALTER TABLE umami.website_event_stats_hourly ADD COLUMN IF NOT EXISTS visitor_id String AFTER distinct_id;
+
+-- identity linking table
+CREATE TABLE IF NOT EXISTS umami.identity_link
+(
+    website_id UUID,
+    visitor_id String,
+    distinct_id String,
+    created_at DateTime('UTC'),
+    linked_at DateTime('UTC')
+)
+ENGINE = ReplacingMergeTree(linked_at)
+ORDER BY (website_id, visitor_id, distinct_id)
+SETTINGS index_granularity = 8192;
+
+-- rebuild the hourly MV so it projects visitor_id
+DROP VIEW IF EXISTS umami.website_event_stats_hourly_mv;
+CREATE MATERIALIZED VIEW umami.website_event_stats_hourly_mv
+TO umami.website_event_stats_hourly
+AS
+SELECT
+    website_id,
+    session_id,
+    visit_id,
+    hostnames as hostname,
+    browser,
+    os,
+    device,
+    screen,
+    language,
+    country,
+    region,
+    city,
+    entry_url,
+    exit_url,
+    url_paths as url_path,
+    url_query,
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    utm_content,
+    utm_term,
+    referrer_domain,
+    page_title,
+    gclid,
+    fbclid,
+    msclkid,
+    ttclid,
+    li_fat_id,
+    twclid,
+    event_type,
+    event_name,
+    views,
+    min_time,
+    max_time,
+    tag,
+    distinct_id,
+    visitor_id,
+    timestamp as created_at
+FROM (SELECT
+    website_id,
+    session_id,
+    visit_id,
+    arrayFilter(x -> x != '', groupArray(hostname)) hostnames,
+    browser,
+    os,
+    device,
+    screen,
+    language,
+    country,
+    region,
+    city,
+    argMinState(url_path, created_at) entry_url,
+    argMaxState(url_path, created_at) exit_url,
+    arrayFilter(x -> x != '', groupArray(url_path)) as url_paths,
+    arrayFilter(x -> x != '', groupArray(url_query)) url_query,
+    arrayFilter(x -> x != '', groupArray(utm_source)) utm_source,
+    arrayFilter(x -> x != '', groupArray(utm_medium)) utm_medium,
+    arrayFilter(x -> x != '', groupArray(utm_campaign)) utm_campaign,
+    arrayFilter(x -> x != '', groupArray(utm_content)) utm_content,
+    arrayFilter(x -> x != '', groupArray(utm_term)) utm_term,
+    arrayFilter(x -> x != '' and x != hostname, groupArray(referrer_domain)) referrer_domain,
+    arrayFilter(x -> x != '', groupArray(page_title)) page_title,
+    arrayFilter(x -> x != '', groupArray(gclid)) gclid,
+    arrayFilter(x -> x != '', groupArray(fbclid)) fbclid,
+    arrayFilter(x -> x != '', groupArray(msclkid)) msclkid,
+    arrayFilter(x -> x != '', groupArray(ttclid)) ttclid,
+    arrayFilter(x -> x != '', groupArray(li_fat_id)) li_fat_id,
+    arrayFilter(x -> x != '', groupArray(twclid)) twclid,
+    event_type,
+    if(event_type = 2, groupArray(event_name), []) event_name,
+    sumIf(1, event_type NOT IN (2, 5)) views,
+    min(created_at) min_time,
+    max(created_at) max_time,
+    arrayFilter(x -> x != '', groupArray(tag)) tag,
+    distinct_id,
+    visitor_id,
+    toStartOfHour(created_at) timestamp
+FROM umami.website_event
+GROUP BY website_id,
+    session_id,
+    visit_id,
+    hostname,
+    browser,
+    os,
+    device,
+    screen,
+    language,
+    country,
+    region,
+    city,
+    event_type,
+    distinct_id,
+    visitor_id,
+    timestamp);

--- a/db/clickhouse/schema.sql
+++ b/db/clickhouse/schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE umami.website_event
     event_name String,
     tag String,
     distinct_id String,
+    visitor_id String,
     created_at DateTime('UTC'),
     job_id Nullable(UUID)
 )
@@ -148,6 +149,7 @@ CREATE TABLE umami.website_event_stats_hourly
     max_time SimpleAggregateFunction(max, DateTime('UTC')),
     tag SimpleAggregateFunction(groupArrayArray, Array(String)),
     distinct_id String,
+    visitor_id String,
     created_at Datetime('UTC')
 )
 ENGINE = AggregatingMergeTree
@@ -201,6 +203,7 @@ SELECT
     max_time,
     tag,
     distinct_id,
+    visitor_id,
     timestamp as created_at
 FROM (SELECT
     website_id,
@@ -239,6 +242,7 @@ FROM (SELECT
     max(created_at) max_time,
     arrayFilter(x -> x != '', groupArray(tag)) tag,
     distinct_id,
+    visitor_id,
     toStartOfHour(created_at) timestamp
 FROM umami.website_event
 GROUP BY website_id,
@@ -255,6 +259,7 @@ GROUP BY website_id,
     city,
     event_type,
     distinct_id,
+    visitor_id,
     timestamp);
 
 -- projections
@@ -424,3 +429,16 @@ ENGINE = MergeTree
     PARTITION BY toYYYYMM(created_at)
     ORDER BY (website_id, url_path, event_type, created_at)
     SETTINGS index_granularity = 8192;
+
+-- identity linking
+CREATE TABLE umami.identity_link
+(
+    website_id UUID,
+    visitor_id String,
+    distinct_id String,
+    created_at DateTime('UTC'),
+    linked_at DateTime('UTC')
+)
+ENGINE = ReplacingMergeTree(linked_at)
+ORDER BY (website_id, visitor_id, distinct_id)
+SETTINGS index_granularity = 8192;

--- a/prisma/migrations/21_add_identity_link/migration.sql
+++ b/prisma/migrations/21_add_identity_link/migration.sql
@@ -17,7 +17,6 @@ CREATE TABLE "identity_link" (
 );
 
 -- CreateIndex
-CREATE UNIQUE INDEX "identity_link_identity_link_id_key" ON "identity_link"("identity_link_id");
 CREATE UNIQUE INDEX "identity_link_website_id_visitor_id_distinct_id_key" ON "identity_link"("website_id", "visitor_id", "distinct_id");
 CREATE INDEX "identity_link_website_id_distinct_id_idx" ON "identity_link"("website_id", "distinct_id");
 CREATE INDEX "identity_link_website_id_visitor_id_idx" ON "identity_link"("website_id", "visitor_id");

--- a/prisma/migrations/21_add_identity_link/migration.sql
+++ b/prisma/migrations/21_add_identity_link/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "session" ADD COLUMN "visitor_id" VARCHAR(50);
+
+-- CreateIndex
+CREATE INDEX "session_website_id_visitor_id_idx" ON "session"("website_id", "visitor_id");
+
+-- CreateTable
+CREATE TABLE "identity_link" (
+    "identity_link_id" UUID NOT NULL,
+    "website_id" UUID NOT NULL,
+    "visitor_id" VARCHAR(50) NOT NULL,
+    "distinct_id" VARCHAR(50) NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "linked_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "identity_link_pkey" PRIMARY KEY ("identity_link_id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "identity_link_identity_link_id_key" ON "identity_link"("identity_link_id");
+CREATE UNIQUE INDEX "identity_link_website_id_visitor_id_distinct_id_key" ON "identity_link"("website_id", "visitor_id", "distinct_id");
+CREATE INDEX "identity_link_website_id_distinct_id_idx" ON "identity_link"("website_id", "distinct_id");
+CREATE INDEX "identity_link_website_id_visitor_id_idx" ON "identity_link"("website_id", "visitor_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -433,7 +433,7 @@ model HeatmapEvent {
 }
 
 model IdentityLink {
-  id         String   @id @unique @map("identity_link_id") @db.Uuid
+  id         String   @id @map("identity_link_id") @db.Uuid
   websiteId  String   @map("website_id") @db.Uuid
   visitorId  String   @map("visitor_id") @db.VarChar(50)
   distinctId String   @map("distinct_id") @db.VarChar(50)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,6 +43,7 @@ model Session {
   region     String?   @db.VarChar(20)
   city       String?   @db.VarChar(50)
   distinctId String?   @map("distinct_id") @db.VarChar(50)
+  visitorId  String?   @map("visitor_id") @db.VarChar(50)
   createdAt  DateTime? @default(now()) @map("created_at") @db.Timestamptz(6)
 
   websiteEvents WebsiteEvent[]
@@ -60,6 +61,7 @@ model Session {
   @@index([websiteId, createdAt, country])
   @@index([websiteId, createdAt, region])
   @@index([websiteId, createdAt, city])
+  @@index([websiteId, visitorId])
   @@map("session")
 }
 
@@ -78,9 +80,9 @@ model Website {
   recorderEnabled Boolean @default(false) @map("recorder_enabled")
   replayConfig    Json?   @map("replay_config")
 
-  user                User?               @relation("user", fields: [userId], references: [id])
-  createUser          User?               @relation("createUser", fields: [createdBy], references: [id])
-  team                Team?               @relation(fields: [teamId], references: [id])
+  user                User?                @relation("user", fields: [userId], references: [id])
+  createUser          User?                @relation("createUser", fields: [createdBy], references: [id])
+  team                Team?                @relation(fields: [teamId], references: [id])
   eventData           EventData[]
   reports             Report[]
   revenue             Revenue[]
@@ -89,6 +91,7 @@ model Website {
   sessionReplays      SessionReplay[]
   sessionReplaysSaved SessionReplaySaved[]
   heatmapEvents       HeatmapEvent[]
+  identityLinks       IdentityLink[]
 
   @@index([userId])
   @@index([teamId])
@@ -208,7 +211,7 @@ model Team {
   members  TeamUser[]
   links    Link[]
   pixels   Pixel[]
-  boards    Board[]
+  boards   Board[]
 
   @@index([accessCode])
   @@map("team")
@@ -346,6 +349,7 @@ model Board {
   @@index([createdAt])
   @@map("board")
 }
+
 model Share {
   id         String    @id() @map("share_id") @db.Uuid
   entityId   String    @map("entity_id") @db.Uuid
@@ -402,22 +406,22 @@ model SessionReplaySaved {
 }
 
 model HeatmapEvent {
-  id               String   @id() @map("heatmap_event_id") @db.Uuid
-  websiteId        String   @map("website_id") @db.Uuid
-  sessionId        String   @map("session_id") @db.Uuid
-  visitId          String   @map("visit_id") @db.Uuid
-  urlPath          String   @map("url_path") @db.VarChar(500)
-  eventType        Int      @map("event_type") @db.Integer
-  x                Int?     @db.Integer
-  y                Int?     @db.Integer
-  pageX            Int?     @map("page_x") @db.Integer
-  pageY            Int?     @map("page_y") @db.Integer
-  pageW            Int?     @map("page_w") @db.Integer
-  viewportW        Int?     @map("viewport_w") @db.Integer
-  viewportH        Int?     @map("viewport_h") @db.Integer
-  pageH            Int?     @map("page_h") @db.Integer
-  scrollPct        Int?     @map("scroll_pct") @db.Integer
-  createdAt        DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  id        String   @id() @map("heatmap_event_id") @db.Uuid
+  websiteId String   @map("website_id") @db.Uuid
+  sessionId String   @map("session_id") @db.Uuid
+  visitId   String   @map("visit_id") @db.Uuid
+  urlPath   String   @map("url_path") @db.VarChar(500)
+  eventType Int      @map("event_type") @db.Integer
+  x         Int?     @db.Integer
+  y         Int?     @db.Integer
+  pageX     Int?     @map("page_x") @db.Integer
+  pageY     Int?     @map("page_y") @db.Integer
+  pageW     Int?     @map("page_w") @db.Integer
+  viewportW Int?     @map("viewport_w") @db.Integer
+  viewportH Int?     @map("viewport_h") @db.Integer
+  pageH     Int?     @map("page_h") @db.Integer
+  scrollPct Int?     @map("scroll_pct") @db.Integer
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
 
   website Website @relation(fields: [websiteId], references: [id])
 
@@ -426,4 +430,20 @@ model HeatmapEvent {
   @@index([websiteId, createdAt])
   @@index([websiteId, urlPath, eventType, createdAt])
   @@map("heatmap_event")
+}
+
+model IdentityLink {
+  id         String   @id @unique @map("identity_link_id") @db.Uuid
+  websiteId  String   @map("website_id") @db.Uuid
+  visitorId  String   @map("visitor_id") @db.VarChar(50)
+  distinctId String   @map("distinct_id") @db.VarChar(50)
+  createdAt  DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
+  linkedAt   DateTime @default(now()) @updatedAt @map("linked_at") @db.Timestamptz(6)
+
+  website Website @relation(fields: [websiteId], references: [id], onDelete: Cascade)
+
+  @@unique([websiteId, visitorId, distinctId])
+  @@index([websiteId, distinctId])
+  @@index([websiteId, visitorId])
+  @@map("identity_link")
 }

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -48,7 +48,7 @@ const schema = z.object({
       ip: z.string().optional(),
       userAgent: z.string().optional(),
       timestamp: z.coerce.number().int().optional(),
-      id: z.string().max(50).optional(),
+      id: z.string().optional(),
       browser: z.string().optional(),
       os: z.string().optional(),
       device: z.string().optional(),

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -48,7 +48,7 @@ const schema = z.object({
       ip: z.string().optional(),
       userAgent: z.string().optional(),
       timestamp: z.coerce.number().int().optional(),
-      id: z.string().optional(),
+      id: z.string().max(50).optional(),
       browser: z.string().optional(),
       os: z.string().optional(),
       device: z.string().optional(),
@@ -294,15 +294,14 @@ export async function POST(request: Request) {
       }
 
       // Create identity link when both visitorId and distinctId are present.
-      // Fire-and-forget to avoid adding latency to the tracking endpoint.
+      // Awaited (single indexed write) so the link is not dropped when a
+      // serverless instance freezes after the response is returned.
       if (visitorId && id && websiteId) {
-        createIdentityLink({
-          websiteId,
-          visitorId,
-          distinctId: id,
-        }).catch(e => {
+        try {
+          await createIdentityLink({ websiteId, visitorId, distinctId: id });
+        } catch (e) {
           console.error('Failed to create identity link:', e);
-        });
+        }
       }
     } else if (type === COLLECTION_TYPE.performance) {
       const base = hostname ? `https://${hostname}` : 'https://localhost';

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -11,7 +11,7 @@ import { parseRequest } from '@/lib/request';
 import { badRequest, forbidden, json, serverError } from '@/lib/response';
 import { anyObjectParam, urlOrPathParam } from '@/lib/schema';
 import { safeDecodeURI, safeDecodeURIComponent } from '@/lib/url';
-import { createSession, saveEvent, saveSessionData } from '@/queries/sql';
+import { createIdentityLink, createSession, saveEvent, saveSessionData } from '@/queries/sql';
 
 interface Cache {
   websiteId: string;
@@ -56,6 +56,7 @@ const schema = z.object({
       cls: z.number().nonnegative().max(100).optional(),
       fcp: z.number().nonnegative().max(60000).optional(),
       ttfb: z.number().nonnegative().max(60000).optional(),
+      vid: z.string().max(50).optional(),
     })
     .refine(
       data => {
@@ -100,6 +101,7 @@ export async function POST(request: Request) {
       cls,
       fcp,
       ttfb,
+      vid: visitorId,
     } = payload;
 
     const sourceId = websiteId || pixelId || linkId;
@@ -167,6 +169,7 @@ export async function POST(request: Request) {
         region,
         city,
         distinctId: id,
+        visitorId,
         createdAt,
       });
     }
@@ -247,6 +250,7 @@ export async function POST(request: Request) {
 
         // Session
         distinctId: id,
+        visitorId,
         browser,
         os,
         device,
@@ -284,6 +288,18 @@ export async function POST(request: Request) {
           sessionData: data,
           distinctId: id,
           createdAt,
+        });
+      }
+
+      // Create identity link when both visitorId and distinctId are present.
+      // Fire-and-forget to avoid adding latency to the tracking endpoint.
+      if (visitorId && id && websiteId) {
+        createIdentityLink({
+          websiteId,
+          visitorId,
+          distinctId: id,
+        }).catch(e => {
+          console.error('Failed to create identity link:', e);
         });
       }
     } else if (type === COLLECTION_TYPE.performance) {

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -5,6 +5,7 @@ import clickhouse from '@/lib/clickhouse';
 import { CACHE_TOKEN_TYPE, COLLECTION_TYPE, EVENT_TYPE } from '@/lib/constants';
 import { getSalt, hash, secret, uuid } from '@/lib/crypto';
 import { getClientInfo, hasBlockedIp } from '@/lib/detect';
+import { resolveVisitorId } from '@/lib/identity';
 import { createToken, parseToken } from '@/lib/jwt';
 import { fetchWebsite } from '@/lib/load';
 import { parseRequest } from '@/lib/request';
@@ -101,7 +102,6 @@ export async function POST(request: Request) {
       cls,
       fcp,
       ttfb,
-      vid: visitorId,
     } = payload;
 
     const sourceId = websiteId || pixelId || linkId;
@@ -153,7 +153,9 @@ export async function POST(request: Request) {
     const sessionSalt = getSalt(saltRotation, createdAt);
     const visitSalt = hash(startOfHour(createdAt).toUTCString());
 
-    const sessionId = id ? uuid(sourceId, id) : uuid(sourceId, ip, userAgent, sessionSalt);
+    const fingerprintId = uuid(sourceId, ip, userAgent, sessionSalt);
+    const sessionId = id ? uuid(sourceId, id) : fingerprintId;
+    const visitorId = resolveVisitorId({ clientVid: payload.vid, fingerprintId });
 
     // Create a session if not found
     if (!clickhouse.enabled && !cache?.sessionId) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -278,6 +278,7 @@ export const FIELD_LENGTH = {
   region: 20,
   city: 50,
   distinctId: 50,
+  visitorId: 50,
   url: 500,
   pageTitle: 500,
   eventName: 50,

--- a/src/lib/identity.test.ts
+++ b/src/lib/identity.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveVisitorId } from './identity';
+
+describe('resolveVisitorId', () => {
+  it('uses the server fingerprint id when no client vid is provided', () => {
+    expect(resolveVisitorId({ fingerprintId: 'fp-123' })).toBe('fp-123');
+  });
+
+  it('prefers an explicit client vid (opt-in) over the fingerprint', () => {
+    expect(resolveVisitorId({ clientVid: 'vid-abc', fingerprintId: 'fp-123' })).toBe('vid-abc');
+  });
+
+  it('falls back to the fingerprint when client vid is an empty string', () => {
+    expect(resolveVisitorId({ clientVid: '', fingerprintId: 'fp-123' })).toBe('fp-123');
+  });
+});

--- a/src/lib/identity.ts
+++ b/src/lib/identity.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolves the value stored as a session/event `visitor_id`.
+ *
+ * Default (banner-free): the server-derived anonymous fingerprint id, which the
+ * /api/send endpoint computes from the request (sourceId + ip + user-agent +
+ * rotating salt). Nothing is stored on the device.
+ *
+ * Opt-in (data-identity-stitching="true"): a persistent client id from
+ * localStorage, used to bridge anonymous activity across devices / salt windows.
+ * This requires consent and is never sent unless the site explicitly enables it.
+ */
+export function resolveVisitorId({
+  clientVid,
+  fingerprintId,
+}: {
+  clientVid?: string;
+  fingerprintId: string;
+}): string {
+  return clientVid || fingerprintId;
+}

--- a/src/queries/sql/events/saveEvent.ts
+++ b/src/queries/sql/events/saveEvent.ts
@@ -26,6 +26,7 @@ export interface SaveEventArgs {
 
   // Session
   distinctId?: string;
+  visitorId?: string;
   browser?: string;
   os?: string;
   device?: string;
@@ -182,6 +183,7 @@ async function clickhouseQuery({
   referrerQuery,
   referrerDomain,
   distinctId,
+  visitorId,
   browser,
   os,
   device,
@@ -245,6 +247,7 @@ async function clickhouseQuery({
     event_name: truncateString(eventName, FIELD_LENGTH.eventName) ?? null,
     tag: truncateString(tag, FIELD_LENGTH.tag),
     distinct_id: truncateString(distinctId, FIELD_LENGTH.distinctId),
+    visitor_id: truncateString(visitorId, FIELD_LENGTH.visitorId),
     created_at: getUTCString(createdAt),
     browser: truncateString(browser, FIELD_LENGTH.browser),
     os: truncateString(os, FIELD_LENGTH.os),

--- a/src/queries/sql/getWebsiteStats.test.ts
+++ b/src/queries/sql/getWebsiteStats.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const src = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), 'getWebsiteStats.ts'),
+  'utf8',
+);
+
+describe('getWebsiteStats visitor resolution', () => {
+  it('counts visitors by resolved identity, then visitor_id, then session_id', () => {
+    expect(src).toContain('coalesce(t.resolved_identity, t.visitor_id, t.session_id::text)');
+    expect(src).toContain('coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))');
+  });
+
+  it('does not double-join the session table (no duplicate join bug)', () => {
+    const relational = src.split('async function clickhouseQuery')[0];
+    const joins = relational.match(/left join session/g) ?? [];
+    expect(joins.length).toBe(1);
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: intentional literal string check
+    expect(relational).not.toContain('${joinSessionQuery}');
+  });
+
+  it('keeps the clickhouse table unaliased so fragment filters resolve', () => {
+    const clickhouse = src.split('async function clickhouseQuery')[1];
+    expect(clickhouse).not.toContain('website_event we');
+    expect(clickhouse).toContain('left join identity_link final il');
+  });
+});

--- a/src/queries/sql/getWebsiteStats.test.ts
+++ b/src/queries/sql/getWebsiteStats.test.ts
@@ -10,8 +10,12 @@ const src = readFileSync(
 
 describe('getWebsiteStats visitor resolution', () => {
   it('counts visitors by resolved identity, then visitor_id, then session_id', () => {
+    // PostgreSQL: LEFT JOIN yields real NULLs, plain coalesce is correct
     expect(src).toContain('coalesce(t.resolved_identity, t.visitor_id, t.session_id::text)');
-    expect(src).toContain('coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))');
+    // ClickHouse: LEFT JOIN fills unmatched String with '', so nullIf is required
+    expect(src).toContain(
+      "coalesce(nullIf(t.resolved_identity, ''), nullIf(t.visitor_id, ''), toString(t.session_id))",
+    );
   });
 
   it('does not double-join the session table (no duplicate join bug)', () => {
@@ -25,6 +29,15 @@ describe('getWebsiteStats visitor resolution', () => {
   it('keeps the clickhouse table unaliased so fragment filters resolve', () => {
     const clickhouse = src.split('async function clickhouseQuery')[1];
     expect(clickhouse).not.toContain('website_event we');
-    expect(clickhouse).toContain('left join identity_link final il');
+    expect(clickhouse).toContain('from identity_link final');
+  });
+
+  it('de-duplicates identity_link to one identity per visitor (prevents row fan-out)', () => {
+    const relational = src.split('async function clickhouseQuery')[0];
+    const clickhouse = src.split('async function clickhouseQuery')[1];
+    // PostgreSQL picks the earliest-linked distinct_id per visitor
+    expect(relational).toContain('distinct on (website_id, visitor_id)');
+    // ClickHouse picks the earliest-linked distinct_id per visitor
+    expect(clickhouse).toContain('argMin(distinct_id, linked_at)');
   });
 });

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -58,7 +58,11 @@ async function relationalQuery(
       ${excludeBounceQuery}
       left join session on session.session_id = website_event.session_id
         and session.website_id = website_event.website_id
-      left join identity_link il on il.visitor_id = session.visitor_id
+      left join (
+        select distinct on (website_id, visitor_id) website_id, visitor_id, distinct_id
+        from identity_link
+        order by website_id, visitor_id, linked_at asc, distinct_id asc
+      ) il on il.visitor_id = session.visitor_id
         and il.website_id = session.website_id
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
@@ -90,7 +94,7 @@ async function clickhouseQuery(
     sql = `
     select
       sum(t.c) as "pageviews",
-      uniq(coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))) as "visitors",
+      uniq(coalesce(nullIf(t.resolved_identity, ''), nullIf(t.visitor_id, ''), toString(t.session_id))) as "visitors",
       uniq(t.visit_id) as "visits",
       ${bounceQuery} as "bounces",
       sum(max_time-min_time) as "totaltime"
@@ -106,7 +110,11 @@ async function clickhouseQuery(
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      left join identity_link final il on il.visitor_id = website_event.visitor_id
+      left join (
+        select website_id, visitor_id, argMin(distinct_id, linked_at) as distinct_id
+        from identity_link final
+        group by website_id, visitor_id
+      ) il on il.visitor_id = website_event.visitor_id
         and il.website_id = website_event.website_id
       where website_event.website_id = {websiteId:UUID}
         and website_event.created_at between {startDate:DateTime64} and {endDate:DateTime64}
@@ -119,7 +127,7 @@ async function clickhouseQuery(
     sql = `
     select
       sum(t.c) as "pageviews",
-      uniq(coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))) as "visitors",
+      uniq(coalesce(nullIf(t.resolved_identity, ''), nullIf(t.visitor_id, ''), toString(t.session_id))) as "visitors",
       uniq(t.visit_id) as "visits",
       ${bounceQuery} as "bounces",
       sum(max_time-min_time) as "totaltime"
@@ -134,7 +142,11 @@ async function clickhouseQuery(
         from website_event_stats_hourly "website_event"
         ${cohortQuery}
         ${excludeBounceQuery}
-        left join identity_link final il on il.visitor_id = "website_event".visitor_id
+        left join (
+          select website_id, visitor_id, argMin(distinct_id, linked_at) as distinct_id
+          from identity_link final
+          group by website_id, visitor_id
+        ) il on il.visitor_id = "website_event".visitor_id
           and il.website_id = "website_event".website_id
     where "website_event".website_id = {websiteId:UUID}
       and "website_event".created_at between {startDate:DateTime64} and {endDate:DateTime64}

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -28,11 +28,10 @@ async function relationalQuery(
   filters: QueryFilters,
 ): Promise<WebsiteStatsData[]> {
   const { getTimestampDiffSQL, parseFilters, rawQuery } = prisma;
-  const { filterQuery, joinSessionQuery, cohortQuery, excludeBounceQuery, queryParams } =
-    parseFilters({
-      ...filters,
-      websiteId,
-    });
+  const { filterQuery, cohortQuery, excludeBounceQuery, queryParams } = parseFilters({
+    ...filters,
+    websiteId,
+  });
 
   const { excludeBounce } = filters;
   const bounceQuery = excludeBounce ? '0' : 'coalesce(sum(case when t.c = 1 then 1 else 0 end), 0)';
@@ -41,7 +40,7 @@ async function relationalQuery(
     `
     select
       cast(coalesce(sum(t.c), 0) as bigint) as "pageviews",
-      count(distinct t.session_id) as "visitors",
+      count(distinct coalesce(t.resolved_identity, t.visitor_id, t.session_id::text)) as "visitors",
       count(distinct t.visit_id) as "visits",
       ${bounceQuery} as "bounces",
       cast(coalesce(sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}), 0) as bigint) as "totaltime"
@@ -49,19 +48,23 @@ async function relationalQuery(
       select
         website_event.session_id,
         website_event.visit_id,
+        session.visitor_id,
+        il.distinct_id as "resolved_identity",
         count(*) as "c",
         min(website_event.created_at) as "min_time",
         max(website_event.created_at) as "max_time"
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      ${joinSessionQuery}  
+      left join session on session.session_id = website_event.session_id
+        and session.website_id = website_event.website_id
+      left join identity_link il on il.visitor_id = session.visitor_id
+        and il.website_id = session.website_id
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         and website_event.event_type NOT IN (2, 5)
         ${filterQuery}
-      group by 1, 2
-     
+      group by 1, 2, 3, 4
     ) as t
     `,
     queryParams,
@@ -87,49 +90,57 @@ async function clickhouseQuery(
     sql = `
     select
       sum(t.c) as "pageviews",
-      uniq(t.session_id) as "visitors",
+      uniq(coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))) as "visitors",
       uniq(t.visit_id) as "visits",
       ${bounceQuery} as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
-        session_id,
-        visit_id,
+        website_event.session_id,
+        website_event.visit_id,
+        website_event.visitor_id,
+        il.distinct_id as resolved_identity,
         count(*) c,
-        min(created_at) min_time,
-        max(created_at) max_time
+        min(website_event.created_at) min_time,
+        max(website_event.created_at) max_time
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      where website_id = {websiteId:UUID}
-        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-        and event_type NOT IN (2, 5)
+      left join identity_link final il on il.visitor_id = website_event.visitor_id
+        and il.website_id = website_event.website_id
+      where website_event.website_id = {websiteId:UUID}
+        and website_event.created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and website_event.event_type NOT IN (2, 5)
         ${filterQuery}
-      group by session_id, visit_id
+      group by website_event.session_id, website_event.visit_id, website_event.visitor_id, il.distinct_id
     ) as t;
     `;
   } else {
     sql = `
     select
       sum(t.c) as "pageviews",
-      uniq(session_id) as "visitors",
-      uniq(visit_id) as "visits",
+      uniq(coalesce(t.resolved_identity, t.visitor_id, toString(t.session_id))) as "visitors",
+      uniq(t.visit_id) as "visits",
       ${bounceQuery} as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (select
-            session_id,
-            visit_id,
-            sum(views) c,
-            min(min_time) min_time,
-            max(max_time) max_time
+            "website_event".session_id,
+            "website_event".visit_id,
+            "website_event".visitor_id,
+            il.distinct_id as resolved_identity,
+            sum("website_event".views) c,
+            min("website_event".min_time) min_time,
+            max("website_event".max_time) max_time
         from website_event_stats_hourly "website_event"
         ${cohortQuery}
         ${excludeBounceQuery}
-    where website_id = {websiteId:UUID}
-      and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-      and event_type NOT IN (2, 5)
+        left join identity_link final il on il.visitor_id = "website_event".visitor_id
+          and il.website_id = "website_event".website_id
+    where "website_event".website_id = {websiteId:UUID}
+      and "website_event".created_at between {startDate:DateTime64} and {endDate:DateTime64}
+      and "website_event".event_type NOT IN (2, 5)
       ${filterQuery}
-      group by session_id, visit_id
+      group by "website_event".session_id, "website_event".visit_id, "website_event".visitor_id, il.distinct_id
     ) as t;
     `;
   }

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -61,6 +61,7 @@ async function relationalQuery(
       left join (
         select distinct on (website_id, visitor_id) website_id, visitor_id, distinct_id
         from identity_link
+        where website_id = {{websiteId::uuid}}
         order by website_id, visitor_id, linked_at asc, distinct_id asc
       ) il on il.visitor_id = session.visitor_id
         and il.website_id = session.website_id
@@ -113,6 +114,7 @@ async function clickhouseQuery(
       left join (
         select website_id, visitor_id, argMin(distinct_id, linked_at) as distinct_id
         from identity_link final
+        where website_id = {websiteId:UUID}
         group by website_id, visitor_id
       ) il on il.visitor_id = website_event.visitor_id
         and il.website_id = website_event.website_id
@@ -145,6 +147,7 @@ async function clickhouseQuery(
         left join (
           select website_id, visitor_id, argMin(distinct_id, linked_at) as distinct_id
           from identity_link final
+          where website_id = {websiteId:UUID}
           group by website_id, visitor_id
         ) il on il.visitor_id = "website_event".visitor_id
           and il.website_id = "website_event".website_id

--- a/src/queries/sql/identity/createIdentityLink.ts
+++ b/src/queries/sql/identity/createIdentityLink.ts
@@ -1,0 +1,77 @@
+/**
+ * Identity Stitching - Links anonymous browser sessions to authenticated user identities
+ *
+ * Design decisions:
+ * - One visitor can link to multiple distinct_ids (user logs into different accounts)
+ * - One distinct_id can link to multiple visitors (user on multiple devices/browsers)
+ * - Links are additive and never invalidated (preserves historical journey)
+ * - Uses ReplacingMergeTree in ClickHouse with linked_at for deduplication
+ * - Upsert pattern ensures idempotency for repeated identify() calls
+ *
+ * Edge cases handled:
+ * - Safari private browsing: visitorId will be undefined, no link created
+ * - localStorage cleared: new visitorId generated, creates new link
+ * - Multiple tabs: same visitorId shared via localStorage
+ */
+
+import clickhouse from '@/lib/clickhouse';
+import { uuid } from '@/lib/crypto';
+import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import kafka from '@/lib/kafka';
+import prisma from '@/lib/prisma';
+
+export interface CreateIdentityLinkArgs {
+  websiteId: string;
+  visitorId: string;
+  distinctId: string;
+}
+
+export async function createIdentityLink(data: CreateIdentityLinkArgs) {
+  return runQuery({
+    [PRISMA]: () => relationalQuery(data),
+    [CLICKHOUSE]: () => clickhouseQuery(data),
+  });
+}
+
+async function relationalQuery({ websiteId, visitorId, distinctId }: CreateIdentityLinkArgs) {
+  const { client } = prisma;
+
+  return client.identityLink.upsert({
+    where: {
+      websiteId_visitorId_distinctId: {
+        websiteId,
+        visitorId,
+        distinctId,
+      },
+    },
+    update: {
+      linkedAt: new Date(),
+    },
+    create: {
+      id: uuid(),
+      websiteId,
+      visitorId,
+      distinctId,
+    },
+  });
+}
+
+async function clickhouseQuery({ websiteId, visitorId, distinctId }: CreateIdentityLinkArgs) {
+  const { insert, getUTCString } = clickhouse;
+  const { sendMessage } = kafka;
+
+  const now = getUTCString(new Date());
+  const message = {
+    website_id: websiteId,
+    visitor_id: visitorId,
+    distinct_id: distinctId,
+    created_at: now,
+    linked_at: now,
+  };
+
+  if (kafka.enabled) {
+    await sendMessage('identity_link', message);
+  } else {
+    await insert('identity_link', [message]);
+  }
+}

--- a/src/queries/sql/identity/createIdentityLink.ts
+++ b/src/queries/sql/identity/createIdentityLink.ts
@@ -15,8 +15,10 @@
  */
 
 import clickhouse from '@/lib/clickhouse';
+import { FIELD_LENGTH } from '@/lib/constants';
 import { uuid } from '@/lib/crypto';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import { truncateString } from '@/lib/format';
 import kafka from '@/lib/kafka';
 import prisma from '@/lib/prisma';
 
@@ -27,9 +29,18 @@ export interface CreateIdentityLinkArgs {
 }
 
 export async function createIdentityLink(data: CreateIdentityLinkArgs) {
+  // Truncate to the column width (VARCHAR(50)) so long ids are stitched
+  // consistently with how sessions/events store them, instead of failing the
+  // write. The send endpoint accepts ids of any length and never rejects them.
+  const normalized: CreateIdentityLinkArgs = {
+    websiteId: data.websiteId,
+    visitorId: truncateString(data.visitorId, FIELD_LENGTH.visitorId),
+    distinctId: truncateString(data.distinctId, FIELD_LENGTH.distinctId),
+  };
+
   return runQuery({
-    [PRISMA]: () => relationalQuery(data),
-    [CLICKHOUSE]: () => clickhouseQuery(data),
+    [PRISMA]: () => relationalQuery(normalized),
+    [CLICKHOUSE]: () => clickhouseQuery(normalized),
   });
 }
 

--- a/src/queries/sql/identity/getLinkedVisitorIds.ts
+++ b/src/queries/sql/identity/getLinkedVisitorIds.ts
@@ -1,0 +1,72 @@
+/**
+ * Resolves all visitor IDs linked to a given distinct_id (authenticated user)
+ *
+ * Use cases (for future implementation):
+ * - User journey reports: aggregate sessions across devices
+ * - Cohort analysis: include all linked sessions
+ * - Retroactive attribution: credit conversions to original anonymous session
+ *
+ * Note: Uses FINAL keyword in ClickHouse to ensure deduplication from ReplacingMergeTree
+ */
+
+import clickhouse from '@/lib/clickhouse';
+import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
+import prisma from '@/lib/prisma';
+
+export interface GetLinkedVisitorIdsArgs {
+  websiteId: string;
+  distinctId: string;
+}
+
+export interface LinkedVisitorId {
+  visitorId: string;
+  linkedAt: Date;
+}
+
+export async function getLinkedVisitorIds(
+  data: GetLinkedVisitorIdsArgs,
+): Promise<LinkedVisitorId[]> {
+  return runQuery({
+    [PRISMA]: () => relationalQuery(data),
+    [CLICKHOUSE]: () => clickhouseQuery(data),
+  });
+}
+
+async function relationalQuery({
+  websiteId,
+  distinctId,
+}: GetLinkedVisitorIdsArgs): Promise<LinkedVisitorId[]> {
+  const { client } = prisma;
+
+  const links = await client.identityLink.findMany({
+    where: {
+      websiteId,
+      distinctId,
+    },
+    select: {
+      visitorId: true,
+      linkedAt: true,
+    },
+  });
+
+  return links;
+}
+
+async function clickhouseQuery({
+  websiteId,
+  distinctId,
+}: GetLinkedVisitorIdsArgs): Promise<LinkedVisitorId[]> {
+  const { rawQuery } = clickhouse;
+
+  return rawQuery<LinkedVisitorId[]>(
+    `
+    select
+      visitor_id as visitorId,
+      linked_at as linkedAt
+    from identity_link final
+    where website_id = {websiteId:UUID}
+      and distinct_id = {distinctId:String}
+    `,
+    { websiteId, distinctId },
+  );
+}

--- a/src/queries/sql/identity/index.ts
+++ b/src/queries/sql/identity/index.ts
@@ -1,0 +1,2 @@
+export * from './createIdentityLink';
+export * from './getLinkedVisitorIds';

--- a/src/queries/sql/index.ts
+++ b/src/queries/sql/index.ts
@@ -29,6 +29,8 @@ export * from './getWeeklyTraffic';
 export * from './heatmap/extractHeatmapEvents';
 export * from './heatmap/getHeatmap';
 export * from './heatmap/saveHeatmapEvents';
+export * from './identity/createIdentityLink';
+export * from './identity/getLinkedVisitorIds';
 export * from './pageviews/getPageviewExpandedMetrics';
 export * from './pageviews/getPageviewMetrics';
 export * from './pageviews/getPageviewStats';

--- a/src/queries/sql/sessions/createSession.ts
+++ b/src/queries/sql/sessions/createSession.ts
@@ -34,6 +34,7 @@ export async function createSession(data: Prisma.SessionCreateInput) {
       region,
       city,
       distinct_id,
+      visitor_id,
       created_at
     )
     values (
@@ -48,6 +49,7 @@ export async function createSession(data: Prisma.SessionCreateInput) {
       {{region}},
       {{city}},
       {{distinctId}},
+      {{visitorId}},
       {{createdAt}}
     )
     on conflict (session_id) do nothing

--- a/src/queries/sql/sessions/createSession.ts
+++ b/src/queries/sql/sessions/createSession.ts
@@ -18,6 +18,7 @@ export async function createSession(data: Prisma.SessionCreateInput) {
     region: truncateString(data.region, FIELD_LENGTH.region),
     city: truncateString(data.city, FIELD_LENGTH.city),
     distinctId: truncateString(data.distinctId, FIELD_LENGTH.distinctId),
+    visitorId: truncateString(data.visitorId, FIELD_LENGTH.visitorId),
   };
 
   await rawQuery(

--- a/src/tracker/identity.test.ts
+++ b/src/tracker/identity.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, 'index.js'), 'utf8');
+
+describe('tracker identity stitching default', () => {
+  it('is opt-in: only enabled when data-identity-stitching === "true"', () => {
+    expect(src).toContain("config('identity-stitching') === _true");
+    expect(src).not.toContain("config('identity-stitching') !== _false");
+  });
+
+  it('does not read/write localStorage for a visitor id unless enabled', () => {
+    // getVisitorId must guard on identityStitching before touching localStorage
+    expect(src).toMatch(/getVisitorId[\s\S]*?if \(!identityStitching/);
+  });
+});

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -38,6 +38,7 @@
   const credentials = config('fetch-credentials') || 'omit';
   const perf = config('performance') === _true;
   const autoPageview = config('auto-pageview') !== _false;
+  const identityStitching = config('identity-stitching') !== _false;
 
   const domains = domain.split(',').map(n => n.trim());
   const host =
@@ -49,6 +50,39 @@
   const delayDuration = 300;
 
   /* Helper functions */
+
+  /**
+   * Identity Stitching: Generates a persistent visitor ID stored in localStorage.
+   * When combined with identify(), links anonymous sessions to authenticated users.
+   * Gracefully degrades when localStorage is unavailable (Safari private browsing).
+   */
+  const generateUUID = () =>
+    'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
+      const r = (Math.random() * 16) | 0;
+      return (c === 'x' ? r : (r & 0x3) | 0x8).toString(16);
+    });
+
+  const getVisitorId = () => {
+    if (!identityStitching || !localStorage) return undefined;
+
+    try {
+      const storageKey = 'umami.visitor';
+      let vid = localStorage.getItem(storageKey);
+
+      if (!vid) {
+        vid =
+          typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : generateUUID();
+        localStorage.setItem(storageKey, vid);
+      }
+
+      return vid;
+    } catch {
+      // localStorage access throws in Safari private browsing
+      return undefined;
+    }
+  };
+
+  const visitorId = getVisitorId();
 
   const normalize = raw => {
     if (!raw) return raw;
@@ -72,6 +106,7 @@
     referrer: currentRef,
     tag,
     id: identity ? identity : undefined,
+    vid: visitorId,
   });
 
   const hasDoNotTrack = () => {
@@ -152,12 +187,21 @@
 
   /* Tracking functions */
 
-  const trackingDisabled = () =>
-    disabled ||
-    !website ||
-    localStorage?.getItem('umami.disabled') ||
-    (domain && !domains.includes(hostname)) ||
-    (dnt && hasDoNotTrack());
+  const trackingDisabled = () => {
+    let storageDisabled = false;
+    try {
+      storageDisabled = localStorage?.getItem('umami.disabled');
+    } catch {
+      // localStorage throws in Safari private browsing
+    }
+    return (
+      disabled ||
+      !website ||
+      storageDisabled ||
+      (domain && !domains.includes(hostname)) ||
+      (dnt && hasDoNotTrack())
+    );
+  };
 
   const send = async (payload, type = 'event') => {
     if (trackingDisabled()) return;

--- a/src/tracker/index.js
+++ b/src/tracker/index.js
@@ -38,7 +38,7 @@
   const credentials = config('fetch-credentials') || 'omit';
   const perf = config('performance') === _true;
   const autoPageview = config('auto-pageview') !== _false;
-  const identityStitching = config('identity-stitching') !== _false;
+  const identityStitching = config('identity-stitching') === _true;
 
   const domains = domain.split(',').map(n => n.trim());
   const host =


### PR DESCRIPTION
## Summary

This links the anonymous activity to the logged-in user, so the Visitors count on
the overview is correct across the login. Before, when someone browses anonymously
and then calls `identify()`, they were counted two times. Now they count as one.
Resolves #3820.

This continues #3825 from @Lokimorty (I kept the original commit), rebased on the
current `dev` and finished it: migrations, the server-side default, the opt-in
client id, some correctness fixes and tests.

## How it works

Default is cookieless / no banner, nothing is stored in the browser:

- On `identify()`, `/api/send` recomputes the anonymous fingerprint session id
  (`uuid(sourceId, ip, userAgent, salt)` — it can get this from the request itself)
  and writes a row into `identity_link` (`visitor_id -> distinct_id`).
- `getWebsiteStats` resolves the identity by joining `identity_link` at query time.
  Event rows are never changed, so calling `identify()` later still attributes the
  old anonymous activity. Postgres and ClickHouse return the same result here
  (ClickHouse needs `nullIf` because a LEFT JOIN fills String columns with `''` and
  not NULL, and the link is pre-aggregated to one identity per visitor so it can not
  inflate pageviews/bounces).

There is also an opt-in persistent visitor id in `localStorage`
(`data-identity-stitching="true"`, default **off**) for the cross-device /
cross salt-window case. This one stores an id in the browser, so it needs consent,
and the `vid` comes from the client (so it is client-trusted).

## What changed

- **DB:** `IdentityLink` (Prisma + ClickHouse `ReplacingMergeTree`), `session.visitor_id`,
  `visitor_id` on ClickHouse `website_event` / `website_event_stats_hourly` (+ MV rebuild).
  Migrations: `prisma/migrations/21_add_identity_link` and
  `db/clickhouse/migrations/13_add_identity_link`.
- **Server (`/api/send`):** builds `visitor_id` from the request fingerprint by default
  (the opt-in client `vid` wins when it is present), and links it to `distinct_id` on
  `identify()` (awaited, not fire-and-forget).
- **Tracker:** `data-identity-stitching` (default off) controls the persistent
  `localStorage` id; no-op in Safari private mode.
- **Stats:** `getWebsiteStats` counts visitors by the resolved identity, same result on
  Postgres and ClickHouse, no row fan-out.

## Scope and limitations

- For now the identity is resolved only in `getWebsiteStats` (the overview Visitors stat).
  Funnels, sessions, breakdowns, channels and the other visitor queries are not resolved
  yet — I left them for a follow-up so this PR stays small to review.
- The banner-free default only works inside the same salt window (default 1 month) and the
  same device/network. For cross-device or older anonymous activity you need the opt-in
  `localStorage` id. If the link write fails, or the anonymous part crosses a salt window
  before `identify()`, those sessions fall back to counting per fingerprint.
- If one browser logs into several accounts, they collapse into one identity (the
  earliest linked one).
- **Kafka:** the link write sends to an `identity_link` topic. Like the other umami topics,
  the Kafka -> ClickHouse table/MV is set up outside this repo, so if you run the Kafka
  ingestion path you also need to add `identity_link` ingestion there. If not, the links
  are not stored and the stitching does nothing on that path.

## Test plan

- [x] Unit tests pass (`pnpm test`): the server-side resolution helper, the tracker opt-in
      default, and the query resolution + Postgres/ClickHouse parity / fan-out guards.
- [ ] Anonymous pageview → `identify('user1')` → overview shows one visitor across the login.
- [ ] `data-identity-stitching` not set → no `localStorage` write (cookieless default).
- [ ] ClickHouse: `identity_link` is filled, and the overview Visitors matches Postgres on a
      mixed linked / unlinked dataset.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4367"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785320242&installation_id=134563449&pr_number=4367&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4367&signature=2bd930daff58505943dee9b4a57554cec5e0d9fb5a63e0a89df0e1ba2f092198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->