### PR TITLE
fix: dismiss session modals when clicking the side margins

### DIFF
--- a/src/app/(main)/websites/[websiteId]/sessions/SessionModal.module.css
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionModal.module.css
@@ -1,0 +1,3 @@
+.modal {
+  width: min(calc(100dvw - 48px), 1320px);
+}

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionModal.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionModal.tsx
@@ -2,6 +2,7 @@
 import { Column, Dialog, Modal, type ModalProps } from '@umami/react-zen';
 import { SessionProfile } from '@/app/(main)/websites/[websiteId]/sessions/SessionProfile';
 import { useNavigation } from '@/components/hooks';
+import styles from './SessionModal.module.css';
 
 export interface SessionModalProps extends ModalProps {
   websiteId: string;
@@ -25,12 +26,13 @@ export function SessionModal({ websiteId, ...props }: SessionModalProps) {
     <Modal
       placement="bottom"
       offset="80px"
+      className={styles.modal}
       isOpen={!!session}
       onOpenChange={handleOpenChange}
       isDismissable
       {...props}
     >
-      <Column height="100%" maxWidth="1320px" style={{ margin: '0 auto' }}>
+      <Column height="100%">
         <Dialog variant="sheet" className="rounded-lg">
           {({ close }) => (
             <Column padding="10">

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionModal.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionModal.tsx
@@ -8,7 +8,7 @@ export interface SessionModalProps extends ModalProps {
   websiteId: string;
 }
 
-export function SessionModal({ websiteId, ...props }: SessionModalProps) {
+export function SessionModal({ websiteId, className, ...props }: SessionModalProps) {
   const {
     router,
     pathname,
@@ -26,7 +26,7 @@ export function SessionModal({ websiteId, ...props }: SessionModalProps) {
     <Modal
       placement="bottom"
       offset="80px"
-      className={styles.modal}
+      className={[styles.modal, className].filter(Boolean).join(' ')}
       isOpen={!!session}
       onOpenChange={handleOpenChange}
       isDismissable

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionProfileModal.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionProfileModal.tsx
@@ -3,6 +3,7 @@ import { Column, Dialog, Modal } from '@umami/react-zen';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { buildPath } from '@/lib/url';
 import { SessionProfile } from './SessionProfile';
+import styles from './SessionModal.module.css';
 
 export function SessionProfileModal({
   websiteId,
@@ -28,8 +29,15 @@ export function SessionProfileModal({
   };
 
   return (
-    <Modal placement="bottom" offset="80px" isOpen onOpenChange={handleOpenChange} isDismissable>
-      <Column height="100%" maxWidth="1320px" style={{ margin: '0 auto' }}>
+    <Modal
+      placement="bottom"
+      offset="80px"
+      className={styles.modal}
+      isOpen
+      onOpenChange={handleOpenChange}
+      isDismissable
+    >
+      <Column height="100%">
         <Dialog variant="sheet" className="rounded-lg">
           <Column padding="10">
             <SessionProfile websiteId={websiteId} sessionId={sessionId} onClose={closeModal} />

--- a/tests/e2e/session-modal-dismiss.spec.ts
+++ b/tests/e2e/session-modal-dismiss.spec.ts
@@ -1,0 +1,72 @@
+import { type APIRequestContext, expect, test } from '@playwright/test';
+import { uuid } from '../../src/lib/crypto';
+import { type Auth, authHeaders, deleteWebsite, loginPage, umamiUser } from './helpers';
+
+// The session modal is a bottom sheet capped at 1320px and centered, so on a
+// wide viewport there are dark side margins. Clicking those margins must
+// dismiss the modal (regression test for the full-width click-catcher bug).
+test.use({ viewport: { width: 1600, height: 900 } });
+
+async function createWebsite(request: APIRequestContext, auth: Auth, websiteId: string) {
+  const response = await request.post('/api/websites', {
+    headers: authHeaders(auth),
+    data: {
+      id: websiteId,
+      createdBy: umamiUser.id,
+      name: 'Modal dismiss test',
+      domain: 'modal-dismiss-test.com',
+    },
+  });
+  expect(response.status()).toBe(200);
+}
+
+test.describe('SessionModal outside-click dismissal', () => {
+  let auth: Auth;
+  const websiteId = uuid();
+
+  test.beforeEach(async ({ page, request }) => {
+    auth = await loginPage(page, request);
+    await createWebsite(request, auth, websiteId);
+    // The modal opens purely from the `session` query param, so a random id is
+    // enough to render it — no seeded session data required.
+    await page.goto(`/websites/${websiteId}/sessions?session=${uuid()}`);
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+
+  test.afterEach(async ({ request }) => {
+    await deleteWebsite(request, auth, websiteId);
+  });
+
+  test('clicking in the left side margin dismisses the modal', async ({ page }) => {
+    const box = await page.getByRole('dialog').boundingBox();
+    const marginX = 20;
+    const midY = box.y + box.height / 2;
+    expect(marginX).toBeLessThan(box.x); // genuinely outside the sheet
+
+    await page.mouse.click(marginX, midY);
+
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page).not.toHaveURL(/session=/);
+  });
+
+  test('clicking in the right side margin dismisses the modal', async ({ page }) => {
+    const box = await page.getByRole('dialog').boundingBox();
+    const marginX = page.viewportSize().width - 20;
+    const midY = box.y + box.height / 2;
+    expect(marginX).toBeGreaterThan(box.x + box.width); // genuinely outside the sheet
+
+    await page.mouse.click(marginX, midY);
+
+    await expect(page.getByRole('dialog')).toBeHidden();
+    await expect(page).not.toHaveURL(/session=/);
+  });
+
+  test('control: clicking inside the sheet keeps the modal open', async ({ page }) => {
+    const box = await page.getByRole('dialog').boundingBox();
+
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await expect(page).toHaveURL(/session=/);
+  });
+});

--- a/tests/e2e/session-modal-dismiss.spec.ts
+++ b/tests/e2e/session-modal-dismiss.spec.ts
@@ -1,11 +1,13 @@
-import { type APIRequestContext, expect, test } from '@playwright/test';
+import { type APIRequestContext, expect, type Page, test } from '@playwright/test';
 import { uuid } from '../../src/lib/crypto';
 import { type Auth, authHeaders, deleteWebsite, loginPage, umamiUser } from './helpers';
 
 // The session modal is a bottom sheet capped at 1320px and centered, so on a
 // wide viewport there are dark side margins. Clicking those margins must
 // dismiss the modal (regression test for the full-width click-catcher bug).
-test.use({ viewport: { width: 1600, height: 900 } });
+const VIEWPORT = { width: 1600, height: 900 };
+
+test.use({ viewport: VIEWPORT });
 
 async function createWebsite(request: APIRequestContext, auth: Auth, websiteId: string) {
   const response = await request.post('/api/websites', {
@@ -18,6 +20,13 @@ async function createWebsite(request: APIRequestContext, auth: Auth, websiteId: 
     },
   });
   expect(response.status()).toBe(200);
+}
+
+async function getSheetBox(page: Page) {
+  const box = await page.getByRole('dialog').boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) throw new Error('dialog has no bounding box');
+  return box;
 }
 
 test.describe('SessionModal outside-click dismissal', () => {
@@ -38,7 +47,7 @@ test.describe('SessionModal outside-click dismissal', () => {
   });
 
   test('clicking in the left side margin dismisses the modal', async ({ page }) => {
-    const box = await page.getByRole('dialog').boundingBox();
+    const box = await getSheetBox(page);
     const marginX = 20;
     const midY = box.y + box.height / 2;
     expect(marginX).toBeLessThan(box.x); // genuinely outside the sheet
@@ -50,8 +59,8 @@ test.describe('SessionModal outside-click dismissal', () => {
   });
 
   test('clicking in the right side margin dismisses the modal', async ({ page }) => {
-    const box = await page.getByRole('dialog').boundingBox();
-    const marginX = page.viewportSize().width - 20;
+    const box = await getSheetBox(page);
+    const marginX = VIEWPORT.width - 20;
     const midY = box.y + box.height / 2;
     expect(marginX).toBeGreaterThan(box.x + box.width); // genuinely outside the sheet
 
@@ -62,7 +71,7 @@ test.describe('SessionModal outside-click dismissal', () => {
   });
 
   test('control: clicking inside the sheet keeps the modal open', async ({ page }) => {
-    const box = await page.getByRole('dialog').boundingBox();
+    const box = await getSheetBox(page);
 
     await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
 


### PR DESCRIPTION
## Problem

The session detail modal (`SessionModal`) and session profile modal (`SessionProfileModal`) can only be dismissed by clicking the thin area *above* the sheet — clicking the dark space to the **left or right** of the sheet does nothing.

## Cause

Both modals apply their `1320px` max width to an **inner `<Column>`** rather than to the `<Modal>` itself:

```tsx
<Modal placement="bottom" offset="80px" isDismissable>
  <Column height="100%" maxWidth="1320px" style={{ margin: '0 auto' }}>
    ...
```

react-zen's `Modal` with `placement="bottom"` renders the react-aria modal box as `absolute inset-x-0 bottom-0 h-[calc(100dvh-offset)]` — i.e. **full viewport width**. react-aria only dismisses on interaction *outside* that box, but the box's transparent side margins sit on top of the underlay and swallow the click. Only the `offset` strip above the sheet is real underlay, so only clicks there dismiss.

`ReplayModal` (same `placement="bottom"`) is unaffected because it correctly sets the width on the Modal box itself (via a CSS module), so its box is the centered ~1320px sheet.

## Fix

Move the width from the inner `Column` onto the `Modal` box via a CSS module, matching the existing `ReplayModal` pattern. The click-catcher box is now the centered sheet, so the side margins become real overlay and dismiss on click.

## Testing

Adds an e2e regression test (`tests/e2e/session-modal-dismiss.spec.ts`) that opens the modal on a wide viewport and asserts left- and right-margin clicks dismiss it, with an in-sheet control click that must keep it open. Verified the test fails on `dev` without this change and passes with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785664070&installation_id=134563449&pr_number=4374&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4374&signature=946d65127dd5f72083fe27043b0247d04b5e6bd9b003ea790d77b9cb7a4062d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->