### PR TITLE
verify Kafka broker TLS certificate by default

### DIFF
--- a/src/lib/kafka.ts
+++ b/src/lib/kafka.ts
@@ -47,7 +47,7 @@ function getClient() {
     username && password
       ? {
           ssl: {
-            rejectUnauthorized: false,
+            rejectUnauthorized: process.env.KAFKA_SSL_ALLOW_UNAUTHORIZED !== 'true',
           },
           sasl: {
             mechanism,


### PR DESCRIPTION
## Summary

In `src/lib/kafka.ts`, `getClient()` sets `ssl: { rejectUnauthorized: false }`
whenever SASL `username`/`password` are present — so the SASL password is sent
over a TLS connection whose broker certificate is never validated. A network
attacker between umami and the Kafka broker can present any certificate,
terminate the TLS, and capture the credentials (and read/inject analytics
events). The insecure setting is coupled to exactly the case where credentials
are on the wire, and there is currently no way to enable verification.

## Change

Verify the broker certificate by default, with an opt-out env var for
self-signed brokers that matches the existing `KAFKA_*` configuration:

```
rejectUnauthorized: process.env.KAFKA_SSL_ALLOW_UNAUTHORIZED !== 'true'
```

## Compatibility

Managed Kafka providers commonly used with SASL (Confluent, AWS MSK, Aiven,
Upstash) present valid certificates, so verification is transparent for them.
Deployments pointing at a self-signed broker can set
`KAFKA_SSL_ALLOW_UNAUTHORIZED=true` to restore the previous behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4377"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785757561&installation_id=134563449&pr_number=4377&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4377&signature=6f662626f5fbfafbee02e19d5ae3232db2f463b838d01563cf8ebe088bea426f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->