### PR TITLE
Add per-website IP blocklist to exclude IPs from statistics

### DIFF
--- a/prisma/migrations/21_add_blocked_ips/migration.sql
+++ b/prisma/migrations/21_add_blocked_ips/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "website" ADD COLUMN "blocked_ips" VARCHAR(500);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ model Website {
 
   recorderEnabled Boolean @default(false) @map("recorder_enabled")
   replayConfig    Json?   @map("replay_config")
+  blockedIps      String? @map("blocked_ips")
 
   user                User?               @relation("user", fields: [userId], references: [id])
   createUser          User?               @relation("createUser", fields: [createdBy], references: [id])

--- a/public/intl/messages/en-GB.json
+++ b/public/intl/messages/en-GB.json
@@ -30,6 +30,7 @@
     "before": "Before",
     "behavior": "Behaviour",
     "block-selector": "Block selector",
+    "blocked-ips": "Blocked IPs",
     "boards": "Boards",
     "board-type": "Board type",
     "bounce-rate": "Bounce rate",
@@ -434,6 +435,7 @@
     "replay-min-duration-description": "Only show replays at or above this duration.",
     "viewed-page": "Viewed page",
     "upgrade-required": "This feature requires a {plan} plan subscription.",
+    "blocked-ips-description": "Enter IP addresses (comma separated, supports CIDR notation) to exclude from statistics.",
     "visitor-log": "Visitor from <b>{country}</b> using <b>{browser}</b> on <b>{os}</b> <b>{device}</b>"
   }
 }

--- a/public/intl/messages/en-US.json
+++ b/public/intl/messages/en-US.json
@@ -30,6 +30,7 @@
     "before": "Before",
     "behavior": "Behavior",
     "block-selector": "Block selector",
+    "blocked-ips": "Blocked IPs",
     "boards": "Boards",
     "board-type": "Board type",
     "bounce-rate": "Bounce rate",
@@ -443,6 +444,7 @@
     "replay-min-duration-description": "Only show replays at or above this duration.",
     "viewed-page": "Viewed page",
     "upgrade-required": "This feature requires a {plan} plan subscription.",
+    "blocked-ips-description": "Enter IP addresses (comma separated, supports CIDR notation) to exclude from statistics.",
     "visitor-log": "Visitor from <b>{country}</b> using <b>{browser}</b> on <b>{os}</b> <b>{device}</b>"
   }
 }

--- a/src/app/(main)/websites/[websiteId]/settings/WebsiteBlocklist.tsx
+++ b/src/app/(main)/websites/[websiteId]/settings/WebsiteBlocklist.tsx
@@ -30,6 +30,7 @@ export function WebsiteBlocklist({ websiteId }: { websiteId: string }) {
         onChange={setBlockedIps}
         asTextArea
         resize="none"
+        maxLength={500}
         style={{ maxWidth: '500px' }}
       />
       <Row>

--- a/src/app/(main)/websites/[websiteId]/settings/WebsiteBlocklist.tsx
+++ b/src/app/(main)/websites/[websiteId]/settings/WebsiteBlocklist.tsx
@@ -1,0 +1,42 @@
+import { Button, Column, Label, Row, Text, TextField } from '@umami/react-zen';
+import { useState } from 'react';
+import { useMessages, useUpdateQuery, useWebsite } from '@/components/hooks';
+
+export function WebsiteBlocklist({ websiteId }: { websiteId: string }) {
+  const website = useWebsite();
+  const { t, labels, messages } = useMessages();
+  const { mutateAsync, touch, toast, isPending } = useUpdateQuery(`/websites/${websiteId}`);
+  const [blockedIps, setBlockedIps] = useState(website?.blockedIps || '');
+
+  const handleSave = async () => {
+    await mutateAsync(
+      { blockedIps: blockedIps || null },
+      {
+        onSuccess: async () => {
+          toast(t(messages.saved));
+          touch('websites');
+          touch(`website:${websiteId}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Column gap="4">
+      <Label>{t(labels.blockedIps)}</Label>
+      <Text color="muted">{t(messages.blockedIpsDescription)}</Text>
+      <TextField
+        value={blockedIps}
+        onChange={setBlockedIps}
+        asTextArea
+        resize="none"
+        style={{ maxWidth: '500px' }}
+      />
+      <Row>
+        <Button variant="primary" onPress={handleSave} isDisabled={isPending}>
+          {t(labels.save)}
+        </Button>
+      </Row>
+    </Column>
+  );
+}

--- a/src/app/(main)/websites/[websiteId]/settings/WebsiteSettings.tsx
+++ b/src/app/(main)/websites/[websiteId]/settings/WebsiteSettings.tsx
@@ -1,5 +1,6 @@
 import { Column } from '@umami/react-zen';
 import { Panel } from '@/components/common/Panel';
+import { WebsiteBlocklist } from './WebsiteBlocklist';
 import { WebsiteData } from './WebsiteData';
 import { WebsiteEditForm } from './WebsiteEditForm';
 import { WebsiteReplaySettings } from './WebsiteReplaySettings';
@@ -17,6 +18,9 @@ export function WebsiteSettings({ websiteId }: { websiteId: string; openExternal
       </Panel>
       <Panel>
         <WebsiteReplaySettings websiteId={websiteId} />
+      </Panel>
+      <Panel>
+        <WebsiteBlocklist websiteId={websiteId} />
       </Panel>
       <Panel>
         <WebsiteShareForm websiteId={websiteId} />

--- a/src/app/api/record/route.ts
+++ b/src/app/api/record/route.ts
@@ -175,6 +175,10 @@ export async function POST(request: Request) {
       return forbidden();
     }
 
+    if (website?.blockedIps && hasBlockedIp(ip, website.blockedIps)) {
+      return json({ beep: 'boop' });
+    }
+
     if (body.type === 'record') {
       if (!replayEnabled) {
         return json({ ok: false, reason: 'replay_disabled' });

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -119,11 +119,13 @@ export async function POST(request: Request) {
         }
       }
 
-      // Find website
-      website = await fetchWebsite(websiteId);
+      // Find website (only on first request to reduce overhead on hot path)
+      if (!cache?.websiteId) {
+        website = await fetchWebsite(websiteId);
 
-      if (!website) {
-        return badRequest({ message: 'Website not found.' });
+        if (!website) {
+          return badRequest({ message: 'Website not found.' });
+        }
       }
     }
 

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -106,6 +106,7 @@ export async function POST(request: Request) {
 
     // Cache check
     let cache: Cache | null = null;
+    let website = null;
 
     if (websiteId) {
       const cacheHeader = request.headers.get('x-umami-cache');
@@ -119,12 +120,10 @@ export async function POST(request: Request) {
       }
 
       // Find website
-      if (!cache?.websiteId) {
-        const website = await fetchWebsite(websiteId);
+      website = await fetchWebsite(websiteId);
 
-        if (!website) {
-          return badRequest({ message: 'Website not found.' });
-        }
+      if (!website) {
+        return badRequest({ message: 'Website not found.' });
       }
     }
 
@@ -142,6 +141,11 @@ export async function POST(request: Request) {
     // IP block
     if (hasBlockedIp(ip)) {
       return forbidden();
+    }
+
+    // Per-website IP block
+    if (website?.blockedIps && hasBlockedIp(ip, website.blockedIps)) {
+      return json({ beep: 'boop' });
     }
 
     const createdAt = timestamp ? new Date(timestamp * 1000) : new Date();

--- a/src/app/api/websites/[websiteId]/route.ts
+++ b/src/app/api/websites/[websiteId]/route.ts
@@ -91,7 +91,7 @@ export async function POST(
     const website = await updateWebsite(websiteId, {
       name,
       domain,
-      blockedIps: blockedIps ?? undefined,
+      blockedIps: blockedIps !== undefined ? blockedIps : undefined,
       ...(replayConfig !== undefined && {
         replayConfig: nextReplayConfig as Prisma.InputJsonObject,
         recorderEnabled: getRecorderEnabled(nextReplayConfig),

--- a/src/app/api/websites/[websiteId]/route.ts
+++ b/src/app/api/websites/[websiteId]/route.ts
@@ -43,6 +43,7 @@ export async function POST(
   const schema = z.object({
     name: z.string().max(100).optional(),
     domain: z.string().max(500).optional(),
+    blockedIps: z.string().max(500).nullable().optional(),
     shareId: z.string().max(50).nullable().optional(),
     replayConfig: z
       .object({
@@ -65,7 +66,7 @@ export async function POST(
   }
 
   const { websiteId } = await params;
-  const { name, domain, shareId, replayConfig } = body;
+  const { name, domain, blockedIps, shareId, replayConfig } = body;
 
   if (!(await canUpdateWebsite(auth, websiteId))) {
     return unauthorized();
@@ -90,6 +91,7 @@ export async function POST(
     const website = await updateWebsite(websiteId, {
       name,
       domain,
+      blockedIps: blockedIps ?? undefined,
       ...(replayConfig !== undefined && {
         replayConfig: nextReplayConfig as Prisma.InputJsonObject,
         recorderEnabled: getRecorderEnabled(nextReplayConfig),

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -384,6 +384,7 @@ export const labels: Record<string, string> = {
   replayId: 'label.replay-id',
   replayEnabled: 'label.replay-enabled',
   recorderCode: 'label.recorder-code',
+  blockedIps: 'label.blocked-ips',
   sampleRate: 'label.sample-rate',
   minDurationSeconds: 'label.min-duration-seconds',
   maskLevel: 'label.mask-level',
@@ -444,4 +445,5 @@ export const messages: Record<string, string> = {
   serverError: 'message.sever-error',
   upgradeRequired: 'message.upgrade-required',
   replayMinDurationDescription: 'message.replay-min-duration-description',
+  blockedIpsDescription: 'message.blocked-ips-description',
 };

--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -103,5 +103,9 @@ test('hasBlockedIp: handles mixed separators in extraIps', () => {
 test('hasBlockedIp: combines IGNORE_IP and extraIps correctly', () => {
   process.env.IGNORE_IP = '10.0.0.0/8';
 
-  expect(hasBlockedIp('10.0.0.5', '192.168.1.0/24')).toBe(true);
+  try {
+    expect(hasBlockedIp('10.0.0.5', '192.168.1.0/24')).toBe(true);
+  } finally {
+    delete process.env.IGNORE_IP;
+  }
 });

--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -75,3 +75,33 @@ test('hasBlockedIp: returns false for malformed client ip with cidr block', () =
 
   expect(hasBlockedIp('not-an-ip')).toBe(false);
 });
+
+test('hasBlockedIp: matches exact ip with extraIps', () => {
+  expect(hasBlockedIp('192.168.1.1', '192.168.1.1')).toBe(true);
+});
+
+test('hasBlockedIp: matches cidr with extraIps', () => {
+  expect(hasBlockedIp('10.0.0.5', '10.0.0.0/8')).toBe(true);
+});
+
+test('hasBlockedIp: does not match when ip not in extraIps', () => {
+  expect(hasBlockedIp('192.168.1.1', '10.0.0.0/8')).toBe(false);
+});
+
+test('hasBlockedIp: returns false when extraIps is empty string', () => {
+  expect(hasBlockedIp('192.168.1.1', '')).toBe(false);
+});
+
+test('hasBlockedIp: handles newlines as separator in extraIps', () => {
+  expect(hasBlockedIp('10.0.0.1', '192.168.1.1\n10.0.0.1')).toBe(true);
+});
+
+test('hasBlockedIp: handles mixed separators in extraIps', () => {
+  expect(hasBlockedIp('10.0.0.1', '192.168.1.1,\n10.0.0.1')).toBe(true);
+});
+
+test('hasBlockedIp: combines IGNORE_IP and extraIps correctly', () => {
+  process.env.IGNORE_IP = '10.0.0.0/8';
+
+  expect(hasBlockedIp('10.0.0.5', '192.168.1.0/24')).toBe(true);
+});

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -147,14 +147,16 @@ export async function getClientInfo(request: Request, payload: Record<string, an
   return { userAgent, browser, os, ip, country, region, city, device };
 }
 
-export function hasBlockedIp(clientIp: string) {
+export function hasBlockedIp(clientIp: string, extraIps?: string) {
   const ignoreIps = process.env.IGNORE_IP;
 
-  if (!clientIp || !ignoreIps) {
+  const allIps = [ignoreIps, extraIps].filter(Boolean).join(',');
+
+  if (!clientIp || !allIps) {
     return false;
   }
 
-  const ips = ignoreIps.split(',').map(n => n.trim());
+  const ips = allIps.split(/[\s,]+/).filter(Boolean);
 
   return ips.some(ip => {
     if (ip === clientIp) {


### PR DESCRIPTION
## Summary

Adds the ability to configure IP addresses (with CIDR support) to exclude from statistics on a per-website basis. This is useful for developers who want to exclude their own traffic from analytics without relying on the global `IGNORE_IP` environment variable.

## Changes

### Database
- Added `blocked_ips VARCHAR(500)` column to the `website` table (via migration `prisma/migrations/21_add_blocked_ips/`)
- Updated Prisma schema with the new `blockedIps` field on the `Website` model

### Backend
- Extended `hasBlockedIp()` in `src/lib/detect.ts` to accept an optional `extraIps` parameter, merging it with the global `IGNORE_IP` env var
- Improved IP list parsing to support both comma and newline/whitespace separators
- Added per-website IP blocking check in `POST /api/send` (main tracking endpoint) and `POST /api/record` (session replay/heatmap recording)
- Blocked IPs silently drop the event (returns `{ beep: "boop" }`) — same pattern as the bot check, so blocked visitors are not aware

### API
- Added `blockedIps` field to the website update schema (`POST /api/websites/[id]`)

### Frontend
- Added **WebsiteBlocklist** component in website settings with a textarea for entering comma/newline-separated IPs and CIDR ranges
- Integrated into the settings page alongside existing panels

### i18n
- Added `blocked-ips` label and `blocked-ips-description` message in `en-US` and `en-GB` locales

### Tests
- Added 7 test cases for `hasBlockedIp()` covering:
  - Exact IP match with `extraIps`
  - CIDR range match with `extraIps`
  - Non-matching IP
  - Empty string handling
  - Newlines as separators
  - Mixed separators
  - Combined global `IGNORE_IP` + `extraIps`

## Usage

1. Go to **Settings** for a website
2. Find the **Blocked IPs** panel
3. Enter IPs (comma or newline separated, supports CIDR like `192.168.1.0/24`)
4. Click Save

Visitors whose IP matches any entry will be silently excluded from analytics for that website.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785853556&installation_id=134563449&pr_number=4378&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4378&signature=7c1d3c10954fa1354650fba282c8f6975a150b8d065baab115b6ea8d97a0a410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->