### PR TITLE
Update URL validation logic in LinkEditForm

### DIFF
--- a/src/app/(main)/links/LinkEditForm.tsx
+++ b/src/app/(main)/links/LinkEditForm.tsx
@@ -60,7 +60,7 @@ export function LinkEditForm({
   };
 
   const checkUrl = (url: string) => {
-    if (!isValidUrl(url)) {
+    if (!isValidUrl(url) || (url === `${hostUrl}/${slug}`))) {
       return t(labels.invalidUrl);
     }
     return true;

--- a/src/app/(main)/links/LinkEditForm.tsx
+++ b/src/app/(main)/links/LinkEditForm.tsx
@@ -60,7 +60,7 @@ export function LinkEditForm({
   };
 
   const checkUrl = (url: string) => {
-    if (!isValidUrl(url) || (url === `${hostUrl}/${slug}`))) {
+    if (!isValidUrl(url) || (url === `${hostUrl}/${defaultSlug}`)) {
       return t(labels.invalidUrl);
     }
     return true;

--- a/src/app/(main)/links/LinkEditForm.tsx
+++ b/src/app/(main)/links/LinkEditForm.tsx
@@ -59,8 +59,8 @@ export function LinkEditForm({
     });
   };
 
-  const checkUrl = (url: string) => {
-    if (!isValidUrl(url) || (url === `${hostUrl}/${defaultSlug}`)) {
+  const checkUrl = (url: string, formValues: any) => {
+    if (!isValidUrl(url) || (url === `${hostUrl}/${formValues.slug}`)) {
       return t(labels.invalidUrl);
     }
     return true;


### PR DESCRIPTION
This is a fairly superficial fix. It prevents using the same forwarding URL as the primary link, but realistically it’s an unlikely scenario since no one would normally set identical values for both.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786736514&installation_id=134563449&pr_number=4389&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4389&signature=da1dfe70aaad05a00ddaa0da3db188da74052397e8a347ff47de4bc33036ce82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->