### PR TITLE
Fix client IP resolution when CLIENT_IP_HEADER is set to x-forwarded-for

### DIFF
--- a/src/lib/detect.test.ts
+++ b/src/lib/detect.test.ts
@@ -24,6 +24,14 @@ test('getIpAddress: Custom header', () => {
   expect(getIpAddress(new Headers({ 'x-custom-ip-header': IP }))).toEqual(IP);
 });
 
+test('getIpAddress: Custom header set to x-forwarded-for uses leftmost IP in chain', () => {
+  process.env.CLIENT_IP_HEADER = 'x-forwarded-for';
+
+  expect(
+    getIpAddress(new Headers({ 'x-forwarded-for': `${IP}, 10.0.0.1, 10.0.0.2` })),
+  ).toEqual(IP);
+});
+
 test('getIpAddress: CloudFlare header', () => {
   expect(getIpAddress(new Headers({ 'cf-connecting-ip': IP }))).toEqual(IP);
 });

--- a/src/lib/ip.ts
+++ b/src/lib/ip.ts
@@ -58,11 +58,25 @@ function resolveIp(ip?: string | null) {
   }
 }
 
+function parseHeaderValue(header: string, value: string) {
+  if (header === 'x-forwarded-for') {
+    return resolveIp(value?.split(',')?.[0]?.trim());
+  }
+
+  if (header === 'forwarded') {
+    const match = value.match(/for=(\[?[0-9a-fA-F:.]+]?)/);
+
+    return match ? resolveIp(match[1]) : undefined;
+  }
+
+  return resolveIp(value);
+}
+
 export function getIpAddress(headers: Headers) {
   const customHeader = process.env.CLIENT_IP_HEADER;
 
   if (customHeader && headers.get(customHeader)) {
-    return resolveIp(headers.get(customHeader));
+    return parseHeaderValue(customHeader.toLowerCase(), headers.get(customHeader));
   }
 
   const header = IP_ADDRESS_HEADERS.find(name => headers.get(name));
@@ -70,19 +84,7 @@ export function getIpAddress(headers: Headers) {
     return undefined;
   }
 
-  const ip = headers.get(header);
-
-  if (header === 'x-forwarded-for') {
-    return resolveIp(ip?.split(',')?.[0]?.trim());
-  }
-
-  if (header === 'forwarded') {
-    const match = ip.match(/for=(\[?[0-9a-fA-F:.]+]?)/);
-
-    return match ? resolveIp(match[1]) : undefined;
-  }
-
-  return resolveIp(ip);
+  return parseHeaderValue(header, headers.get(header));
 }
 
 export function stripPort(ip?: string | null) {


### PR DESCRIPTION
When CLIENT_IP_HEADER is set explicitly, for example to x-forwarded-for or forwarded, getIpAddress() skipped the header specific parsing and just passed the raw header value straight to resolveIp(). For x-forwarded-for that value can be a comma separated chain of IPs added by every hop in the proxy path. So instead of picking the original client IP, which is the leftmost entry, the whole raw string got used and that usually resolves to the wrong address.

This only affected the custom header path. The default detection using the built in header list already handled the comma separated chain correctly.

Moved the x-forwarded-for and forwarded parsing into a shared helper and reused it for both the custom header and the default header list, so behavior is consistent now. Added a test covering CLIENT_IP_HEADER=x-forwarded-for with multiple IPs in the chain.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4394"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786891633&installation_id=134563449&pr_number=4394&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4394&signature=8c1ab2b7e3cd4a8e599525717e20dd3d3ead91c5533f47a718a154a3cadbad69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->