### PR TITLE
fix: support ClickHouse 22 date formats

### DIFF
--- a/src/lib/clickhouse.test.ts
+++ b/src/lib/clickhouse.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'vitest';
+import { CLICKHOUSE_DATE_FORMATS } from './clickhouse';
+
+describe('CLICKHOUSE_DATE_FORMATS', () => {
+  test('uses date format tokens compatible with ClickHouse 22.8 and newer', () => {
+    expect(CLICKHOUSE_DATE_FORMATS).toMatchObject({
+      utc: '%Y-%m-%dT%TZ',
+      second: '%Y-%m-%dT%T',
+      minute: '%Y-%m-%d %R:00',
+    });
+  });
+});

--- a/src/lib/clickhouse.ts
+++ b/src/lib/clickhouse.ts
@@ -7,9 +7,11 @@ import { filtersObjectToArray } from './params';
 import type { Operator, PropertyFilter, QueryFilters, QueryOptions } from './types';
 
 export const CLICKHOUSE_DATE_FORMATS = {
-  utc: '%Y-%m-%dT%H:%i:%SZ',
-  second: '%Y-%m-%dT%H:%i:%S',
-  minute: '%Y-%m-%d %H:%i:00',
+  // %i is unsupported by ClickHouse before v23.4. %T and %R work on both
+  // older and newer versions while retaining the intended ISO time format.
+  utc: '%Y-%m-%dT%TZ',
+  second: '%Y-%m-%dT%T',
+  minute: '%Y-%m-%d %R:00',
   hour: '%Y-%m-%d %H:00:00',
   day: '%Y-%m-%d',
   month: '%Y-%m-01',

--- a/src/queries/sql/replays/getSessionReplays.ts
+++ b/src/queries/sql/replays/getSessionReplays.ts
@@ -114,7 +114,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters, session
     : '';
 
   const havingQuery = minDurationMs
-    ? `having toInt64(sum(dateDiff('millisecond', session_replay.started_at, session_replay.ended_at))) >= {minDurationMs:Int64}`
+    ? `having toInt64(sum(toUnixTimestamp64Milli(session_replay.ended_at) - toUnixTimestamp64Milli(session_replay.started_at))) >= {minDurationMs:Int64}`
     : '';
 
   return pagedRawQuery(
@@ -132,7 +132,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters, session
       count(session_replay.replay_id) as chunkCount,
       min(session_replay.started_at) as startedAt,
       max(session_replay.ended_at) as endedAt,
-      toInt64(sum(dateDiff('millisecond', session_replay.started_at, session_replay.ended_at))) as duration,
+      toInt64(sum(toUnixTimestamp64Milli(session_replay.ended_at) - toUnixTimestamp64Milli(session_replay.started_at))) as duration,
       max(session_replay.created_at) as createdAt
     from session_replay
     join (


### PR DESCRIPTION
## Summary

Use `%T` and `%R` in ClickHouse date formatting instead of `%i`, and use millisecond timestamp subtraction for session-replay durations.

## Why

Umami v3.2.0 uses `%i` for minute values in `formatDateTime`. ClickHouse 22.8 rejects that token, which prevents session queries from loading. `%T` and `%R` produce the same required time strings on ClickHouse 22.8 and current ClickHouse releases.

ClickHouse 22.8 also rejects `dateDiff('millisecond', DateTime64, DateTime64)` with `Code: 36 / BAD_ARGUMENTS`, which prevents the session-replay list from loading. `toUnixTimestamp64Milli` subtraction preserves millisecond precision and works on both ClickHouse 22.8 and current releases.

## Validation

- Verified the generated formats against ClickHouse 22.8.4.7 and 26.6.1.
- Verified the replay-duration expression returns `1865` milliseconds on ClickHouse 22.8.4.7 and 26.6.1; the original `dateDiff('millisecond', ...)` fails on 22.8 with `BAD_ARGUMENTS`.
- Added and ran `src/lib/clickhouse.test.ts`.