### PR TITLE
fix: formatLongNumber shows billions ~1000x too large on metric tiles

### DIFF
--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -27,6 +27,8 @@ test('formatNumber', () => {
 });
 
 test('formatLongNumber', () => {
+  expect(format.formatLongNumber(1000000000)).toBe('1.0b');
+  expect(format.formatLongNumber(2500000000)).toBe('2.5b');
   expect(format.formatLongNumber(1200000)).toBe('1.2m');
   expect(format.formatLongNumber(575000)).toBe('575k');
   expect(format.formatLongNumber(10500)).toBe('10.5k');

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -51,7 +51,7 @@ export function formatLongNumber(value: number) {
   const n = Number(value);
 
   if (n >= 1000000000) {
-    return `${(n / 1000000).toFixed(1)}b`;
+    return `${(n / 1000000000).toFixed(1)}b`;
   }
   if (n >= 1000000) {
     return `${(n / 1000000).toFixed(1)}m`;


### PR DESCRIPTION
## What changed

`formatLongNumber` in `src/lib/format.ts` divided the value by `1000000` in its billions branch while still appending the `b` suffix. Any value at or above `1e9` therefore rendered about 1000 times too large. I switched that branch to divide by `1000000000` so the number matches the `b` unit.

## Why

I run a fairly high traffic site on Umami and noticed a metric tile that should read around `1.2b` pageviews was showing `1200.0b`. Digging in, the billions branch was scaling by a million instead of a billion.

```js
formatLongNumber(1000000000) // was "1000.0b", now "1.0b"
formatLongNumber(2500000000) // was "2500.0b", now "2.5b"
```

The neighbouring `m` and `k` branches already divide by their matching factor, and the sibling `formatLongCurrency` uses `1000000000` for its own billions branch, so this brings `formatLongNumber` in line with both.

## Testing

I extended the existing `formatLongNumber` test in `src/lib/format.test.ts` with two assertions for the billions range. Reverting the source fix makes the new assertion fail with `expected '1000.0b' to be '1.0b'`, and it passes with the fix in place.

```
pnpm test
```

## Notes

Targeting `dev` per CONTRIBUTING. One line of production code plus a regression test, no other behaviour touched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787229668&installation_model_id=22160&pr_number=4402&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4402&signature=9e55fc5373615c918a27c9a9f537f40bf3f8f08fc1c38111d21822b25e2d5f4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->