### PR TITLE
Validate website name and domain input on server side

### DIFF
--- a/src/app/api/websites/[websiteId]/route.ts
+++ b/src/app/api/websites/[websiteId]/route.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { Prisma } from '@/generated/prisma/client';
-import { ENTITY_TYPE } from '@/lib/constants';
+import { DOMAIN_REGEX, ENTITY_TYPE } from '@/lib/constants';
 import { uuid } from '@/lib/crypto';
 import { getRecorderConfig, getRecorderEnabled } from '@/lib/recorder';
 import { parseRequest } from '@/lib/request';
@@ -41,8 +41,8 @@ export async function POST(
   { params }: { params: Promise<{ websiteId: string }> },
 ) {
   const schema = z.object({
-    name: z.string().max(100).optional(),
-    domain: z.string().max(500).optional(),
+    name: z.string().trim().min(1).max(100).optional(),
+    domain: z.string().trim().regex(DOMAIN_REGEX).max(500).optional(),
     shareId: z.string().max(50).nullable().optional(),
     replayConfig: z
       .object({

--- a/src/app/api/websites/route.ts
+++ b/src/app/api/websites/route.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { ENTITY_TYPE } from '@/lib/constants';
+import { DOMAIN_REGEX, ENTITY_TYPE } from '@/lib/constants';
 import { uuid } from '@/lib/crypto';
 import { fetchAccount, fetchTeam } from '@/lib/load';
 import { getQueryFilters, parseRequest } from '@/lib/request';
@@ -37,8 +37,8 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   const schema = z.object({
-    name: z.string().max(100),
-    domain: z.string().max(500),
+    name: z.string().trim().min(1).max(100),
+    domain: z.string().trim().regex(DOMAIN_REGEX).max(500),
     shareId: z.string().max(50).nullable().optional(),
     teamId: z.uuid().nullable().optional(),
     id: z.uuid().nullable().optional(),


### PR DESCRIPTION
## Summary
This PR adds server-side validation for website creation/update to match the validation already enforced by the frontend.

## Problem
The frontend validates:
- website `name` is required
- website `domain` matches `DOMAIN_REGEX`

However, the backend(Zod validation) only checked:

```
name: z.string().max(100)
domain: z.string().max(500)
```

As a result, invalid values could be submitted directly to the API, bypassing the frontend validation.

The following invalid inputs which are rejected by frontend can be accepted by backend API.
```
domain = "abc"
domain = "https://example.com"
domain = ""
name = ""
```

## Changes Made
### Better Zod validation:
- Require non-empty website name : `name: z.string().trim().min(1).max(100)`
- Validate website domain using DOMAIN_REGEX:   `domain: z.string().trim().regex(DOMAIN_REGEX).max(500)`

This keeps backend validation consistent with the frontend.
Changes were made in both website add (`POST /api/websites`) and website create (`POST /api/websites/[websiteId]`) endpoint.

Fixes #4403

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4404"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787242474&installation_model_id=22160&pr_number=4404&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4404&signature=b693d123eecc4eae7bc2c02fe22712bb5a28e9ef8d5f8907c265fbdc0ac1b831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->