### PR TITLE
fix: /metrics/expanded search query

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -75,6 +75,7 @@ export const SEGMENT_TYPES = {
 
 export const FILTER_COLUMNS = {
   path: 'url_path',
+  fullPath: 'url_path',
   entry: 'url_path',
   exit: 'url_path',
   referrer: 'referrer_domain',


### PR DESCRIPTION
As reported in Discord (https://discord.com/channels/951898446804172840/951899492469338164/1528681579285708850) filtering currently is broken for URL. 

<img width="617" height="508" alt="image" src="https://github.com/user-attachments/assets/7539e467-2f59-4cef-a3bc-23156126ba20" />


This is due to the frontend sending the `search=test&type=fullPath` parameters, but `fullPath` is not mapped by the `getRequestFilters` function. This PR adds it to the global `FILTER_COLUMNS` list.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787255192&installation_model_id=22160&pr_number=4405&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4405&signature=a3f4ed4f5bd2aafed005855e5e276c978786050b3eed379499ab769c316fdef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->