### PR TITLE
Feat: Improve bounce calculations with configurable threshold v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       DATABASE_URL: postgresql://umami:umami@db:5432/umami
       APP_SECRET: replace-me-with-a-random-string
+      # BOUNCE_THRESHOLD: 2 # OPTIONAL: set the minimum amount custom events to trigger a bounce
     depends_on:
       db:
         condition: service_healthy

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,8 @@
 export const CURRENT_VERSION = process.env.currentVersion;
+export const BOUNCE_THRESHOLD = Math.max(
+  1,
+  Number.parseInt(process.env.BOUNCE_THRESHOLD || '1', 10) || 1,
+);
 export const AUTH_TOKEN = 'umami.auth';
 export const LOCALE_CONFIG = 'umami.locale';
 export const TIMEZONE_CONFIG = 'umami.timezone';

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,8 +1,5 @@
 export const CURRENT_VERSION = process.env.currentVersion;
-export const BOUNCE_THRESHOLD = Math.max(
-  1,
-  Number.parseInt(process.env.BOUNCE_THRESHOLD || '1', 10) || 1,
-);
+export const BOUNCE_THRESHOLD = Math.max(1, Number.parseInt(process.env.BOUNCE_THRESHOLD, 10) || 1);
 export const AUTH_TOKEN = 'umami.auth';
 export const LOCALE_CONFIG = 'umami.locale';
 export const TIMEZONE_CONFIG = 'umami.timezone';

--- a/src/queries/sql/events/getEventExpandedMetrics.ts
+++ b/src/queries/sql/events/getEventExpandedMetrics.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
+import { BOUNCE_THRESHOLD, EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -54,7 +54,7 @@ async function relationalQuery(
       sum(t.c) as "pageviews",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(case when t.c = 1 then 1 else 0 end) as "bounces",
+      sum(case when t.c = 1 and (t.events_count - t.c) < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime"
     from (
       select
@@ -63,10 +63,19 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time"
+        max(website_event.created_at) as "max_time",
+        max((
+          select count(*)
+          from website_event we2
+          where we2.website_id = website_event.website_id
+            and we2.session_id = website_event.session_id
+            and we2.visit_id = website_event.visit_id
+            and we2.created_at between {{startDate}} and {{endDate}}
+            and we2.event_type = ${EVENT_TYPE.customEvent}
+        )) as "events_count"
       from website_event
       ${cohortQuery}
-      ${joinSessionQuery}  
+      ${joinSessionQuery}
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         ${filterQuery}
@@ -104,7 +113,7 @@ async function clickhouseQuery(
       sum(t.c) as "pageviews",
       uniq(t.session_id) as "visitors",
       uniq(t.visit_id) as "visits",
-      sum(if(t.c = 1, 1, 0)) as "bounces",
+      sumIf(1, t.c = 1 and (toInt64(ifNull(e.events_count, 0)) - toInt64(t.c)) < ${BOUNCE_THRESHOLD}) as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
@@ -122,7 +131,15 @@ async function clickhouseQuery(
         ${filterQuery}
       group by name, session_id, visit_id
     ) as t
-    group by name 
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id)
+    group by name
     order by visitors desc, visits desc
     limit ${limit}
     offset ${offset}

--- a/src/queries/sql/events/getEventExpandedMetrics.ts
+++ b/src/queries/sql/events/getEventExpandedMetrics.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { BOUNCE_THRESHOLD, EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
+import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -54,7 +54,7 @@ async function relationalQuery(
       sum(t.c) as "pageviews",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(case when t.c = 1 and (t.events_count - t.c) < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
+      sum(case when t.c = 1 then 1 else 0 end) as "bounces",
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime"
     from (
       select
@@ -63,19 +63,10 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time",
-        max((
-          select count(*)
-          from website_event we2
-          where we2.website_id = website_event.website_id
-            and we2.session_id = website_event.session_id
-            and we2.visit_id = website_event.visit_id
-            and we2.created_at between {{startDate}} and {{endDate}}
-            and we2.event_type = ${EVENT_TYPE.customEvent}
-        )) as "events_count"
+        max(website_event.created_at) as "max_time"
       from website_event
       ${cohortQuery}
-      ${joinSessionQuery}
+      ${joinSessionQuery}  
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         ${filterQuery}
@@ -113,7 +104,7 @@ async function clickhouseQuery(
       sum(t.c) as "pageviews",
       uniq(t.session_id) as "visitors",
       uniq(t.visit_id) as "visits",
-      sumIf(1, t.c = 1 and (toInt64(ifNull(e.events_count, 0)) - toInt64(t.c)) < ${BOUNCE_THRESHOLD}) as "bounces",
+      sum(if(t.c = 1, 1, 0)) as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
@@ -131,15 +122,7 @@ async function clickhouseQuery(
         ${filterQuery}
       group by name, session_id, visit_id
     ) as t
-    left join (
-      select session_id, visit_id, toUInt32(count()) as events_count
-      from website_event
-      where website_id = {websiteId:UUID}
-        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
-        and event_type = ${EVENT_TYPE.customEvent}
-      group by session_id, visit_id
-    ) as e using (session_id, visit_id)
-    group by name
+    group by name 
     order by visitors desc, visits desc
     limit ${limit}
     offset ${offset}

--- a/src/queries/sql/events/getWebsiteEvents.ts
+++ b/src/queries/sql/events/getWebsiteEvents.ts
@@ -22,8 +22,8 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
   });
 
   const searchQuery = search
-    ? `and ((event_name ilike {{search}} and event_type = 2)
-           or (url_path ilike {{search}} and event_type = 1))`
+    ? `and ((event_name ilike {{search}} and event_type = ${EVENT_TYPE.customEvent})
+           or (url_path ilike {{search}} and event_type = ${EVENT_TYPE.pageView}))`
     : '';
 
   return pagedRawQuery(
@@ -77,8 +77,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
   });
 
   const searchQuery = search
-    ? `and ((positionCaseInsensitive(event_name, {search:String}) > 0 and event_type = 2)
-           or (positionCaseInsensitive(url_path, {search:String}) > 0 and event_type = 1))`
+    ? `and ((positionCaseInsensitive(event_name, {search:String}) > 0 and event_type = ${EVENT_TYPE.customEvent})
+           or (positionCaseInsensitive(url_path, {search:String}) > 0 and event_type = ${EVENT_TYPE.pageView}))`
     : '';
 
   return pagedRawQuery(

--- a/src/queries/sql/getChannelExpandedMetrics.ts
+++ b/src/queries/sql/getChannelExpandedMetrics.ts
@@ -1,6 +1,8 @@
 import clickhouse from '@/lib/clickhouse';
 import {
+  BOUNCE_THRESHOLD,
   EMAIL_DOMAINS,
+  EVENT_TYPE,
   LLM_DOMAINS,
   PAID_AD_PARAMS,
   SEARCH_DOMAINS,
@@ -120,20 +122,34 @@ async function relationalQuery(
           min(created_at) as min_time,
           max(created_at) as max_time
         from prefix
+        group by session_id, visit_id),
+
+      visit_events as (
+        select
+          session_id,
+          visit_id,
+          count(*) as events_count
+        from website_event
+        where website_id = {{websiteId::uuid}}
+          and created_at between {{startDate}} and {{endDate}}
+          and event_type = ${EVENT_TYPE.customEvent}
         group by session_id, visit_id)
-  
+
       select
         visit_channels.name,
         sum(visit_stats.c) as "pageviews",
         count(distinct visit_stats.session_id) as "visitors",
         count(distinct visit_stats.visit_id) as "visits",
-        sum(case when visit_stats.c = 1 then 1 else 0 end) as "bounces",
+        sum(case when visit_stats.c = 1 and coalesce(visit_events.events_count, 0) < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
         sum(${getTimestampDiffSQL('visit_stats.min_time', 'visit_stats.max_time')}) as "totaltime"
       from visit_stats
       join visit_channels
         on visit_channels.session_id = visit_stats.session_id
         and visit_channels.visit_id = visit_stats.visit_id
-      group by visit_channels.name 
+      left join visit_events
+        on visit_events.session_id = visit_stats.session_id
+        and visit_events.visit_id = visit_stats.visit_id
+      group by visit_channels.name
       order by visitors desc, visits desc
       `,
     queryParams,
@@ -158,7 +174,7 @@ async function clickhouseQuery(
       sum(t.c) as "pageviews",
       uniq(t.session_id) as "visitors",
       uniq(t.visit_id) as "visits",
-      sum(if(t.c = 1, 1, 0)) as "bounces",
+      sumIf(1, t.c = 1 and ifNull(e.events_count, 0) < ${BOUNCE_THRESHOLD}) as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
@@ -213,7 +229,15 @@ async function clickhouseQuery(
       )
       group by session_id, visit_id
     ) as t
-    group by name 
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id)
+    group by name
     order by visitors desc, visits desc;
     `,
     queryParams,

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { EVENT_COLUMNS } from '@/lib/constants';
+import { BOUNCE_THRESHOLD, EVENT_COLUMNS, EVENT_TYPE } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -35,7 +35,9 @@ async function relationalQuery(
     });
 
   const { excludeBounce } = filters;
-  const bounceQuery = excludeBounce ? '0' : 'coalesce(sum(case when t.c = 1 then 1 else 0 end), 0)';
+  const bounceQuery = excludeBounce
+    ? '0'
+    : `coalesce(sum(case when t.c = 1 and t.events_count < ${BOUNCE_THRESHOLD} then 1 else 0 end), 0)`;
 
   return rawQuery(
     `
@@ -51,11 +53,20 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time"
+        max(website_event.created_at) as "max_time",
+        max((
+          select count(*)
+          from website_event we2
+          where we2.website_id = website_event.website_id
+            and we2.session_id = website_event.session_id
+            and we2.visit_id = website_event.visit_id
+            and we2.created_at between {{startDate}} and {{endDate}}
+            and we2.event_type = ${EVENT_TYPE.customEvent}
+        )) as "events_count"
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      ${joinSessionQuery}  
+      ${joinSessionQuery}
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         and website_event.event_type NOT IN (2, 5)
@@ -81,7 +92,9 @@ async function clickhouseQuery(
 
   let sql = '';
   const { excludeBounce } = filters;
-  const bounceQuery = excludeBounce ? '0' : 'sumIf(1, t.c = 1)';
+  const bounceQuery = excludeBounce
+    ? '0'
+    : `sumIf(1, t.c = 1 and ifNull(e.events_count, 0) < ${BOUNCE_THRESHOLD})`;
 
   if (EVENT_COLUMNS.some(item => Object.keys(filters).includes(item))) {
     sql = `
@@ -106,7 +119,15 @@ async function clickhouseQuery(
         and event_type NOT IN (2, 5)
         ${filterQuery}
       group by session_id, visit_id
-    ) as t;
+    ) as t
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id);
     `;
   } else {
     sql = `
@@ -130,7 +151,14 @@ async function clickhouseQuery(
       and event_type NOT IN (2, 5)
       ${filterQuery}
       group by session_id, visit_id
-    ) as t;
+    ) as t
+    left join (
+      select session_id, visit_id, toUInt32(sumIf(views, event_type = ${EVENT_TYPE.customEvent})) as events_count
+      from website_event_stats_hourly
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id);
     `;
   }
 

--- a/src/queries/sql/getWebsiteStats.ts
+++ b/src/queries/sql/getWebsiteStats.ts
@@ -153,7 +153,7 @@ async function clickhouseQuery(
       group by session_id, visit_id
     ) as t
     left join (
-      select session_id, visit_id, toUInt32(sumIf(views, event_type = ${EVENT_TYPE.customEvent})) as events_count
+      select session_id, visit_id, toUInt32(sum(length(event_name))) as events_count
       from website_event_stats_hourly
       where website_id = {websiteId:UUID}
         and created_at between {startDate:DateTime64} and {endDate:DateTime64}

--- a/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
+++ b/src/queries/sql/pageviews/getPageviewExpandedMetrics.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { FILTER_COLUMNS, GROUPED_DOMAINS, SESSION_COLUMNS } from '@/lib/constants';
+import { BOUNCE_THRESHOLD, EVENT_TYPE, FILTER_COLUMNS, GROUPED_DOMAINS, SESSION_COLUMNS } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -96,7 +96,7 @@ async function relationalQuery(
       sum(t.c) as "pageviews",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(case when t.c = 1 then 1 else 0 end) as "bounces",
+      sum(case when t.c = 1 and t.events_count < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime"
     from (
       select
@@ -105,12 +105,21 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time"
+        max(website_event.created_at) as "max_time",
+        max((
+          select count(*)
+          from website_event we2
+          where we2.website_id = website_event.website_id
+            and we2.session_id = website_event.session_id
+            and we2.visit_id = website_event.visit_id
+            and we2.created_at between {{startDate}} and {{endDate}}
+            and we2.event_type = ${EVENT_TYPE.customEvent}
+        )) as "events_count"
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      ${joinSessionQuery} 
-      ${entryExitQuery} 
+      ${joinSessionQuery}
+      ${entryExitQuery}
       where website_event.website_id = {{websiteId::uuid}}
       and website_event.created_at between {{startDate}} and {{endDate}}
       and website_event.event_type NOT IN (2, 5)
@@ -188,7 +197,7 @@ async function clickhouseQuery(
       sum(t.c) as "pageviews",
       uniq(t.session_id) as "visitors",
       uniq(t.visit_id) as "visits",
-      sum(if(t.c = 1, 1, 0)) as "bounces",
+      sumIf(1, t.c = 1 and ifNull(e.events_count, 0) < ${BOUNCE_THRESHOLD}) as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
@@ -211,6 +220,14 @@ async function clickhouseQuery(
         ${filterQuery}
       group by name, session_id, visit_id
     ) as t
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id)
     group by name
     order by visitors desc, visits desc
     limit ${limit}

--- a/src/queries/sql/reports/getBreakdown.ts
+++ b/src/queries/sql/reports/getBreakdown.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
+import { BOUNCE_THRESHOLD, EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -50,7 +50,7 @@ async function relationalQuery(
       sum(t.c) as "views",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(case when t.c = 1 then 1 else 0 end) as "bounces",
+      sum(case when t.c = 1 and t.events_count < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime",
       ${parseFieldsByName(fields)}
     from (
@@ -60,14 +60,23 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time"
+        max(website_event.created_at) as "max_time",
+        max((
+          select count(*)
+          from website_event we2
+          where we2.website_id = website_event.website_id
+            and we2.session_id = website_event.session_id
+            and we2.visit_id = website_event.visit_id
+            and we2.created_at between {{startDate}} and {{endDate}}
+            and we2.event_type = ${EVENT_TYPE.customEvent}
+        )) as "events_count"
       from website_event
-      ${cohortQuery}  
+      ${cohortQuery}
       ${joinSessionQuery}
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         ${filterQuery}
-      group by ${parseFieldsByName(fields)}, 
+      group by ${parseFieldsByName(fields)},
         website_event.session_id, website_event.visit_id
     ) as t
     group by ${parseFieldsByName(fields)}
@@ -99,7 +108,7 @@ async function clickhouseQuery(
       sum(t.c) as "views",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(if(t.c = 1, 1, 0)) as "bounces",
+      sumIf(1, t.c = 1 and ifNull(e.events_count, 0) < ${BOUNCE_THRESHOLD}) as "bounces",
       sum(max_time-min_time) as "totaltime",
       ${parseFieldsByName(fields)}
     from (
@@ -115,9 +124,17 @@ async function clickhouseQuery(
       where website_id = {websiteId:UUID}
         and created_at between {startDate:DateTime64} and {endDate:DateTime64}
         ${filterQuery}
-      group by ${parseFieldsByName(fields)}, 
+      group by ${parseFieldsByName(fields)},
         session_id, visit_id
     ) as t
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id)
     group by ${parseFieldsByName(fields)}
     order by 2 desc, 1 desc
     limit 500

--- a/src/queries/sql/sessions/getSessionExpandedMetrics.ts
+++ b/src/queries/sql/sessions/getSessionExpandedMetrics.ts
@@ -1,5 +1,5 @@
 import clickhouse from '@/lib/clickhouse';
-import { FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
+import { BOUNCE_THRESHOLD, EVENT_TYPE, FILTER_COLUMNS, SESSION_COLUMNS } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
 import prisma from '@/lib/prisma';
 import type { QueryFilters } from '@/lib/types';
@@ -62,7 +62,7 @@ async function relationalQuery(
       sum(t.c) as "pageviews",
       count(distinct t.session_id) as "visitors",
       count(distinct t.visit_id) as "visits",
-      sum(case when t.c = 1 then 1 else 0 end) as "bounces",
+      sum(case when t.c = 1 and t.events_count < ${BOUNCE_THRESHOLD} then 1 else 0 end) as "bounces",
       sum(${getTimestampDiffSQL('t.min_time', 't.max_time')}) as "totaltime"
     from (
       select
@@ -72,11 +72,20 @@ async function relationalQuery(
         website_event.visit_id,
         count(*) as "c",
         min(website_event.created_at) as "min_time",
-        max(website_event.created_at) as "max_time"
+        max(website_event.created_at) as "max_time",
+        max((
+          select count(*)
+          from website_event we2
+          where we2.website_id = website_event.website_id
+            and we2.session_id = website_event.session_id
+            and we2.visit_id = website_event.visit_id
+            and we2.created_at between {{startDate}} and {{endDate}}
+            and we2.event_type = ${EVENT_TYPE.customEvent}
+        )) as "events_count"
       from website_event
       ${cohortQuery}
       ${excludeBounceQuery}
-      ${joinSessionQuery}  
+      ${joinSessionQuery}
       where website_event.website_id = {{websiteId::uuid}}
         and website_event.created_at between {{startDate}} and {{endDate}}
         and website_event.event_type NOT IN (2, 5)
@@ -122,7 +131,7 @@ async function clickhouseQuery(
       sum(t.c) as "pageviews",
       uniq(t.session_id) as "visitors",
       uniq(t.visit_id) as "visits",
-      sum(if(t.c = 1, 1, 0)) as "bounces",
+      sumIf(1, t.c = 1 and ifNull(e.events_count, 0) < ${BOUNCE_THRESHOLD}) as "bounces",
       sum(max_time-min_time) as "totaltime"
     from (
       select
@@ -144,7 +153,15 @@ async function clickhouseQuery(
       group by name, session_id, visit_id
       ${includeCountry ? ', country' : ''}
     ) as t
-    group by name 
+    left join (
+      select session_id, visit_id, toUInt32(count()) as events_count
+      from website_event
+      where website_id = {websiteId:UUID}
+        and created_at between {startDate:DateTime64} and {endDate:DateTime64}
+        and event_type = ${EVENT_TYPE.customEvent}
+      group by session_id, visit_id
+    ) as e using (session_id, visit_id)
+    group by name
     ${includeCountry ? ', country' : ''}
     order by visitors desc, visits desc
     limit ${limit}

--- a/src/queries/sql/sessions/getWebsiteSession.ts
+++ b/src/queries/sql/sessions/getWebsiteSession.ts
@@ -49,8 +49,8 @@ async function relationalQuery(websiteId: string, sessionId: string) {
           session.city,
           min(website_event.created_at) as min_time,
           max(website_event.created_at) as max_time,
-          sum(case when website_event.event_type = 1 then 1 else 0 end) as views,
-          sum(case when website_event.event_type = 2 then 1 else 0 end) as events
+          sum(case when website_event.event_type = ${EVENT_TYPE.pageView} then 1 else 0 end) as views,
+          sum(case when website_event.event_type = ${EVENT_TYPE.customEvent} then 1 else 0 end) as events
     from session
     join website_event on website_event.session_id = session.session_id
     where session.website_id = {{websiteId::uuid}}

--- a/src/queries/sql/sessions/getWebsiteSessionStats.ts
+++ b/src/queries/sql/sessions/getWebsiteSessionStats.ts
@@ -36,11 +36,11 @@ async function relationalQuery(
   return rawQuery(
     `
     select
-      sum(case when website_event.event_type = 1 then 1 else 0 end) as "pageviews",
+      sum(case when website_event.event_type = ${EVENT_TYPE.pageView} then 1 else 0 end) as "pageviews",
       count(distinct website_event.session_id) as "visitors",
       count(distinct website_event.visit_id) as "visits",
       count(distinct session.country) as "countries",
-      sum(case when website_event.event_type = 2 then 1 else 0 end) as "events"
+      sum(case when website_event.event_type = ${EVENT_TYPE.customEvent} then 1 else 0 end) as "events"
     from website_event
     ${cohortQuery}
     join session on website_event.session_id = session.session_id
@@ -67,11 +67,11 @@ async function clickhouseQuery(
   if (EVENT_COLUMNS.some(item => Object.keys(filters).includes(item))) {
     sql = `
     select
-      sumIf(1, event_type = 1) as "pageviews",
+      sumIf(1, event_type = ${EVENT_TYPE.pageView}) as "pageviews",
       uniq(session_id) as "visitors",
       uniq(visit_id) as "visits",
       uniq(country) as "countries",
-      sumIf(1, event_type = 2) as "events"
+      sumIf(1, event_type = ${EVENT_TYPE.customEvent}) as "events"
     from website_event
     ${cohortQuery}
     where website_id = {websiteId:UUID}

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -50,8 +50,8 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
       min(website_event.created_at) as "firstAt",
       max(website_event.created_at) as "lastAt",
       count(distinct website_event.visit_id) as "visits",
-      sum(case when website_event.event_type = 1 then 1 else 0 end) as "views",
-      sum(case when website_event.event_type = 2 then 1 else 0 end) as "events",
+      sum(case when website_event.event_type = ${EVENT_TYPE.pageView} then 1 else 0 end) as "views",
+      sum(case when website_event.event_type = ${EVENT_TYPE.customEvent} then 1 else 0 end) as "events",
       max(website_event.created_at) as "createdAt"
     from website_event 
     ${cohortQuery}
@@ -125,8 +125,8 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       ${getDateStringSQL('min(created_at)')} as firstAt,
       ${getDateStringSQL('max(created_at)')} as lastAt,
       uniq(visit_id) as visits,
-      sumIf(1, event_type = 1) as views,
-      sumIf(1, event_type = 2) as events,
+      sumIf(1, event_type = ${EVENT_TYPE.pageView}) as views,
+      sumIf(1, event_type = ${EVENT_TYPE.customEvent}) as events,
       max(created_at) as createdAt
     from website_event
     ${cohortQuery}
@@ -155,7 +155,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters) {
       ${getDateStringSQL('min(min_time)')} as firstAt,
       ${getDateStringSQL('max(max_time)')} as lastAt,
       uniq(visit_id) as visits,
-      sumIf(views, event_type = 1) as views,
+      sumIf(views, event_type = ${EVENT_TYPE.pageView}) as views,
       sum(length(event_name)) as events,
       max(max_time) as createdAt
     from website_event_stats_hourly as website_event


### PR DESCRIPTION
This PR is the evolution of #3614 remade to be v3 compatible. The base concept remains unchanged.

---

### What's changed

Right now, a visit with a single pageview is always counted as a bounce. As discussed in #3518 and #2544 (and the #3614 PR), this does not work well for SPAs or landing pages where a page change doesn't happen. A better approach is to define a bounce as a visit with zero custom events, since custom events allow implementers to capture engagement in ways that fit their use case.

Because engagement is subjective, I introduced a configurable BOUNCE_THRESHOLD. A visit is now considered a bounce if its number of custom events is strictly less than the configured threshold. This lets each project decide what level of interaction counts as "engagement."

The change is backwards compatible by setting a default of 1 (current behavior).

### Concrete examples
- BOUNCE_THRESHOLD = 1 (default)
  - events_count = 0 → 0 < 1 ⇒ bounce
  - events_count = 1 → 1 ≥ 1 ⇒ not a bounce
  - events_count = 2 → 2 ≥ 1 ⇒ not a bounce

- BOUNCE_THRESHOLD = 2
  - events_count = 0 → 0 < 2 ⇒ bounce
  - events_count = 1 → 1 < 2 ⇒ bounce
  - events_count = 2 → 2 ≥ 2 ⇒ not a bounce
  - events_count = 3 → 3 ≥ 2 ⇒ not a bounce

### Description

This pull request introduces enhancements to bounce calculations and refactors event type handling:

- Adds a new configurable constant, `BOUNCE_THRESHOLD`, to define the minimum amount of custom events to count as a non-bounce. Defaults to 1 for backwards compatibility / env not provided.
- Updates bounce logic to use `events_count` and account for sessions with custom events (`EVENT_TYPE.customEvent`).
- Replaces hardcoded event type values with named constants from `EVENT_TYPE` as seen in other project files.

v3 restructured the query layer heavily since #3614 was first proposed (v2.19.0 → v3.2.0+dev). The original PR touched only `getWebsiteStats` and `getInsights`. Since then i noticed that:
- `getInsights.ts` was removed; its logic now lives in `getBreakdown.ts` so I updated there instead.
- The "bounce = single-event visit" formula got duplicated into several other report views that didn't exist when #3614 was opened: Channels, Pageviews, Sessions, Events breakdowns each reimplement it independently. Fixing only the original 2 files would leave bounce rate meaning different things per report, so this PR updates all of them, hope to have not missed other occurencies:
  - `getWebsiteStats.ts`
  - `getBreakdown.ts` (was `getInsights.ts`)
  - `getChannelExpandedMetrics.ts`
  - `getPageviewExpandedMetrics.ts`
  - `getSessionExpandedMetrics.ts`
  - `getEventExpandedMetrics.ts`

The PR partially addresses #3518

### Disclaimer about ClickHouse

I am not proficient with ClickHouse, edits to these queries have been made with the help of AI. Please review them carefully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787675221&installation_model_id=22160&pr_number=4408&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4408&signature=e7df7789bdc0a9722fbd451186b39429056dc755dbf526a152bf76a858849378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->