### PR TITLE
ci: attach provenance and SBOM attestations to the published images

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,6 +111,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.compute.outputs.ghcr_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -122,6 +124,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: mode=max
+          sbom: true
           tags: ${{ steps.compute.outputs.docker_tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Hi, and thanks for umami.

`.github/workflows/cd.yml` builds and pushes two image variants — the PostgreSQL and MySQL builds — to both `ghcr.io` and Docker Hub, but none of the pushed manifests carry a provenance or SBOM attestation.

umami is analytics people self-host precisely so the data stays theirs, and the image is what they deploy. Being able to confirm the image was built by this workflow from this repository fits the reason someone chose to self-host in the first place.

The change is two lines on each of the two build steps:

```yaml
          push: true
          provenance: mode=max
          sbom: true
```

BuildKit attaches the attestation to the image manifest, so each build covers both registries it pushes to — no second credential and no extra step. **No permissions change is needed**: the job's `contents: read` and `packages: write` stay exactly as they are, and nothing needs `id-token`. Your tag-assembly logic and the `GHCR_TAGS` / Docker Hub tag lists are untouched.

Consumers can then check either variant with:

```
docker buildx imagetools inspect ghcr.io/umami-software/umami:postgresql-latest --format '{{ json .Provenance }}'
```

Two caveats worth stating: `mode=max` records the full build including build args (`provenance: true` gives a smaller record if any have ever been sensitive), and attestations add an extra manifest to the index — both GHCR and Docker Hub support this.

No SLSA level claimed — the attestation is what BuildKit produces.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and both push targets myself.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787870125&installation_model_id=22160&pr_number=4414&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4414&signature=2a5d477b21865f942752dcf9084307dba0eff1e4f9512f0822a15134315e2d24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->