### PR TITLE
fix(events): keep the selected property when switching events

### DIFF
--- a/src/app/(main)/websites/[websiteId]/events/EventProperties.tsx
+++ b/src/app/(main)/websites/[websiteId]/events/EventProperties.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Column, Grid, Label, ListItem, Row, Select } from '@umami/react-zen';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ComboBox } from '@/components/common/ComboBox';
 import { LoadingPanel } from '@/components/common/LoadingPanel';
 import { Panel } from '@/components/common/Panel';
@@ -27,11 +27,6 @@ export function EventProperties({ websiteId }: { websiteId: string }) {
   const [propertyName, setPropertyName] = useState('');
   const [propertyFilters, setPropertyFilters] = useState<PropertyFilter[]>([]);
   const { t, labels } = useMessages();
-
-  useEffect(() => {
-    setPropertyName('');
-    setPropertyFilters([]);
-  }, [eventName]);
 
   const { data, isLoading, isFetching, error } = useEventDataPropertiesQuery(websiteId);
 
@@ -72,8 +67,14 @@ export function EventProperties({ websiteId }: { websiteId: string }) {
   }, [eventNames, eventSearch]);
 
   const handleEventChange = (value: string) => {
+    const nextProperties = new Set<string>(
+      data
+        ?.filter((field: { eventName: string }) => field.eventName === value)
+        .map((field: { propertyName: string }) => field.propertyName) ?? [],
+    );
+
     setEventName(value);
-    setPropertyName('');
+    setPropertyName(nextProperties.has(propertyName) ? propertyName : '');
     setPropertyFilters([]);
   };
 


### PR DESCRIPTION
## Problem

In a website's **Properties** tab, picking a different event always clears the
selected property, even when the newly selected event exposes that very same
property.

Properties such as `page`, `url` or `source` are commonly attached to several
events, so comparing one property across events is a routine task. Today it
means re-selecting the property after every single switch, and the chart area
goes empty in between.

## Change

`handleEventChange` now keeps the current property when the newly selected
event also exposes it, and clears it otherwise, which is the current behaviour.

```ts
const nextProperties = new Set<string>(
  data
    ?.filter((field: { eventName: string }) => field.eventName === value)
    .map((field: { propertyName: string }) => field.propertyName) ?? [],
);

setEventName(value);
setPropertyName(nextProperties.has(propertyName) ? propertyName : '');
setPropertyFilters([]);
```

Property filters are still cleared unconditionally: their values are tied to a
specific event, so carrying them over would filter on values that may not exist
for the new event.

The `useEffect` that reset the property on every `eventName` change is removed.
`setEventName` is only ever called from `handleEventChange`, so the effect was
redundant, and it would have immediately overwritten the property being kept.

## How to test

1. Open a website with at least two events sharing a property name (for example
   two events both carrying `page`).
2. Go to **Properties**, select the first event, then select that shared
   property. The chart renders.
3. Switch to the second event.
   - Before: the property selector is emptied and the chart disappears.
   - After: the property stays selected and the chart reloads for the new event.
4. Switch to an event that does not expose that property: the selector is
   cleared, as before.

## Checks

- `biome lint` and `biome format` report no changes on the modified file.
- `tsc --noEmit` on the full project: 0 errors.
- `vitest run`: 685 tests pass. The 2 failures in `AttributionPage.test.tsx` are
  pre-existing on `dev` and unrelated to this change: the `@umami/react-zen`
  mock in that file does not define `ZenProvider`, which `src/test/render.tsx`
  requires. Verified by running that test file on a clean `dev` checkout, where
  it fails identically.
- No test is added here: `EventProperties` has no test file yet, and covering it
  would mean mocking the whole chart/pivot-table tree. Happy to add one if you
  would like it in this PR.

Targeting `dev`, per `CONTRIBUTING.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788352272&installation_model_id=22160&pr_number=4419&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4419&signature=82fe16facede6374101029a03ee63691a0547b7af7f25938c477e9ce4b49b921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
