### PR TITLE
feat: Multi website board components

### DIFF
--- a/src/app/(main)/boards/[boardId]/BoardComponentSelect.tsx
+++ b/src/app/(main)/boards/[boardId]/BoardComponentSelect.tsx
@@ -22,6 +22,7 @@ import {
 import { BoardComponentRenderer } from './BoardComponentRenderer';
 
 const COMPONENT_GROUP_ORDER: string[] = [
+  'All websites',
   'Traffic',
   'Events',
   'Behavior',
@@ -144,7 +145,6 @@ export function BoardComponentSelect({
 
   const needsWebsite = selectedDef?.requiresWebsite !== false;
   const isOpenType = isOpenBoardType(boardType);
-  const hasSelectedEntity = isOpenType ? !!selectedEntityId : !!boardEntityId;
   const resolvedEntityType = needsWebsite
     ? isOpenType
       ? selectedEntityType
@@ -448,62 +448,56 @@ export function BoardComponentSelect({
         <Column gap="3" height="100%" style={{ width: 280, flexShrink: 0, minWidth: 0 }}>
           <Text weight="bold">Components</Text>
           <Column border="left" paddingLeft="4" height="100%" style={{ minHeight: 0 }}>
-            {hasSelectedEntity ? (
-              <Column gap="1" height="100%" style={{ overflowY: 'auto', minHeight: 0 }}>
-                {groupedDefinitions.map(({ group, definitions }) => (
-                  <Column key={group} gap="1" paddingBottom="2">
-                    <Text size="sm" color="muted" weight="bold">
-                      {group}
-                    </Text>
-                    {definitions.map(def => {
-                      const Icon = def.icon;
+            <Column gap="1" height="100%" style={{ overflowY: 'auto', minHeight: 0 }}>
+              {groupedDefinitions.map(({ group, definitions }) => (
+                <Column key={group} gap="1" paddingBottom="2">
+                  <Text size="sm" color="muted" weight="bold">
+                    {group}
+                  </Text>
+                  {definitions.map(def => {
+                    const Icon = def.icon;
 
-                      return (
-                        <Row
-                          key={def.type}
-                          tabIndex={0}
-                          gap="3"
-                          alignItems="flex-start"
-                          paddingX="3"
-                          paddingY="2"
-                          borderRadius
-                          backgroundColor={
-                            selectedDef?.type === def.type ? 'surface-sunken' : undefined
-                          }
-                          hover={{ backgroundColor: 'surface-sunken' }}
-                          style={{ cursor: 'pointer' }}
-                          onClick={() => handleSelectComponent(def)}
-                        >
-                          <Icon size={16} />
-                          <Column gap="1">
-                            <Text
-                              size="sm"
-                              weight={selectedDef?.type === def.type ? 'bold' : undefined}
-                            >
-                              {def.name}
-                            </Text>
-                            <Text size="xs" color="muted">
-                              {def.description}
-                            </Text>
-                          </Column>
-                        </Row>
-                      );
-                    })}
-                  </Column>
-                ))}
-              </Column>
-            ) : (
-              <Column alignItems="center" justifyContent="center" height="100%">
-                <Text color="muted">{t(messages.selectBoardEntityFirst)}</Text>
-              </Column>
-            )}
+                    return (
+                      <Row
+                        key={def.type}
+                        tabIndex={0}
+                        gap="3"
+                        alignItems="flex-start"
+                        paddingX="3"
+                        paddingY="2"
+                        borderRadius
+                        backgroundColor={
+                          selectedDef?.type === def.type ? 'surface-sunken' : undefined
+                        }
+                        hover={{ backgroundColor: 'surface-sunken' }}
+                        style={{ cursor: 'pointer' }}
+                        onClick={() => handleSelectComponent(def)}
+                      >
+                        <Icon size={16} />
+                        <Column gap="1">
+                          <Text
+                            size="sm"
+                            weight={selectedDef?.type === def.type ? 'bold' : undefined}
+                          >
+                            {def.name}
+                          </Text>
+                          <Text size="xs" color="muted">
+                            {def.description}
+                          </Text>
+                        </Column>
+                      </Row>
+                    );
+                  })}
+                </Column>
+              ))}
+            </Column>
           </Column>
         </Column>
 
         <Column gap="3" flexGrow={1} height="100%" style={{ minWidth: 0 }}>
           <Text weight="bold">Preview</Text>
           <Column border="left" paddingLeft="4" height="100%" style={{ minWidth: 0 }}>
-            {hasSelectedEntity && previewConfig && (!needsWebsite || resolvedEntityId) ? (
+            {previewConfig && (!needsWebsite || resolvedEntityId) ? (
               <BoardComponentRenderer
                 config={previewConfig}
                 websiteId={resolvedEntityId}
@@ -513,11 +507,9 @@ export function BoardComponentSelect({
             ) : (
               <Column alignItems="center" justifyContent="center" height="100%">
                 <Text color="muted">
-                  {!hasSelectedEntity
+                  {selectedDef && needsWebsite && !resolvedEntityId
                     ? t(messages.selectBoardEntityFirst)
-                    : resolvedEntityId
-                      ? t(messages.selectComponentPreview)
-                      : t(messages.selectBoardEntityFirst)}
+                    : t(messages.selectComponentPreview)}
                 </Text>
               </Column>
             )}

--- a/src/app/(main)/boards/[boardId]/BoardControls.tsx
+++ b/src/app/(main)/boards/[boardId]/BoardControls.tsx
@@ -1,8 +1,9 @@
-import { Box } from '@umami/react-zen';
+import { Box, Row } from '@umami/react-zen';
 import { LinkControls } from '@/app/(main)/links/[linkId]/LinkControls';
 import { PixelControls } from '@/app/(main)/pixels/[pixelId]/PixelControls';
 import { WebsiteControls } from '@/app/(main)/websites/[websiteId]/WebsiteControls';
 import { useBoard } from '@/components/hooks';
+import { WebsiteDateFilter } from '@/components/input/WebsiteDateFilter';
 import { BOARD_ENTITY_TYPES, getBoardEntity, getFirstBoardComponentEntity } from '@/lib/boards';
 
 export function BoardControls() {
@@ -13,7 +14,15 @@ export function BoardControls() {
   const entityId = boardEntity.entityId || fallbackEntity.entityId;
 
   if (!entityId) {
-    return null;
+    // Boards composed only of entity-independent components (e.g. the All
+    // websites group) still need the date range to be visible and adjustable
+    return (
+      <Box marginBottom="4">
+        <Row alignItems="center" justifyContent="flex-end">
+          <WebsiteDateFilter showAllTime={false} />
+        </Row>
+      </Box>
+    );
   }
 
   return (

--- a/src/app/(main)/boards/boardComponentRegistry.tsx
+++ b/src/app/(main)/boards/boardComponentRegistry.tsx
@@ -1,8 +1,8 @@
 import type { ComponentType } from 'react';
 import { TextBlock } from '@/app/(main)/boards/TextBlock';
-import { BoardFunnel } from '@/app/(main)/websites/[websiteId]/(reports)/funnels/BoardFunnel';
 import { LinkMetricsBar } from '@/app/(main)/links/[linkId]/LinkMetricsBar';
 import { PixelMetricsBar } from '@/app/(main)/pixels/[pixelId]/PixelMetricsBar';
+import { BoardFunnel } from '@/app/(main)/websites/[websiteId]/(reports)/funnels/BoardFunnel';
 import { BoardGoal } from '@/app/(main)/websites/[websiteId]/(reports)/goals/BoardGoal';
 import { BoardRevenueChart } from '@/app/(main)/websites/[websiteId]/(reports)/revenue/BoardRevenueChart';
 import { BoardRevenueMetricsBar } from '@/app/(main)/websites/[websiteId]/(reports)/revenue/BoardRevenueMetricsBar';
@@ -27,6 +27,8 @@ import {
   Target,
   Users,
 } from '@/components/icons';
+import { AllWebsitesMetricsBar } from '@/components/metrics/AllWebsitesMetricsBar';
+import { AllWebsitesTable } from '@/components/metrics/AllWebsitesTable';
 import { EventsChart } from '@/components/metrics/EventsChart';
 import { MetricsTable } from '@/components/metrics/MetricsTable';
 import { WeeklyTraffic } from '@/components/metrics/WeeklyTraffic';
@@ -92,16 +94,7 @@ const METRIC_TYPES = [
 ];
 
 const PIXEL_LINK_METRIC_TYPES = METRIC_TYPES.filter(({ value }) =>
-  [
-    'referrer',
-    'channel',
-    'browser',
-    'os',
-    'device',
-    'country',
-    'region',
-    'city',
-  ].includes(value),
+  ['referrer', 'channel', 'browser', 'os', 'device', 'country', 'region', 'city'].includes(value),
 );
 
 const LIMIT_OPTIONS = [
@@ -150,6 +143,36 @@ const componentDefinitions: ComponentDefinition[] = [
       pixel: PixelMetricsBarAdapter,
       link: LinkMetricsBarAdapter,
     },
+  },
+  {
+    type: 'AllWebsitesMetricsBar',
+    name: 'All websites metrics',
+    description: 'Combined visitors, visits, and views across all your websites',
+    category: 'overview',
+    group: 'All websites',
+    icon: PanelTop,
+    component: AllWebsitesMetricsBar,
+    requiresWebsite: false,
+  },
+  {
+    type: 'AllWebsitesTable',
+    name: 'All websites table',
+    description: 'Per-website traffic with trend sparklines',
+    category: 'tables',
+    group: 'All websites',
+    icon: Sheet,
+    component: AllWebsitesTable,
+    requiresWebsite: false,
+    defaultProps: { limit: 10 },
+    configFields: [
+      {
+        name: 'limit',
+        label: 'Rows',
+        type: 'select',
+        options: LIMIT_OPTIONS,
+        defaultValue: '10',
+      },
+    ],
   },
   {
     type: 'EventsMetricsBar',

--- a/src/components/hooks/index.ts
+++ b/src/components/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './context/useWebsite';
 
 // Query hooks
 export * from './queries/useActiveUsersQuery';
+export * from './queries/useAllWebsitesStatsQuery';
 export * from './queries/useApiKeysQuery';
 export * from './queries/useAttributionQuery';
 export * from './queries/useBoardQuery';

--- a/src/components/hooks/queries/useAllWebsitesStatsQuery.ts
+++ b/src/components/hooks/queries/useAllWebsitesStatsQuery.ts
@@ -1,0 +1,101 @@
+import type { ReactQueryOptions } from '@/lib/types';
+import { useApi } from '../useApi';
+import { useDateParameters } from '../useDateParameters';
+import { useModified } from '../useModified';
+
+// /api/websites/charts accepts at most 20 ids per request
+const CHARTS_BATCH_SIZE = 20;
+const STATS_CONCURRENCY = 6;
+const WEBSITES_PAGE_SIZE = 200;
+
+export interface AllWebsitesTotals {
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+}
+
+export interface WebsiteOverview {
+  id: string;
+  name: string;
+  domain: string;
+  stats: AllWebsitesTotals;
+  series: number[];
+}
+
+export interface AllWebsitesStatsData {
+  websites: WebsiteOverview[];
+  totals: AllWebsitesTotals;
+  series: number[];
+}
+
+function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+export function useAllWebsitesStatsQuery(options?: ReactQueryOptions<AllWebsitesStatsData>) {
+  const { get, useQuery } = useApi();
+  const { startAt, endAt, timezone } = useDateParameters();
+  const { modified } = useModified('websites');
+
+  return useQuery<AllWebsitesStatsData>({
+    queryKey: ['websites:all:stats', { startAt, endAt, timezone, modified }],
+    queryFn: async () => {
+      const { data: websites = [] } = await get('/me/websites', {
+        pageSize: WEBSITES_PAGE_SIZE,
+      });
+      const ids: string[] = websites.map(({ id }) => id);
+
+      const charts: Record<string, { values: number[]; total: number }> = {};
+      for (const batch of chunk(ids, CHARTS_BATCH_SIZE)) {
+        const { data } = await get('/websites/charts', {
+          ids: batch.join(','),
+          startAt,
+          endAt,
+          timezone,
+        });
+        Object.assign(charts, data);
+      }
+
+      const statsById: Record<string, AllWebsitesTotals> = {};
+      for (const batch of chunk(ids, STATS_CONCURRENCY)) {
+        await Promise.all(
+          batch.map(async id => {
+            statsById[id] = await get(`/websites/${id}/stats`, { startAt, endAt });
+          }),
+        );
+      }
+
+      const totals: AllWebsitesTotals = {
+        pageviews: 0,
+        visitors: 0,
+        visits: 0,
+        bounces: 0,
+        totaltime: 0,
+      };
+      const series: number[] = [];
+
+      const result: WebsiteOverview[] = websites.map(({ id, name, domain }) => {
+        const stats = statsById[id];
+        const values = charts[id]?.values ?? [];
+
+        for (const key of Object.keys(totals) as (keyof AllWebsitesTotals)[]) {
+          totals[key] += Number(stats?.[key]) || 0;
+        }
+        values.forEach((value, index) => {
+          series[index] = (series[index] ?? 0) + value;
+        });
+
+        return { id, name, domain, stats, series: values };
+      });
+
+      return { websites: result, totals, series };
+    },
+    ...options,
+  });
+}

--- a/src/components/hooks/queries/useAllWebsitesStatsQuery.ts
+++ b/src/components/hooks/queries/useAllWebsitesStatsQuery.ts
@@ -46,9 +46,17 @@ export function useAllWebsitesStatsQuery(options?: ReactQueryOptions<AllWebsites
   return useQuery<AllWebsitesStatsData>({
     queryKey: ['websites:all:stats', { startAt, endAt, timezone, modified }],
     queryFn: async () => {
-      const { data: websites = [] } = await get('/me/websites', {
-        pageSize: WEBSITES_PAGE_SIZE,
-      });
+      const websites: { id: string; name: string; domain: string }[] = [];
+      for (let page = 1; ; page++) {
+        const { data = [], count = 0 } = await get('/me/websites', {
+          page,
+          pageSize: WEBSITES_PAGE_SIZE,
+        });
+        websites.push(...data);
+        if (data.length < WEBSITES_PAGE_SIZE || websites.length >= count) {
+          break;
+        }
+      }
       const ids: string[] = websites.map(({ id }) => id);
 
       const charts: Record<string, { values: number[]; total: number }> = {};

--- a/src/components/metrics/AllWebsitesMetricsBar.tsx
+++ b/src/components/metrics/AllWebsitesMetricsBar.tsx
@@ -1,0 +1,44 @@
+'use client';
+import { useMessages } from '@/components/hooks';
+import { useAllWebsitesStatsQuery } from '@/components/hooks/queries/useAllWebsitesStatsQuery';
+import { formatLongNumber, formatShortTime } from '@/lib/format';
+import { MetricsBar } from './MetricsBar';
+import { StatCard } from './StatCard';
+
+export function AllWebsitesMetricsBar() {
+  const { t, labels } = useMessages();
+  const { data, isLoading } = useAllWebsitesStatsQuery();
+  const { websites = [], totals, series } = data || {};
+
+  const bounceRate =
+    totals?.visits > 0 ? Math.min(100, Math.round((totals.bounces / totals.visits) * 100)) : 0;
+  const avgDuration = totals?.visits > 0 ? totals.totaltime / totals.visits : 0;
+
+  return (
+    <MetricsBar>
+      <StatCard label={t(labels.websites)} value={websites.length} isLoading={isLoading} />
+      <StatCard
+        label={t(labels.visitors)}
+        value={formatLongNumber(totals?.visitors ?? 0)}
+        isLoading={isLoading}
+      />
+      <StatCard
+        label={t(labels.visits)}
+        value={formatLongNumber(totals?.visits ?? 0)}
+        isLoading={isLoading}
+      />
+      <StatCard
+        label={t(labels.views)}
+        value={formatLongNumber(totals?.pageviews ?? 0)}
+        isLoading={isLoading}
+        sparkData={series}
+      />
+      <StatCard label={t(labels.bounceRate)} value={`${bounceRate}%`} isLoading={isLoading} />
+      <StatCard
+        label={t(labels.visitDuration)}
+        value={formatShortTime(Math.round(avgDuration), ['m', 's'], ' ')}
+        isLoading={isLoading}
+      />
+    </MetricsBar>
+  );
+}

--- a/src/components/metrics/AllWebsitesTable.tsx
+++ b/src/components/metrics/AllWebsitesTable.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useMemo } from 'react';
+import { LoadingPanel } from '@/components/common/LoadingPanel';
+import { useAllWebsitesStatsQuery } from '@/components/hooks/queries/useAllWebsitesStatsQuery';
+import { WebsiteStatsTable } from './WebsiteStatsTable';
+
+export function AllWebsitesTable({ limit = 10 }: { limit?: number | string }) {
+  const { data, isLoading, error } = useAllWebsitesStatsQuery();
+
+  const websites = useMemo(() => {
+    return [...(data?.websites ?? [])]
+      .sort((a, b) => (b.stats?.visitors ?? 0) - (a.stats?.visitors ?? 0))
+      .slice(0, Number(limit) || 10);
+  }, [data?.websites, limit]);
+
+  return (
+    <LoadingPanel data={data?.websites} isLoading={isLoading} error={error}>
+      <WebsiteStatsTable websites={websites} />
+    </LoadingPanel>
+  );
+}

--- a/src/components/metrics/SparkLine.tsx
+++ b/src/components/metrics/SparkLine.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { Box } from '@umami/react-zen';
+import ChartJS from 'chart.js/auto';
+import { useEffect, useRef } from 'react';
+
+export interface SparkLineProps {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  fillColor?: string;
+}
+
+export function SparkLine({
+  data,
+  width = 100,
+  height = 32,
+  color = 'rgba(80, 130, 255, 0.9)',
+  fillColor = 'rgba(80, 130, 255, 0.15)',
+}: SparkLineProps) {
+  const canvas = useRef<HTMLCanvasElement>(null);
+  const chart = useRef<ChartJS<'line', number[], number> | null>(null);
+
+  useEffect(() => {
+    if (!canvas.current || !data?.length) return;
+
+    chart.current = new ChartJS(canvas.current, {
+      type: 'line',
+      data: {
+        labels: data.map((_, i) => i),
+        datasets: [
+          {
+            data,
+            borderColor: color,
+            backgroundColor: fillColor,
+            borderWidth: 1.5,
+            fill: true,
+            tension: 0.4,
+            pointRadius: 0,
+            pointHitRadius: 0,
+          },
+        ],
+      },
+      options: {
+        responsive: false,
+        maintainAspectRatio: false,
+        animation: { duration: 0 },
+        plugins: {
+          legend: { display: false },
+          tooltip: { enabled: false },
+        },
+        scales: {
+          x: { display: false },
+          y: { display: false, beginAtZero: true },
+        },
+        elements: {
+          line: { borderJoinStyle: 'round' },
+        },
+      },
+    });
+
+    return () => {
+      chart.current?.destroy();
+    };
+  }, [data, color, fillColor]);
+
+  if (!data?.length) return null;
+
+  return (
+    <Box style={{ width, height, flexShrink: 0 }}>
+      <canvas ref={canvas} width={width} height={height} />
+    </Box>
+  );
+}

--- a/src/components/metrics/StatCard.tsx
+++ b/src/components/metrics/StatCard.tsx
@@ -1,0 +1,36 @@
+'use client';
+import { Column, Heading, Loading, Text } from '@umami/react-zen';
+import { Panel } from '@/components/common/Panel';
+import { SparkLine } from './SparkLine';
+
+export function StatCard({
+  label,
+  value,
+  isLoading,
+  sparkData,
+}: {
+  label: string;
+  value: string | number;
+  isLoading?: boolean;
+  sparkData?: number[];
+}) {
+  return (
+    <Panel>
+      <Column gap="2" alignItems="center" paddingY="2">
+        <Text size="sm" color="muted">
+          {label}
+        </Text>
+        {isLoading ? (
+          <Loading />
+        ) : (
+          <>
+            <Heading size="xl">
+              {typeof value === 'number' ? value.toLocaleString() : value}
+            </Heading>
+            {sparkData && sparkData.length > 1 && <SparkLine data={sparkData} />}
+          </>
+        )}
+      </Column>
+    </Panel>
+  );
+}

--- a/src/components/metrics/WebsiteStatsTable.tsx
+++ b/src/components/metrics/WebsiteStatsTable.tsx
@@ -1,0 +1,114 @@
+'use client';
+import { Column, Icon, Loading, Row, Text } from '@umami/react-zen';
+import Link from 'next/link';
+import { Favicon } from '@/components/common/Favicon';
+import { useMessages, useNavigation } from '@/components/hooks';
+import { SparkLine } from './SparkLine';
+
+export interface WebsiteStatsRow {
+  id: string;
+  name: string;
+  domain: string;
+  stats: {
+    pageviews: number;
+    visitors: number;
+    visits: number;
+    bounces: number;
+    totaltime: number;
+  };
+  series?: number[];
+}
+
+export function WebsiteStatsTable({
+  websites,
+  isLoading,
+}: {
+  websites: WebsiteStatsRow[];
+  isLoading?: boolean;
+}) {
+  const { t, labels } = useMessages();
+  const { renderUrl } = useNavigation();
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!websites.length) {
+    return <Text color="muted">No data available.</Text>;
+  }
+
+  return (
+    <Column gap="0">
+      <Row
+        paddingY="3"
+        paddingX="4"
+        gap="4"
+        style={{
+          borderBottom: '1px solid var(--base300)',
+          fontWeight: 600,
+          fontSize: '0.85rem',
+        }}
+      >
+        <Text style={{ flex: 2 }}>{t(labels.name)}</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{t(labels.visitors)}</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{t(labels.views)}</Text>
+        <Text style={{ width: 100, textAlign: 'center' }}>&nbsp;</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{t(labels.bounceRate)}</Text>
+        <Text style={{ flex: 1, textAlign: 'right' }}>{t(labels.visitDuration)}</Text>
+      </Row>
+      {websites.map(({ id, name, domain, stats, series }) => {
+        const bounceRate = stats?.visits > 0 ? Math.round((stats.bounces / stats.visits) * 100) : 0;
+        const avgDuration = stats?.visits > 0 ? Math.round(stats.totaltime / stats.visits) : 0;
+
+        return (
+          <Row
+            key={id}
+            paddingY="3"
+            paddingX="4"
+            gap="4"
+            alignItems="center"
+            style={{
+              borderBottom: '1px solid var(--base200)',
+              fontSize: '0.875rem',
+            }}
+          >
+            <Link
+              href={renderUrl(`/websites/${id}`)}
+              style={{ flex: 2, textDecoration: 'none', color: 'inherit' }}
+            >
+              <Row alignItems="center" gap="3">
+                <Icon size="md" color="muted">
+                  <Favicon domain={domain} />
+                </Icon>
+                <Column>
+                  <Text>{name}</Text>
+                  <Text size="xs" color="muted">
+                    {domain}
+                  </Text>
+                </Column>
+              </Row>
+            </Link>
+            <Text style={{ flex: 1, textAlign: 'right' }}>
+              {stats?.visitors?.toLocaleString() || '0'}
+            </Text>
+            <Text style={{ flex: 1, textAlign: 'right' }}>
+              {stats?.pageviews?.toLocaleString() || '0'}
+            </Text>
+            <Row style={{ width: 100 }} justifyContent="center">
+              {series && series.length > 1 && <SparkLine data={series} width={80} height={24} />}
+            </Row>
+            <Text style={{ flex: 1, textAlign: 'right' }}>{bounceRate}%</Text>
+            <Text style={{ flex: 1, textAlign: 'right' }}>{formatDuration(avgDuration)}</Text>
+          </Row>
+        );
+      })}
+    </Column>
+  );
+}
+
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}m ${secs}s`;
+}


### PR DESCRIPTION
Implements the multi-website overview as board components, following the direction suggested in #4056 — the aggregate view lives in the boards system rather than a dedicated dashboard route.

## What's included

A new **All websites** component group in the board component picker. Both components are entity-independent (`requiresWebsite: false`):

- **All websites metrics** — combined visitors, visits, and views across every website the user can access, with an aggregate trend sparkline, plus overall bounce rate, average visit duration, and website count.
- **All websites table** — one row per website (favicon, name, domain, visitors, views, trend sparkline, bounce rate, visit duration), sorted by visitors, with a configurable row limit.

The `SparkLine`, `StatCard`, and `WebsiteStatsTable` presentation components are ported from #4056 (authorship preserved — credit @petebytes) into `src/components/metrics/`, adapted to the current `useMessages` API and react-zen size scales.

### Data flow

A shared `useAllWebsitesStatsQuery` hook composes existing endpoints — no API changes:

1. `/me/websites` for the website list
2. `/websites/charts` for trend series, batched 20 ids per request
3. `/websites/{id}/stats` fanned out 6 at a time, summed client-side

Both components read the shared date-range state, so they follow the board's date filter like any other panel.

## Follow-up commits since opening

Two issues surfaced while exercising the components on a live instance — both are latent board-system gaps that only manifest once entity-independent components exist:

1. **Component picker: show entity-independent components before an entity is selected** (12e16fe). The component list was hidden until a website/pixel/link was chosen, which forced a meaningless website pick before an "All websites" panel could be added. The list now always renders (All websites group ordered first), and the preview pane prompts for an entity only when the selected component actually requires one.
2. **Boards: show a date filter when no component is entity-bound** (b51b8e8). `BoardControls` returned `null` when neither the board nor any component had an `entityId`, so a board composed purely of entity-independent panels had no visible or adjustable date range — panels silently used the persisted/default global range. It now renders a standalone `WebsiteDateFilter` in that case ("All time" hidden, since that option derives from a single website's data range).

## Testing

- Deployed on a self-hosted instance (postgres flavor) tracking 6 websites, seeded with 14 days of traffic across a pool of distinct visitors, referrers, UTM campaigns, and devices.
- Verified: aggregate totals reconcile with the per-website stats pages across date ranges; sparklines follow the selected range; table sorting and row-limit config; picker flow with and without an entity selected; date filter appears on an all-websites-only board and drives all panels.
- `tsc` and `biome check` clean.

## Screenshots

<!-- panels -->
<img width="1420" height="927" alt="Screenshot 2026-08-03 at 21 10 13" src="https://github.com/user-attachments/assets/e30a906d-6676-4090-867d-65d71b2e2469" />

<!-- component picker -->
<img width="1253" height="806" alt="Screenshot 2026-08-03 at 21 10 51" src="https://github.com/user-attachments/assets/5fdb1ab1-b6f8-4255-bc86-a676afb826a7" />

<!-- date filter on an entity-free board -->

## Open questions

- **Team scoping** — team boards currently fall back to the user's own websites (`/me/websites`). Happy to add a scope config field (user vs. team websites) if wanted.
- **All time** — hidden in the entity-free date filter because it's computed from a single website's first-event date. A cross-website date range would need a small API addition.
- **Aggregation location** — the `/stats` fan-out is client-side to keep the diff API-free. If a server-side aggregate endpoint is preferred (e.g. extending `getWebsiteStats` to accept multiple ids), glad to take that on.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788403373&installation_model_id=22160&pr_number=4420&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4420&signature=da33b5e99a9374294e0fd7641842f188c54161419a9204b8a4d0bdd0bb112ef9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->