### PR TITLE
Support distinct ID tracker attribute

### DIFF
--- a/src/tracker/index.test.ts
+++ b/src/tracker/index.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, expect, test, vi } from 'vitest';
+
+afterEach(() => {
+  delete (window as Window & { umami?: unknown }).umami;
+  delete (document as Document & { currentScript?: HTMLScriptElement }).currentScript;
+  delete (document as Document & { readyState?: DocumentReadyState }).readyState;
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+test('identifies data-distinct-id before the initial page view', async () => {
+  const script = document.createElement('script');
+  script.src = 'https://analytics.example.com/script.js';
+  script.dataset.websiteId = 'website-id';
+  script.dataset.distinctId = 'visitor-id';
+
+  Object.defineProperties(document, {
+    currentScript: { configurable: true, value: script },
+    readyState: { configurable: true, value: 'complete' },
+  });
+
+  const fetchMock = vi.fn().mockResolvedValue({ json: vi.fn().mockResolvedValue({}) });
+  vi.stubGlobal('fetch', fetchMock);
+
+  await import('./index');
+
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+  const requests = fetchMock.mock.calls.map(([, init]) => JSON.parse(init.body));
+
+  expect(requests[0]).toMatchObject({
+    type: 'identify',
+    payload: { id: 'visitor-id', website: 'website-id' },
+  });
+  expect(requests[1]).toMatchObject({
+    type: 'event',
+    payload: { id: 'visitor-id', website: 'website-id' },
+  });
+});

--- a/src/tracker/index.ts
+++ b/src/tracker/index.ts
@@ -241,6 +241,7 @@ type MetricEntry = PerformanceEntry & {
   const website = config('website-id');
   const hostUrl = config('host-url');
   const beforeSend = config('before-send');
+  const distinctId = config('distinct-id') || undefined;
   const tag = config('tag') || undefined;
   const autoTrack = config('auto-track') !== _false;
   const dnt = config('do-not-track') === _true;
@@ -636,8 +637,12 @@ type MetricEntry = PerformanceEntry & {
   let initialized = false;
   let disabled = false;
   let cache: string | undefined;
-  let identity: string | undefined;
+  let identity = distinctId;
   let flushPerformance: (() => void) | undefined;
+
+  if (distinctId) {
+    void identify(distinctId);
+  }
 
   if (autoTrack && !trackingDisabled()) {
     if (document.readyState === 'complete') {


### PR DESCRIPTION
Fixes #3411.

## Summary

- read data-distinct-id before automatic tracking starts
- send the configured ID in the initial identify request and first pageview
- add a focused tracker regression test

## Validation

- Vitest: 1 test passed
- tracker TypeScript check
- Biome check

OpenAI Codex assisted with implementation and validation; I reviewed the final diff and test output.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788404106&installation_model_id=22160&pr_number=4421&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4421&signature=80e4fd70d590ceadaa0210da8d411d75b3a1aa58718068a15701e8ca5cba46c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->