### PR TITLE
feat(replays): Add next/previous navigation to session replays modal

### DIFF
--- a/src/app/(main)/websites/[websiteId]/replays/ReplaysTable.tsx
+++ b/src/app/(main)/websites/[websiteId]/replays/ReplaysTable.tsx
@@ -1,10 +1,12 @@
 import { Button, DataColumn, DataTable, type DataTableProps, Icon } from '@umami/react-zen';
+import { useEffect } from 'react';
 import { Play } from 'lucide-react';
 import { Avatar } from '@/components/common/Avatar';
 import { DateDistance } from '@/components/common/DateDistance';
 import Link from '@/components/common/Link';
 import { TypeIcon } from '@/components/common/TypeIcon';
 import { useFormat, useMessages, useNavigation } from '@/components/hooks';
+import { setReplays } from '@/store/replays';
 
 function formatDuration(ms: number) {
   const seconds = Math.floor(ms / 1000);
@@ -17,6 +19,10 @@ export function ReplaysTable({ ...props }: DataTableProps) {
   const { t, labels } = useMessages();
   const { formatValue } = useFormat();
   const { router, updateParams } = useNavigation();
+
+  useEffect(() => {
+    setReplays(props.data || []);
+  }, [props.data]);
 
   return (
     <DataTable {...props}>

--- a/src/app/(main)/websites/[websiteId]/replays/SavedReplaysTable.tsx
+++ b/src/app/(main)/websites/[websiteId]/replays/SavedReplaysTable.tsx
@@ -3,9 +3,16 @@ import { Play } from 'lucide-react';
 import { DateDistance } from '@/components/common/DateDistance';
 import { useMessages, useNavigation } from '@/components/hooks';
 
+import { useEffect } from 'react';
+import { setReplays } from '@/store/replays';
+
 export function SavedReplaysTable({ ...props }: DataTableProps) {
   const { t, labels } = useMessages();
   const { router, updateParams } = useNavigation();
+
+  useEffect(() => {
+    setReplays(props.data || []);
+  }, [props.data]);
 
   return (
     <DataTable {...props}>

--- a/src/app/(main)/websites/[websiteId]/replays/[replayId]/ReplayPlayback.tsx
+++ b/src/app/(main)/websites/[websiteId]/replays/[replayId]/ReplayPlayback.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { Button, Column, Dialog, DialogTrigger, Icon, Popover, Row, Text } from '@umami/react-zen';
-import { Bookmark, X } from 'lucide-react';
+import { Bookmark, ChevronLeft, ChevronRight, X } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { SessionInfo } from '@/app/(main)/websites/[websiteId]/sessions/SessionInfo';
 import { Avatar } from '@/components/common/Avatar';
@@ -8,11 +8,13 @@ import { LoadingPanel } from '@/components/common/LoadingPanel';
 import {
   useMessages,
   useMobile,
+  useNavigation,
   useReplayQuery,
   useReplaySavedQuery,
   useUpdateQuery,
   useWebsiteSessionQuery,
 } from '@/components/hooks';
+import { useReplays } from '@/store/replays';
 import { touch } from '@/components/hooks/useModified';
 import { getReplayViewport } from '@/lib/replay';
 import { ReplayPlayer } from './ReplayPlayer';
@@ -38,8 +40,18 @@ export function ReplayPlayback({
   const { data: session } = useWebsiteSessionQuery(websiteId, replay?.sessionId);
   const { t, labels } = useMessages();
   const { isMobile } = useMobile();
+  const { router, updateParams } = useNavigation();
   const [isSaved, setIsSaved] = useState<boolean | null>(null);
   const { mutate } = useUpdateQuery(`/websites/${websiteId}/replays/saved/${replayId}`);
+  const replays = useReplays(state => state.replays);
+
+  const currentIndex = replays.findIndex(r => r.id === replayId || r.visitId === replayId);
+  const prevReplay = currentIndex > 0 ? replays[currentIndex - 1] : null;
+  const nextReplay = currentIndex !== -1 && currentIndex < replays.length - 1 ? replays[currentIndex + 1] : null;
+
+  const navigateToReplay = (id: string) => {
+    router.push(updateParams({ replay: id }));
+  };
   const replayViewport = useMemo(() => getReplayViewport(replay?.events), [replay?.events]);
   const replayOrientation: ReplayOrientation | null = replayViewport
     ? replayViewport.height > replayViewport.width
@@ -54,6 +66,23 @@ export function ReplayPlayback({
   useEffect(() => {
     onReplayStateChange?.(replayOrientation);
   }, [replayOrientation, onReplayStateChange]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (['INPUT', 'TEXTAREA', 'SELECT'].includes((e.target as HTMLElement)?.tagName)) return;
+
+      if (e.key === 'ArrowLeft' && prevReplay) {
+        e.preventDefault();
+        navigateToReplay(prevReplay.id || prevReplay.visitId);
+      } else if (e.key === 'ArrowRight' && nextReplay) {
+        e.preventDefault();
+        navigateToReplay(nextReplay.id || nextReplay.visitId);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [prevReplay, nextReplay, router, updateParams]);
 
   const handleUnsave = () => {
     setIsSaved(false);
@@ -87,6 +116,16 @@ export function ReplayPlayback({
                 </Column>
               </Row>
               <Row gap="2" style={{ flex: '0 0 auto' }}>
+                <Button variant="quiet" isDisabled={!prevReplay} onPress={() => prevReplay && navigateToReplay(prevReplay.id || prevReplay.visitId)}>
+                  <Icon>
+                    <ChevronLeft />
+                  </Icon>
+                </Button>
+                <Button variant="quiet" isDisabled={!nextReplay} onPress={() => nextReplay && navigateToReplay(nextReplay.id || nextReplay.visitId)}>
+                  <Icon>
+                    <ChevronRight />
+                  </Icon>
+                </Button>
                 {saved ? (
                   <Button onPress={handleUnsave} variant="quiet">
                     <Icon>

--- a/src/app/(main)/websites/[websiteId]/replays/[replayId]/ReplayPlayback.tsx
+++ b/src/app/(main)/websites/[websiteId]/replays/[replayId]/ReplayPlayback.tsx
@@ -44,8 +44,9 @@ export function ReplayPlayback({
   const [isSaved, setIsSaved] = useState<boolean | null>(null);
   const { mutate } = useUpdateQuery(`/websites/${websiteId}/replays/saved/${replayId}`);
   const replays = useReplays(state => state.replays);
+  const getReplayId = (r: any) => r.visitId || r.id;
 
-  const currentIndex = replays.findIndex(r => r.id === replayId || r.visitId === replayId);
+  const currentIndex = replays.findIndex(r => getReplayId(r) === replayId);
   const prevReplay = currentIndex > 0 ? replays[currentIndex - 1] : null;
   const nextReplay = currentIndex !== -1 && currentIndex < replays.length - 1 ? replays[currentIndex + 1] : null;
 
@@ -73,10 +74,10 @@ export function ReplayPlayback({
 
       if (e.key === 'ArrowLeft' && prevReplay) {
         e.preventDefault();
-        navigateToReplay(prevReplay.id || prevReplay.visitId);
+        navigateToReplay(getReplayId(prevReplay));
       } else if (e.key === 'ArrowRight' && nextReplay) {
         e.preventDefault();
-        navigateToReplay(nextReplay.id || nextReplay.visitId);
+        navigateToReplay(getReplayId(nextReplay));
       }
     };
 
@@ -116,12 +117,12 @@ export function ReplayPlayback({
                 </Column>
               </Row>
               <Row gap="2" style={{ flex: '0 0 auto' }}>
-                <Button variant="quiet" isDisabled={!prevReplay} onPress={() => prevReplay && navigateToReplay(prevReplay.id || prevReplay.visitId)}>
+                <Button variant="quiet" isDisabled={!prevReplay} onPress={() => prevReplay && navigateToReplay(getReplayId(prevReplay))}>
                   <Icon>
                     <ChevronLeft />
                   </Icon>
                 </Button>
-                <Button variant="quiet" isDisabled={!nextReplay} onPress={() => nextReplay && navigateToReplay(nextReplay.id || nextReplay.visitId)}>
+                <Button variant="quiet" isDisabled={!nextReplay} onPress={() => nextReplay && navigateToReplay(getReplayId(nextReplay))}>
                   <Icon>
                     <ChevronRight />
                   </Icon>

--- a/src/store/replays.ts
+++ b/src/store/replays.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+interface ReplaysStore {
+  replays: any[];
+}
+
+const store = create<ReplaysStore>(() => ({
+  replays: [],
+}));
+
+export function setReplays(replays: any[]) {
+  store.setState({ replays });
+}
+
+export const useReplays = store;


### PR DESCRIPTION
### PR Description
**What does this PR do?**
This PR adds the ability to seamlessly navigate between consecutive session replays directly from the playback modal, without needing to close it and return to the data table. 

**Changes included:**
- **Global Store**: Introduces a new `useReplays` Zustand store (`src/store/replays.ts`) to track the list of replays currently being viewed on the active page (works for both the standard Replays table and the Saved Replays table).
- **UI Controls**: Adds "Previous" (`ChevronLeft`) and "Next" (`ChevronRight`) action buttons to the `ReplayPlayback` header. These automatically disable when the user reaches the beginning or end of the visible list.
- **Keyboard Shortcuts**: Implements `ArrowLeft` and `ArrowRight` keyboard navigation inside the modal to quickly jump between adjacent replays. The event listener is attached via the capture phase to bypass any potential focus traps, and prevents default action to avoid conflicting with the `rrweb-player`'s internal seeking controls.

Closes: #4416

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788721725&installation_model_id=22160&pr_number=4431&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4431&signature=b4ef7e99b0749669469cc4b12453a4565b2df248f17fa9899534d8d2568e5672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->