### PR TITLE
fix(funnel): add client-side validation to funnel window input

### DIFF
--- a/public/intl/messages/en-US.json
+++ b/public/intl/messages/en-US.json
@@ -442,6 +442,7 @@
     "go-to-settings": "Go to settings",
     "incorrect-username-password": "Incorrect username and/or password.",
     "invalid-domain": "Invalid domain. Do not include http/https.",
+    "invalid-value": "Invalid value",
     "min-password-length": "Minimum length of {n} characters",
     "new-version-available": "A new version of Umami {version} is available!",
     "no-data-available": "No data available.",

--- a/src/app/(main)/websites/[websiteId]/(reports)/funnels/FunnelEditForm.tsx
+++ b/src/app/(main)/websites/[websiteId]/(reports)/funnels/FunnelEditForm.tsx
@@ -200,7 +200,14 @@ export function FunnelEditForm({
       <FormField name="name" label={t(labels.name)} rules={{ required: t(labels.required) }}>
         <TextField autoFocus />
       </FormField>
-      <FormField name="window" label={t(labels.window)} rules={{ required: t(labels.required) }}>
+      <FormField
+        name="window"
+        label={t(labels.window)}
+        rules={{
+          required: t(labels.required),
+          pattern: { value: /^[1-9][0-9]*$/, message: t(labels.invalidValue) || 'Must be greater than 0' },
+        }}
+      >
         <TextField />
       </FormField>
       <FormFieldArray

--- a/src/components/messages.ts
+++ b/src/components/messages.ts
@@ -362,6 +362,7 @@ export const labels: Record<string, string> = {
   slug: 'label.slug',
   audience: 'label.audience',
   invalidUrl: 'label.invalid-url',
+  invalidValue: 'message.invalid-value',
   environment: 'label.environment',
   criteria: 'label.criteria',
   share: 'label.share',


### PR DESCRIPTION
### PR Description
**What does this PR do?**
This PR fixes a bug where users could accidentally create a Funnel report with an invalid or negative "window" time (e.g. `0`, `-1`, or `-`), which would corrupt the funnel and prevent it from being loaded or deleted later in the UI.

**Changes included:**
- **Added regex validation:** Updated the `window` input field in `FunnelEditForm.tsx` to use a `pattern` validation (`/^[1-9][0-9]*$/`). This enforces that the window value must be a positive integer > 0.


Closes: #4432, #4433

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788778098&installation_model_id=22160&pr_number=4434&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4434&signature=ee10dc5db21e99ffdd5b301ac40276db236ac5d64dc5bb1d3c14d9c18b9a9eb2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->