### PR TITLE
fix(sessions): resolve duplicate session_data rows on concurrent identify

### DIFF
--- a/prisma/migrations/21_session_data_unique_key/migration.sql
+++ b/prisma/migrations/21_session_data_unique_key/migration.sql
@@ -1,0 +1,20 @@
+-- Collapse rows that share a session and key, keeping the most recent one.
+-- Ordering falls back to the primary key so rows written within the same
+-- timestamp, or before created_at had a default, resolve deterministically.
+DELETE FROM "session_data"
+WHERE "session_data_id" IN (
+    SELECT "session_data_id"
+    FROM (
+        SELECT
+            "session_data_id",
+            row_number() OVER (
+                PARTITION BY "session_id", "data_key"
+                ORDER BY "created_at" DESC NULLS LAST, "session_data_id" DESC
+            ) AS rn
+        FROM "session_data"
+    ) ranked
+    WHERE rn > 1
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "session_data_session_id_data_key_key" ON "session_data"("session_id", "data_key");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -187,6 +187,7 @@ model SessionData {
   website Website @relation(fields: [websiteId], references: [id])
   session Session @relation(fields: [sessionId], references: [id])
 
+  @@unique([sessionId, dataKey])
   @@index([createdAt])
   @@index([websiteId])
   @@index([sessionId])

--- a/src/queries/sql/sessions/saveSessionData.ts
+++ b/src/queries/sql/sessions/saveSessionData.ts
@@ -49,24 +49,28 @@ export async function relationalQuery({
   }));
 
   for (const data of flattenedData) {
-    const { sessionId, dataKey, ...props } = data;
+    const { id, sessionId, dataKey, ...props } = data;
 
-    const updateResult = await client.sessionData.updateMany({
+    // The unique key lets concurrent calls for the same session resolve in the
+    // database: a collision becomes an update. The generated id belongs to the
+    // insert alone — assigning it on an update would move the primary key.
+    await client.sessionData.upsert({
       where: {
+        sessionId_dataKey: {
+          sessionId,
+          dataKey,
+        },
+      },
+      create: {
+        id,
         sessionId,
         dataKey,
+        ...props,
       },
-      data: {
+      update: {
         ...props,
       },
     });
-
-    // If no record was updated, create a new one
-    if (updateResult.count === 0) {
-      await client.sessionData.create({
-        data,
-      });
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #4183

## Root cause

`session_data` has a primary key on `session_data_id`, but nothing enforces uniqueness on `(session_id, data_key)`. `saveSessionData` compensates with `updateMany` on that pair, falling back to `create` when nothing was updated. The two statements are not atomic, so concurrent `/api/send` calls for the same session — common when several `identify` payloads fire close together — both observe zero updated rows and both insert.

From then on the session is stuck. `updateMany` carries a freshly generated `id` in its update data, so with duplicates present it tries to assign one uuid to several rows and fails with `P2002` on `session_data_pkey`. Session ids are stable for the salt rotation window, so every subsequent `identify` for that visitor fails the same way and the data is silently dropped.

## Change

- `@@unique([sessionId, dataKey])` on `SessionData` — the constraint the write path already assumes, matching how `WebsiteEvent` keys `websiteId_visitId`.
- Migration `21_session_data_unique_key` collapses existing duplicates, keeping the most recent row per pair, then creates the index.
- `relationalQuery` upserts on the new key. The generated `id` moves to the `create` branch only; assigning it during an update is what produced the primary key collision.

Concurrent inserts now resolve in the database rather than between two statements, and a poisoned session can no longer exist.

## Migration cost

The dedupe is a single `DELETE` driven by a window function over `session_data`. On a large installation this is the expensive part of the migration, and it runs in the same transaction as the index creation. Ordering is `created_at DESC NULLS LAST, session_data_id DESC`, so rows written within the same timestamp — or before `created_at` carried a default — resolve deterministically instead of being skipped.

If a staged approach is preferred for large deployments, the delete can be batched ahead of the constraint in a separate migration; happy to restructure.

## Testing

Verified: schema validates, and the generated client exposes `sessionId_dataKey` on `SessionDataWhereUniqueInput`, so the upsert target is correct.

Not verified: I have not run this against a live PostgreSQL instance, so the concurrent behaviour is argued from the constraint semantics rather than reproduced. The claim is that Prisma's `upsert` against a unique key resolves the collision at the database level where two separate statements could not. Worth a maintainer reproducing before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789070094&installation_model_id=22160&pr_number=4440&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4440&signature=4d4426def3a6f92fb2346a5d462703fc3d8b7b912dd470b14077e9fb786df8c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->