### PR TITLE
Add TWD (New Taiwan Dollar) to the revenue currency list

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -705,6 +705,7 @@ export const CURRENCIES = [
   { id: 'MYR', name: 'Malaysian Ringgit' },
   { id: 'INR', name: 'Indian Rupee' },
   { id: 'KRW', name: 'South Korean Won' },
+  { id: 'TWD', name: 'New Taiwan Dollar' },
   { id: 'BRL', name: 'Brazilian Real' },
   { id: 'TRY', name: 'Turkish Lira' },
   { id: 'CZK', name: 'Czech Koruna' },


### PR DESCRIPTION
## What

Adds `TWD` (New Taiwan Dollar, ISO 4217) to `CURRENCIES` in `src/lib/constants.ts`.

## Why

Revenue events tracked with `umami.track('purchase', { revenue: 2980, currency: 'TWD' })` are stored correctly, but the Revenue report filters by a currency picked from `CURRENCIES`. Because `TWD` is not in that list, there is no way to select it and the data is unreachable in the UI — the report shows 0 for every selectable currency.

Taiwan is a sizeable e-commerce market and the list already covers its regional neighbours (JPY, KRW, HKD, SGD, THB, MYR, VND, PHP, IDR), so this looks like an omission rather than an intentional exclusion. Placed next to KRW to keep the East Asian currencies together.

No other changes are needed — formatting already goes through `Intl.NumberFormat`, which supports `TWD`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4444"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789141558&installation_model_id=22160&pr_number=4444&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4444&signature=8751d1e824b4ef1a7560dc5c8578dd357449d40465911e4549604d7eeedf621a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->