### PR TITLE
Fix funnel step editor crash on null event values

### DIFF
--- a/src/app/api/websites/[websiteId]/values/route.ts
+++ b/src/app/api/websites/[websiteId]/values/route.ts
@@ -54,5 +54,5 @@ export async function GET(
     values = await getValues(websiteId, FILTER_COLUMNS[type], filters);
   }
 
-  return json(values.filter(n => n).sort());
+  return json(values.filter(n => n?.value != null).sort());
 }


### PR DESCRIPTION
## Summary

The funnel step editor crashes with `TypeError: Cannot read properties of null (reading 'value')` as soon as you add a step of type **Triggered event**, on any website that has pageviews.

## Root cause

`GET /api/websites/{websiteId}/values?type=event` is meant to return the list of event names for the picker. `getValues` returns `{ value, count }` **objects**, but the route's post-processing guard filters on the *object*:

```ts
return json(values.filter(n => n).sort());
```

`{ value: null, count: N }` is a truthy object, so the null-named **pageview** bucket (pageviews have `event_name = NULL`) passes straight through:

```json
[
  { "value": null, "count": 4800 },
  { "value": "wiz_step_view", "count": 2821 },
  ...
]
```

`LookupField` then does `data?.map(({ value }) => value)` → `items = [null, ...]`, and the `null` flows into react-zen's `ComboBox` / `ListItem`, which dereferences it and throws.

The `filter(n => n)` was correct back when `getValues` returned scalar values; once the shape became `{ value, count }` the guard silently stopped filtering.

## Fix

Filter on the entry's `value` instead of the entry itself — one line in `src/app/api/websites/[websiteId]/values/route.ts`:

```diff
-  return json(values.filter(n => n).sort());
+  return json(values.filter(n => n?.value != null).sort());
```

This drops null-valued buckets (and still guards against null entries).

## Reproduction

1. A website with normal pageviews plus at least one custom event.
2. Reports → Funnel → **Add step** → **Triggered event**.
3. Editor throws before the fix; works after.

## Environment

Observed on v3.3.0 (self-hosted, PostgreSQL).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789210770&installation_model_id=22160&pr_number=4447&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4447&signature=5c7c76b625d8381af00f862d2e7bb4bcd8fc694622b84b066facb62fd7ef2714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->