### PR TITLE
fix(send): keep the root path when REMOVE_TRAILING_SLASH is enabled

### DIFF
--- a/src/app/api/send/route.test.ts
+++ b/src/app/api/send/route.test.ts
@@ -482,6 +482,39 @@ describe('event url and referrer parsing', () => {
     expect(saveEventMock.mock.calls[0][0]).toMatchObject({ urlPath: '/blog' });
   });
 
+  test('REMOVE_TRAILING_SLASH keeps the root path as "/"', async () => {
+    process.env.REMOVE_TRAILING_SLASH = '1';
+
+    await callPOST({
+      type: 'event',
+      payload: { website: WEBSITE_ID, hostname: 'example.com', url: '/' },
+    });
+
+    expect(saveEventMock.mock.calls[0][0]).toMatchObject({ urlPath: '/' });
+  });
+
+  test('REMOVE_TRAILING_SLASH keeps the root path when the url has a hash', async () => {
+    process.env.REMOVE_TRAILING_SLASH = '1';
+
+    await callPOST({
+      type: 'event',
+      payload: { website: WEBSITE_ID, hostname: 'example.com', url: '/#hero' },
+    });
+
+    expect(saveEventMock.mock.calls[0][0]).toMatchObject({ urlPath: '/#hero' });
+  });
+
+  test('REMOVE_TRAILING_SLASH strips a trailing slash before the hash', async () => {
+    process.env.REMOVE_TRAILING_SLASH = '1';
+
+    await callPOST({
+      type: 'event',
+      payload: { website: WEBSITE_ID, hostname: 'example.com', url: '/blog/#hero' },
+    });
+
+    expect(saveEventMock.mock.calls[0][0]).toMatchObject({ urlPath: '/blog#hero' });
+  });
+
   test('maps a "/undefined" pathname to an empty url path', async () => {
     await callPOST({
       type: 'event',

--- a/src/app/api/send/route.ts
+++ b/src/app/api/send/route.ts
@@ -214,7 +214,8 @@ export async function POST(request: Request) {
       const twclid = currentUrl.searchParams.get('twclid');
 
       if (process.env.REMOVE_TRAILING_SLASH) {
-        urlPath = urlPath.replace(/\/(?=(#.*)?$)/, '');
+        // Never strip the root slash, otherwise the home page is saved with an empty path
+        urlPath = urlPath.replace(/(?!^)\/(?=(#.*)?$)/, '');
       }
 
       if (referrer) {


### PR DESCRIPTION
With REMOVE_TRAILING_SLASH set, the regex also matched the leading slash, so a view of "/" was stored with an empty url_path and "/#hero" became "#hero". The home page then dropped out of the paths, entry and exit reports, and it could not be picked as a funnel step.

The regex now skips a match at the start of the path. "/" and "/#hero" stay as they are, "/blog/" and "/blog/#hero" are still trimmed to "/blog" and "/blog#hero".

Three tests are in src/app/api/send/route.test.ts, next to the existing REMOVE_TRAILING_SLASH test. The first two fail on the old regex. This only changes new events, rows already saved with an empty path stay as they are.

Closes #4152

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789276080&installation_model_id=22160&pr_number=4451&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4451&signature=474781de8ec3d997b310c96ff06b1aa7217b63c55809d4a0dea7bf37fb8545f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

