### PR TITLE
fix(auth): lowercase existing usernames so pre-3.2 accounts can log in

### DIFF
--- a/prisma/migrations/24_lowercase_username/migration.sql
+++ b/prisma/migrations/24_lowercase_username/migration.sql
@@ -1,0 +1,15 @@
+-- Usernames are normalized to lowercase on lookup, creation and update, but accounts
+-- created before that change may still be stored with uppercase characters, which makes
+-- them impossible to log in to. Lowercase them so they match what the login query looks for.
+-- Accounts that would collide with another account once lowercased are left untouched so
+-- this migration can never fail on the unique username constraint.
+UPDATE "user" AS u
+SET "username" = LOWER(u."username")
+WHERE u."deleted_at" IS NULL
+  AND u."username" <> LOWER(u."username")
+  AND NOT EXISTS (
+    SELECT 1
+    FROM "user" AS c
+    WHERE c."user_id" <> u."user_id"
+      AND LOWER(c."username") = LOWER(u."username")
+  );

--- a/src/app/api/auth/login/route.test.ts
+++ b/src/app/api/auth/login/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  parseRequest: vi.fn(),
+  getUserByUsername: vi.fn(),
+  getAllUserTeams: vi.fn(),
+  checkPassword: vi.fn(),
+  createSecureToken: vi.fn(),
+  saveAuth: vi.fn(),
+  findTwoFactorAuth: vi.fn(),
+  hash: vi.fn(),
+  secret: vi.fn(),
+}));
+
+vi.mock('@/lib/auth', () => ({
+  saveAuth: mocks.saveAuth,
+}));
+
+vi.mock('@/lib/crypto', () => ({
+  hash: mocks.hash,
+  secret: mocks.secret,
+}));
+
+vi.mock('@/lib/jwt', () => ({
+  createSecureToken: mocks.createSecureToken,
+}));
+
+vi.mock('@/lib/password', () => ({
+  checkPassword: mocks.checkPassword,
+}));
+
+vi.mock('@/lib/prisma', () => ({
+  default: {
+    client: {
+      twoFactorAuth: {
+        findUnique: mocks.findTwoFactorAuth,
+      },
+    },
+  },
+}));
+
+vi.mock('@/lib/redis', () => ({
+  default: {
+    enabled: false,
+  },
+}));
+
+vi.mock('@/lib/request', () => ({
+  parseRequest: mocks.parseRequest,
+}));
+
+vi.mock('@/queries/prisma', () => ({
+  getAllUserTeams: mocks.getAllUserTeams,
+  getUserByUsername: mocks.getUserByUsername,
+}));
+
+import { POST } from './route';
+
+function createRequest(username: string) {
+  return new Request('http://localhost/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password: 'password' }),
+  });
+}
+
+beforeEach(() => {
+  mocks.parseRequest.mockReset();
+  mocks.getUserByUsername.mockReset();
+  mocks.getAllUserTeams.mockReset();
+  mocks.checkPassword.mockReset();
+  mocks.createSecureToken.mockReset();
+  mocks.saveAuth.mockReset();
+  mocks.findTwoFactorAuth.mockReset();
+  mocks.hash.mockReset();
+  mocks.secret.mockReset();
+
+  mocks.parseRequest.mockResolvedValue({
+    body: { username: 'KaKi87', password: 'password' },
+    error: undefined,
+  });
+  mocks.getUserByUsername.mockResolvedValue({
+    id: 'user-1',
+    username: 'kaki87',
+    password: 'password-hash',
+    role: 'admin',
+    createdAt: new Date('2026-07-23T00:00:00.000Z'),
+  });
+  mocks.checkPassword.mockReturnValue(true);
+  mocks.findTwoFactorAuth.mockResolvedValue(null);
+  mocks.getAllUserTeams.mockResolvedValue([]);
+  mocks.hash.mockReturnValue('password-fingerprint');
+  mocks.secret.mockReturnValue('app-secret');
+  mocks.createSecureToken.mockReturnValue('auth-token');
+});
+
+test('POST returns the stored username instead of the submitted one', async () => {
+  const response = await POST(createRequest('KaKi87'));
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    token: 'auth-token',
+    user: {
+      id: 'user-1',
+      username: 'kaki87',
+      isAdmin: true,
+    },
+  });
+});
+
+test('POST returns unauthorized when the username does not match a user', async () => {
+  mocks.getUserByUsername.mockResolvedValue(null);
+
+  const response = await POST(createRequest('KaKi87'));
+
+  expect(mocks.checkPassword).not.toHaveBeenCalled();
+  expect(response.status).toBe(401);
+  await expect(response.json()).resolves.toMatchObject({
+    error: { code: 'incorrect-username-password' },
+  });
+});

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -59,6 +59,7 @@ export async function POST(request: Request) {
 
   return json({
     token,
-    user: { id, username, role, createdAt, isAdmin: role === ROLES.admin, teams },
+    // Return the stored username, not the submitted one, which may differ in case.
+    user: { id, username: user.username, role, createdAt, isAdmin: role === ROLES.admin, teams },
   });
 }


### PR DESCRIPTION
Accounts created before 3.2 can have uppercase letters in their username. 3.2 lowercases the username on lookup but the query is still an exact findUnique, and nothing lowercased the existing rows, so those accounts get "incorrect username and/or password" even though the password hash is still fine.

This adds a migration that lowercases stored usernames. Rows that would collide with another account once lowercased are skipped so it cannot fail on the unique constraint. The login route now returns the stored username instead of echoing back whatever case was typed.

Tests are in src/app/api/auth/login/route.test.ts. One checks the response carries the stored username when the form sends a different case, the other checks the 401 path. I did not test the SQL itself, there is no database test setup in the repo, so I checked the table and column names against prisma/schema.prisma by hand.

Closes #4352

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789276088&installation_model_id=22160&pr_number=4452&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4452&signature=fb51964ad5d829f68cb710ecd2659dfdbdf602229c9e19147a2a7091f2c1379c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
