### PR TITLE
feat(api): support unit parameter in website list charts

### DIFF
--- a/src/app/api/websites/charts/route.ts
+++ b/src/app/api/websites/charts/route.ts
@@ -3,9 +3,9 @@ import { fromZonedTime } from 'date-fns-tz';
 import { parseDateRange } from '@/lib/date';
 import { canViewBatchWebsites } from '@/permissions/website';
 import { parseRequest } from '@/lib/request';
-import { json } from '@/lib/response';
-import { timezoneParam } from '@/lib/schema';
-import { getWebsiteListCharts } from '@/queries/sql';
+import { badRequest, json } from '@/lib/response';
+import { timezoneParam, unitParam } from '@/lib/schema';
+import { MAX_BUCKETS, countBuckets, getWebsiteListCharts } from '@/queries/sql';
 
 const schema = z.object({
   ids: z
@@ -15,6 +15,7 @@ const schema = z.object({
   startAt: z.coerce.number().int().optional(),
   endAt: z.coerce.number().int().optional(),
   timezone: timezoneParam.optional(),
+  unit: unitParam.optional(),
 });
 
 export async function GET(request: Request) {
@@ -32,12 +33,21 @@ export async function GET(request: Request) {
     : fromZonedTime(defaultRange.startDate, timezone);
   const endDate = hasDateRange ? new Date(query.endAt) : fromZonedTime(defaultRange.endDate, timezone);
 
+  // Reject rather than truncate: a capped series would contradict the
+  // full-range total in the same response.
+  if (countBuckets(startDate, endDate, timezone, query.unit) > MAX_BUCKETS) {
+    return badRequest({
+      message: `Requested range exceeds ${MAX_BUCKETS} data points. Use a coarser unit or a shorter range.`,
+    });
+  }
+
   const websiteIds = await canViewBatchWebsites(auth, query.ids);
 
   const data = await getWebsiteListCharts(websiteIds, {
     startDate,
     endDate,
     timezone,
+    unit: query.unit,
   });
 
   return json({ data });

--- a/src/queries/sql/getWebsiteListCharts.test.ts
+++ b/src/queries/sql/getWebsiteListCharts.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const WEBSITE_ID = '00000000-0000-4000-8000-000000000001';
+
+async function loadModule({ mode, rows = [] }: { mode: 'prisma' | 'clickhouse'; rows?: unknown[] }) {
+  vi.resetModules();
+
+  const state = { mode };
+  const prismaRawQuery = vi.fn().mockResolvedValue(rows);
+  const clickhouseRawQuery = vi.fn().mockResolvedValue(rows);
+
+  // Mirrors the real helpers closely enough to assert which one was used.
+  const prismaGetDateSQL = vi.fn(
+    (field: string, unit: string, timezone?: string) =>
+      `to_char(date_trunc('${unit}', ${field} at time zone '${timezone}'), 'YYYY-MM-DD HH24:00:00')`,
+  );
+  const clickhouseGetDateSQL = vi.fn(
+    (field: string, unit: string) => `formatDateTime(${field}, '${unit}')`,
+  );
+
+  vi.doMock('@/lib/db', () => ({
+    CLICKHOUSE: 'clickhouse',
+    PRISMA: 'prisma',
+    runQuery: vi.fn((queries: Record<string, () => unknown>) => queries[state.mode]()),
+  }));
+
+  vi.doMock('@/lib/prisma', () => ({
+    default: { rawQuery: prismaRawQuery, getDateSQL: prismaGetDateSQL },
+  }));
+
+  vi.doMock('@/lib/clickhouse', () => ({
+    default: { rawQuery: clickhouseRawQuery, getDateSQL: clickhouseGetDateSQL },
+  }));
+
+  const mod = await import('./getWebsiteListCharts');
+
+  return {
+    getWebsiteListCharts: mod.getWebsiteListCharts,
+    countBuckets: mod.countBuckets,
+    MAX_BUCKETS: mod.MAX_BUCKETS,
+    prismaRawQuery,
+    clickhouseRawQuery,
+    prismaGetDateSQL,
+    clickhouseGetDateSQL,
+  };
+}
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('getWebsiteListCharts bucketing', () => {
+  test('defaults to the existing 12-hour buckets', async () => {
+    const { getWebsiteListCharts, prismaGetDateSQL, prismaRawQuery } = await loadModule({
+      mode: 'prisma',
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-10T00:00:00Z'),
+      timezone: 'UTC',
+    });
+
+    const [query] = prismaRawQuery.mock.calls[0];
+
+    expect(query).toContain('12 hour');
+    expect(prismaGetDateSQL).not.toHaveBeenCalled();
+    // Two days of 12-hour buckets, inclusive of the closing boundary.
+    expect(result[WEBSITE_ID].values).toHaveLength(5);
+  });
+
+  test('day unit produces one bucket per day via the shared helper', async () => {
+    const { getWebsiteListCharts, prismaGetDateSQL, prismaRawQuery } = await loadModule({
+      mode: 'prisma',
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-10T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    const [query] = prismaRawQuery.mock.calls[0];
+
+    expect(prismaGetDateSQL).toHaveBeenCalledWith('website_event.created_at', 'day', 'UTC');
+    expect(query).not.toContain('12 hour');
+    expect(result[WEBSITE_ID].values).toHaveLength(3);
+  });
+
+  test('hour unit produces one bucket per hour', async () => {
+    const { getWebsiteListCharts, prismaGetDateSQL } = await loadModule({
+      mode: 'prisma',
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-08T23:59:59Z'),
+      timezone: 'UTC',
+      unit: 'hour',
+    });
+
+    expect(prismaGetDateSQL).toHaveBeenCalledWith('website_event.created_at', 'hour', 'UTC');
+    // A full day at hourly resolution, not two 12-hour blocks.
+    expect(result[WEBSITE_ID].values).toHaveLength(24);
+  });
+
+  test('clickhouse uses its own date helper for explicit units', async () => {
+    const { getWebsiteListCharts, clickhouseGetDateSQL } = await loadModule({
+      mode: 'clickhouse',
+    });
+
+    await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-10T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    expect(clickhouseGetDateSQL).toHaveBeenCalledWith('website_event.created_at', 'day', 'UTC');
+  });
+});
+
+describe('getWebsiteListCharts daylight saving time', () => {
+  // A local day is 23 or 25 hours long across a DST transition. Stepping by a
+  // fixed 24 hours would drift the labels off midnight from the transition
+  // onwards, so every following bucket would match no row and read back as 0.
+  test('day buckets stay on local midnight across the autumn transition', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        // 2026-10-25 is the 25-hour day in Europe/Berlin.
+        { websiteId: WEBSITE_ID, x: '2026-10-25 00:00:00', y: 4 },
+        { websiteId: WEBSITE_ID, x: '2026-10-26 00:00:00', y: 7 },
+        { websiteId: WEBSITE_ID, x: '2026-10-27 00:00:00', y: 5 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-10-24T22:00:00Z'), // 2026-10-25 00:00 Berlin
+      endDate: new Date('2026-10-27T22:59:00Z'),
+      timezone: 'Europe/Berlin',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].values).toEqual([4, 7, 5]);
+  });
+
+  test('day buckets stay on local midnight across the spring transition', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        // 2026-03-29 is the 23-hour day in Europe/Berlin.
+        { websiteId: WEBSITE_ID, x: '2026-03-29 00:00:00', y: 2 },
+        { websiteId: WEBSITE_ID, x: '2026-03-30 00:00:00', y: 6 },
+        { websiteId: WEBSITE_ID, x: '2026-03-31 00:00:00', y: 3 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-03-28T23:00:00Z'), // 2026-03-29 00:00 Berlin
+      endDate: new Date('2026-03-31T21:59:00Z'),
+      timezone: 'Europe/Berlin',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].values).toEqual([2, 6, 3]);
+  });
+
+  test('day buckets keep advancing where the transition falls on midnight', async () => {
+    // America/Santiago springs forward at 00:00, so 2026-09-06 00:00 local
+    // does not exist. The series must still advance one day at a time.
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [{ websiteId: WEBSITE_ID, x: '2026-09-04 00:00:00', y: 1 }],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-09-04T04:00:00Z'),
+      endDate: new Date('2026-09-08T04:00:00Z'),
+      timezone: 'America/Santiago',
+      unit: 'day',
+    });
+
+    // Five distinct days, not one bucket repeated.
+    expect(result[WEBSITE_ID].values).toHaveLength(5);
+  });
+
+  test('the repeated autumn hour lands in the first of the two buckets', async () => {
+    // 02:00 local exists twice on 2026-10-25 in Europe/Berlin, and the
+    // database reports both as a single 02:00 row.
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-10-25 01:00:00', y: 5 },
+        { websiteId: WEBSITE_ID, x: '2026-10-25 02:00:00', y: 9 },
+        { websiteId: WEBSITE_ID, x: '2026-10-25 03:00:00', y: 4 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-10-24T23:00:00Z'), // 01:00 Berlin
+      endDate: new Date('2026-10-25T02:00:00Z'), // 03:00 Berlin
+      timezone: 'Europe/Berlin',
+      unit: 'hour',
+    });
+
+    // No leading gap before the repeated hour.
+    expect(result[WEBSITE_ID].values.slice(0, 3)).toEqual([5, 9, 0]);
+  });
+
+  test('the transition day itself is not lost where midnight does not exist', async () => {
+    // America/Santiago springs forward at 00:00 on 2026-09-06, so that day has
+    // no local midnight. The database still truncates it to 2026-09-06.
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-09-05 00:00:00', y: 7 },
+        { websiteId: WEBSITE_ID, x: '2026-09-06 00:00:00', y: 8 },
+        { websiteId: WEBSITE_ID, x: '2026-09-07 00:00:00', y: 9 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-09-05T04:00:00Z'),
+      endDate: new Date('2026-09-07T05:00:00Z'),
+      timezone: 'America/Santiago',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].values).toEqual([7, 8, 9]);
+  });
+});
+
+describe('getWebsiteListCharts minute resolution', () => {
+  // Labels used to be formatted with a hardcoded `HH:00:00`, so every minute
+  // of an hour collapsed onto the same key and the values were lost.
+  test('minute buckets stay distinct', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-08-08 11:00:00', y: 1 },
+        { websiteId: WEBSITE_ID, x: '2026-08-08 11:01:00', y: 4 },
+        { websiteId: WEBSITE_ID, x: '2026-08-08 11:02:00', y: 2 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T11:00:00Z'),
+      endDate: new Date('2026-08-08T11:02:00Z'),
+      timezone: 'UTC',
+      unit: 'minute',
+    });
+
+    expect(result[WEBSITE_ID].values).toEqual([1, 4, 2]);
+  });
+
+  test('an oversized range is reported, not silently truncated', async () => {
+    const { countBuckets, MAX_BUCKETS } = await loadModule({ mode: 'prisma' });
+
+    // A year of minutes is far beyond the cap; the route rejects such a
+    // request so `values` can never contradict `total`.
+    const count = countBuckets(
+      new Date('2026-01-01T00:00:00Z'),
+      new Date('2026-12-31T23:59:00Z'),
+      'UTC',
+      'minute',
+    );
+
+    expect(count).toBeGreaterThan(MAX_BUCKETS);
+  });
+
+  test('a range within the cap is not flagged', async () => {
+    const { countBuckets, MAX_BUCKETS } = await loadModule({ mode: 'prisma' });
+
+    const count = countBuckets(
+      new Date('2026-08-01T00:00:00Z'),
+      new Date('2026-08-31T00:00:00Z'),
+      'UTC',
+      'day',
+    );
+
+    expect(count).toBe(31);
+    expect(count).toBeLessThanOrEqual(MAX_BUCKETS);
+  });
+});
+
+describe('getWebsiteListCharts bucket alignment', () => {
+  // The alignment regression test above uses `unit: 'day'`, which is aligned by
+  // the calendar path. This covers the snapping used for hour/minute.
+  test('an unaligned start is snapped down on the hour path', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-08-08 11:00:00', y: 5 },
+        { websiteId: WEBSITE_ID, x: '2026-08-08 12:00:00', y: 8 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      // 11:37 must be snapped down to the 11:00 bucket, otherwise the labels
+      // carry the offset and match no row.
+      startDate: new Date('2026-08-08T11:37:00Z'),
+      endDate: new Date('2026-08-08T12:30:00Z'),
+      timezone: 'UTC',
+      unit: 'hour',
+    });
+
+    expect(result[WEBSITE_ID].values).toEqual([5, 8]);
+  });
+
+  test('the bucket start never moves ahead of the requested start', async () => {
+    // The repeated 02:xx hour is ambiguous and resolves to its second
+    // occurrence, which would drop the first hour of the range entirely.
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [{ websiteId: WEBSITE_ID, x: '2026-10-25 02:58:00', y: 3 }],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-10-25T00:58:00Z'), // first 02:58 in Berlin
+      endDate: new Date('2026-10-25T01:05:00Z'),
+      timezone: 'Europe/Berlin',
+      unit: 'minute',
+    });
+
+    expect(result[WEBSITE_ID].values.length).toBeGreaterThan(0);
+    expect(result[WEBSITE_ID].values[0]).toBe(3);
+  });
+
+  // Regression: an unaligned startDate used to generate labels that never
+  // matched the truncated values, leaving every bucket at 0 while total stayed
+  // correct — a silent failure behind a 200 response.
+  test('counts land in their bucket even when startDate is not aligned', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-08-08 00:00:00', y: 7 },
+        { websiteId: WEBSITE_ID, x: '2026-08-09 00:00:00', y: 5 },
+        { websiteId: WEBSITE_ID, x: null, y: 12 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      // Deliberately mid-day, as a naive "now minus 7 days" would produce.
+      startDate: new Date('2026-08-08T11:48:44Z'),
+      endDate: new Date('2026-08-10T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].total).toBe(12);
+    expect(result[WEBSITE_ID].values.reduce((a, b) => a + b, 0)).toBe(12);
+    expect(result[WEBSITE_ID].values[0]).toBe(7);
+  });
+
+  // Regression: with an explicit unit the ClickHouse bucket must stay a String.
+  // A DateTime column renders the GROUPING SETS subtotal as the epoch rather
+  // than an empty value, which formatResults would mistake for a data point —
+  // leaving `total` at 0.
+  test('clickhouse keeps the bucket a formatted string for explicit units', async () => {
+    const { getWebsiteListCharts, clickhouseRawQuery } = await loadModule({
+      mode: 'clickhouse',
+    });
+
+    await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-10T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    const [query] = clickhouseRawQuery.mock.calls[0];
+
+    expect(query).toContain('formatDateTime');
+    expect(query).toContain('%Y-%m-%d %T');
+  });
+
+  test('clickhouse reports the subtotal row as the total, not a bucket', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'clickhouse',
+      rows: [
+        { websiteId: WEBSITE_ID, x: '2026-08-08 00:00:00', y: 2 },
+        { websiteId: WEBSITE_ID, x: '', y: 3 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-09T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].total).toBe(3);
+    expect(result[WEBSITE_ID].values[0]).toBe(2);
+  });
+
+  test('matches date-only values as produced by clickhouse', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'clickhouse',
+      rows: [
+        // ClickHouse renders day buckets without a time component.
+        { websiteId: WEBSITE_ID, x: '2026-08-08', y: 4 },
+        { websiteId: WEBSITE_ID, x: '', y: 4 },
+      ],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-09T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].values[0]).toBe(4);
+  });
+
+  test('matches ISO values with a trailing Z as produced on the UTC path', async () => {
+    const { getWebsiteListCharts } = await loadModule({
+      mode: 'prisma',
+      rows: [{ websiteId: WEBSITE_ID, x: '2026-08-08T00:00:00Z', y: 3 }],
+    });
+
+    const result = await getWebsiteListCharts([WEBSITE_ID], {
+      startDate: new Date('2026-08-08T00:00:00Z'),
+      endDate: new Date('2026-08-09T00:00:00Z'),
+      timezone: 'UTC',
+      unit: 'day',
+    });
+
+    expect(result[WEBSITE_ID].values[0]).toBe(3);
+  });
+});

--- a/src/queries/sql/getWebsiteListCharts.ts
+++ b/src/queries/sql/getWebsiteListCharts.ts
@@ -1,5 +1,5 @@
-import { addHours } from 'date-fns';
-import { formatInTimeZone } from 'date-fns-tz';
+import { addHours, addMinutes } from 'date-fns';
+import { formatInTimeZone, fromZonedTime, toZonedTime } from 'date-fns-tz';
 import clickhouse from '@/lib/clickhouse';
 import { EVENT_TYPE } from '@/lib/constants';
 import { CLICKHOUSE, PRISMA, runQuery } from '@/lib/db';
@@ -8,6 +8,62 @@ import prisma from '@/lib/prisma';
 const FUNCTION_NAME = 'getWebsiteListCharts';
 const DEFAULT_TIMEZONE = 'UTC';
 const BUCKET_HOURS = 12;
+
+// Used when no unit is given: the endpoint keeps its original 12-hour
+// bucketing so existing callers see an unchanged response.
+const DEFAULT_UNIT = 'default';
+
+// Upper bound on the generated series. Unlike the other chart endpoints this
+// one fills gaps server-side, so an unbounded range at a fine resolution
+// (a year of minutes is over 500k points) would build huge dense arrays for
+// up to 20 websites at once.
+//
+// The route rejects oversized ranges up front — truncating would leave
+// `values` contradicting the full-range `total`. The check in the loops below
+// is a backstop for direct callers of this function.
+export const MAX_BUCKETS = 10000;
+
+// Units that are true durations and can be stepped on absolute time.
+const BUCKET_STEP: Record<string, (date: Date, timezone: string) => Date> = {
+  [DEFAULT_UNIT]: date => addHours(date, BUCKET_HOURS),
+  minute: date => addMinutes(date, 1),
+  hour: date => addHours(date, 1),
+};
+
+// Units where a bucket is a calendar span, not a fixed duration: a local day
+// is 23 or 25 hours long across a DST transition.
+const CALENDAR_UNITS = new Set(['day', 'month', 'year']);
+
+/** The local calendar date (YYYY-MM-DD) a bucket starts on. */
+function calendarStart(date: Date, unit: string, timezone: string): string {
+  const [year, month, day] = formatInTimeZone(date, timezone, 'yyyy-MM-dd').split('-');
+
+  if (unit === 'year') {
+    return `${year}-01-01`;
+  }
+
+  if (unit === 'month') {
+    return `${year}-${month}-01`;
+  }
+
+  return `${year}-${month}-${day}`;
+}
+
+/** The local calendar date one bucket later. Pure date arithmetic, no offsets. */
+function nextCalendarDate(date: string, unit: string): string {
+  const [year, month, day] = date.split('-').map(Number);
+  const next = new Date(Date.UTC(year, month - 1, day));
+
+  if (unit === 'year') {
+    next.setUTCFullYear(next.getUTCFullYear() + 1, 0, 1);
+  } else if (unit === 'month') {
+    next.setUTCMonth(next.getUTCMonth() + 1, 1);
+  } else {
+    next.setUTCDate(next.getUTCDate() + 1);
+  }
+
+  return next.toISOString().slice(0, 10);
+}
 
 interface WebsiteListChartPoint {
   websiteId: string;
@@ -26,11 +82,13 @@ export async function getWebsiteListCharts(
     startDate,
     endDate,
     timezone = DEFAULT_TIMEZONE,
+    unit = DEFAULT_UNIT,
     eventType,
   }: {
     startDate: Date;
     endDate: Date;
     timezone?: string;
+    unit?: string;
     eventType?: number;
   },
 ): Promise<Record<string, WebsiteListChartData>> {
@@ -40,14 +98,28 @@ export async function getWebsiteListCharts(
 
   return runQuery({
     [PRISMA]: async () => {
-      const points = await relationalQuery(websiteIds, startDate, endDate, timezone, eventType);
+      const points = await relationalQuery(
+        websiteIds,
+        startDate,
+        endDate,
+        timezone,
+        unit,
+        eventType,
+      );
 
-      return formatResults({ points, websiteIds, startDate, endDate, timezone });
+      return formatResults({ points, websiteIds, startDate, endDate, timezone, unit });
     },
     [CLICKHOUSE]: async () => {
-      const points = await clickhouseQuery(websiteIds, startDate, endDate, timezone, eventType);
+      const points = await clickhouseQuery(
+        websiteIds,
+        startDate,
+        endDate,
+        timezone,
+        unit,
+        eventType,
+      );
 
-      return formatResults({ points, websiteIds, startDate, endDate, timezone });
+      return formatResults({ points, websiteIds, startDate, endDate, timezone, unit });
     },
   });
 }
@@ -57,23 +129,28 @@ async function relationalQuery(
   startDate: Date,
   endDate: Date,
   timezone: string,
+  unit: string,
   eventType?: number,
 ): Promise<WebsiteListChartPoint[]> {
-  const { rawQuery } = prisma;
+  const { rawQuery, getDateSQL } = prisma;
   const eventTypeQuery =
     eventType != null
       ? `and website_event.event_type = ${eventType}`
       : `and website_event.event_type NOT IN (${EVENT_TYPE.customEvent}, ${EVENT_TYPE.performance})`;
+  // The 12-hour default bucket has no equivalent in getDateSQL and keeps its
+  // hand-rolled truncation. Every real unit reuses the shared helper.
   const bucketSql =
-    timezone.toLowerCase() === 'utc'
-      ? `
+    unit !== DEFAULT_UNIT
+      ? getDateSQL('website_event.created_at', unit, timezone)
+      : timezone.toLowerCase() === 'utc'
+        ? `
         to_char(
           date_trunc('day', website_event.created_at)
           + floor(extract(hour from website_event.created_at) / ${BUCKET_HOURS}) * interval '${BUCKET_HOURS} hour',
           'YYYY-MM-DD HH24:00:00'
         )
       `
-      : `
+        : `
         to_char(
           date_trunc('day', website_event.created_at at time zone '${timezone}')
           + floor(extract(hour from website_event.created_at at time zone '${timezone}') / ${BUCKET_HOURS}) * interval '${BUCKET_HOURS} hour',
@@ -110,15 +187,24 @@ async function clickhouseQuery(
   startDate: Date,
   endDate: Date,
   timezone: string,
+  unit: string,
   eventType?: number,
 ): Promise<WebsiteListChartPoint[]> {
-  const { rawQuery } = clickhouse;
+  const { rawQuery, getDateSQL } = clickhouse;
   const eventTypeQuery =
     eventType != null
       ? `and event_type = ${eventType}`
       : `and event_type NOT IN (${EVENT_TYPE.customEvent}, ${EVENT_TYPE.performance})`;
   const localTime = `toTimeZone(website_event.created_at, '${timezone}')`;
-  const bucketSql = `
+  // getDateSQL returns a DateTime, but the GROUPING SETS subtotal row needs to
+  // be distinguishable from a real bucket. A DateTime subtotal comes back as
+  // the epoch (1970-01-01 …) rather than an empty value, which formatResults
+  // would treat as an ordinary — and unmatched — data point, losing the total.
+  // Formatting to a String keeps the subtotal empty, as on the default path.
+  const bucketSql =
+    unit !== DEFAULT_UNIT
+      ? `formatDateTime(${getDateSQL('website_event.created_at', unit, timezone)}, '%Y-%m-%d %T')`
+      : `
     formatDateTime(
       toStartOfDay(${localTime}) + toIntervalHour(intDiv(toHour(${localTime}), ${BUCKET_HOURS}) * ${BUCKET_HOURS}),
       '%Y-%m-%d %H:00:00'
@@ -143,32 +229,168 @@ async function clickhouseQuery(
   );
 }
 
-function formatResults(
-  {
-    points,
-    websiteIds,
-    startDate,
-    endDate,
-    timezone,
-  }: {
-    points: WebsiteListChartPoint[];
-    websiteIds: string[];
-    startDate: Date;
-    endDate: Date;
-    timezone: string;
-  },
-) {
-  const buckets: string[] = [];
+/**
+ * Snaps a date down to the start of its bucket in the target timezone, so the
+ * generated labels line up with the truncated values the database returns.
+ *
+ * Without this, a startDate that is not already on a bucket boundary produces
+ * labels that never match any row, and every bucket silently reads back as 0
+ * while `total` stays correct.
+ */
+function startOfBucket(date: Date, unit: string, timezone: string): Date {
+  const local = toZonedTime(date, timezone);
 
-  for (
-    let current = new Date(startDate);
-    current <= endDate;
-    current = addHours(current, BUCKET_HOURS)
-  ) {
-    buckets.push(formatInTimeZone(current, timezone, 'yyyy-MM-dd HH:00:00'));
+  switch (unit) {
+    case 'minute':
+      local.setSeconds(0, 0);
+      break;
+    case 'hour':
+      local.setMinutes(0, 0, 0);
+      break;
+    case 'day':
+      local.setHours(0, 0, 0, 0);
+      break;
+    case 'month':
+      local.setHours(0, 0, 0, 0);
+      local.setDate(1);
+      break;
+    case 'year':
+      local.setHours(0, 0, 0, 0);
+      local.setMonth(0, 1);
+      break;
+    default:
+      // The default 12-hour buckets start at 00:00 and 12:00 local time.
+      local.setHours(Math.floor(local.getHours() / BUCKET_HOURS) * BUCKET_HOURS, 0, 0, 0);
+      break;
   }
 
-  const bucketIndex = new Map(buckets.map((bucket, index) => [bucket, index]));
+  const snapped = fromZonedTime(local, timezone);
+
+  // In the repeated hour of an autumn DST transition the local time is
+  // ambiguous and resolves to its second occurrence, which would place the
+  // bucket start after the requested start. Step back one hour in that case.
+  return snapped > date ? addHours(snapped, -1) : snapped;
+}
+
+/**
+ * Normalises a formatted date into a comparable key.
+ *
+ * The backends disagree on how a truncated date is rendered: Postgres pads to
+ * `YYYY-MM-DD HH:00:00`, ClickHouse drops the time for day and coarser units,
+ * and the UTC paths emit ISO strings with a `T` and a trailing `Z`. Reducing
+ * all of them to `YYYY-MM-DD HH:mm` keeps the lookup format-agnostic.
+ */
+function bucketKey(value: string): string {
+  const [date, time = '00:00'] = value.replace('T', ' ').replace('Z', '').trim().split(' ');
+
+  return `${date} ${time.slice(0, 5)}`;
+}
+
+/**
+ * How many buckets a range would produce. Lets the route reject an oversized
+ * request before any query runs.
+ */
+export function countBuckets(
+  startDate: Date,
+  endDate: Date,
+  timezone = DEFAULT_TIMEZONE,
+  unit = DEFAULT_UNIT,
+): number {
+  const span = endDate.getTime() - startDate.getTime();
+
+  if (span < 0) {
+    return 0;
+  }
+
+  switch (unit) {
+    case 'minute':
+      return Math.floor(span / 60_000) + 1;
+    case 'hour':
+      return Math.floor(span / 3_600_000) + 1;
+    case 'year':
+    case 'month':
+    case 'day': {
+      // Calendar units vary in length, so count them on the local calendar.
+      let count = 0;
+      let date = calendarStart(startDate, unit, timezone);
+
+      while (
+        fromZonedTime(`${date} 00:00:00`, timezone) <= endDate &&
+        count <= MAX_BUCKETS
+      ) {
+        count += 1;
+        date = nextCalendarDate(date, unit);
+      }
+
+      return count;
+    }
+    default:
+      return Math.floor(span / (BUCKET_HOURS * 3_600_000)) + 1;
+  }
+}
+
+function formatResults({
+  points,
+  websiteIds,
+  startDate,
+  endDate,
+  timezone,
+  unit,
+}: {
+  points: WebsiteListChartPoint[];
+  websiteIds: string[];
+  startDate: Date;
+  endDate: Date;
+  timezone: string;
+  unit: string;
+}) {
+  const buckets: string[] = [];
+  // Minutes must survive into the label, otherwise every bucket of an hour
+  // collapses onto the same key.
+  const format = unit === 'minute' ? 'yyyy-MM-dd HH:mm:00' : 'yyyy-MM-dd HH:00:00';
+
+  if (CALENDAR_UNITS.has(unit)) {
+    // Calendar units advance on the local date itself. Deriving the next date
+    // from the previous instant would stall in zones whose DST transition is at
+    // midnight: the bucket for such a day resolves to 23:00 of the day before,
+    // which reads back as the earlier date and never moves on.
+    let date = calendarStart(startDate, unit, timezone);
+
+    for (
+      let current = fromZonedTime(`${date} 00:00:00`, timezone);
+      current <= endDate && buckets.length < MAX_BUCKETS;
+      current = fromZonedTime(`${(date = nextCalendarDate(date, unit))} 00:00:00`, timezone)
+    ) {
+      // Label from the calendar date, not from the instant: where local
+      // midnight does not exist (a DST transition at 00:00) the instant sits at
+      // 23:00 the day before, while the database still truncates to that day.
+      buckets.push(`${date} 00:00:00`);
+    }
+  } else {
+    const step = BUCKET_STEP[unit] ?? BUCKET_STEP[DEFAULT_UNIT];
+
+    for (
+      let current = startOfBucket(startDate, unit, timezone);
+      current <= endDate && buckets.length < MAX_BUCKETS;
+      current = step(current, timezone)
+    ) {
+      buckets.push(formatInTimeZone(current, timezone, format));
+    }
+  }
+
+  // The repeated hour of an autumn DST transition renders to the same local
+  // label twice, and the database collapses both into one row. Keeping the
+  // first index puts that row in the earlier of the two buckets instead of
+  // leaving a gap before it.
+  const bucketIndex = new Map<string, number>();
+
+  buckets.forEach((bucket, index) => {
+    const key = bucketKey(bucket);
+
+    if (!bucketIndex.has(key)) {
+      bucketIndex.set(key, index);
+    }
+  });
   const charts = websiteIds.reduce<Record<string, WebsiteListChartData>>((result, websiteId) => {
     result[websiteId] = {
       values: Array.from({ length: buckets.length }, () => 0),
@@ -189,7 +411,7 @@ function formatResults(
       return;
     }
 
-    const index = bucketIndex.get(String(x).slice(0, 19));
+    const index = bucketIndex.get(bucketKey(String(x)));
 
     if (index !== undefined) {
       charts[websiteId].values[index] = Number(y);


### PR DESCRIPTION
First off: the batch endpoint added in 3.3 is great. I maintain StatsFlow, an
iOS client for Umami, and it took loading the charts for all my websites from
one request per site down to a single request — for 18 sites that's 5.6s to
0.6s. Really nice addition.

That's what got me looking at hourly data. The endpoint only returns fixed
12-hour buckets, so I can't get an hourly chart for "today" out of it (I'd get
two data points instead of 24), and a daily chart has to be reassembled on the
client.

While adding `unit` I ran into two bugs in the existing code. They're both in
the same function, so I fixed them here rather than opening separate PRs — happy
to split it up if you'd rather review them separately.

I have a self-hosted 3.3.0 instance with ~53k events across 18 websites, so I
could check all of this against real data rather than just fixtures.

## 1. The `unit` parameter

Every other chart endpoint already takes `unit`, so this uses the same
`unitParam` and the same values. Non-default units go through the existing
`getDateSQL` helper on both backends instead of hand-rolling more truncation SQL.

**Leaving `unit` out keeps the current 12-hour bucketing**, so the website list
in the UI and any existing caller sees the same response as before. I checked
that against my instance: byte-identical.

Two edge cases do change on the default path, both as a consequence of the
bugfix below:

- an `endDate` that falls between the old and the snapped bucket end can add
  one trailing zero bucket; the leading values are unchanged
- the 10k limit now also applies here, which a default-path range would only
  reach at roughly 13 years

One implementation detail worth flagging: the 12-hour bucket has no equivalent
in `getDateSQL`, so it keeps its own truncation. To make an explicit
`unit=hour` mean actual hours, the default case needed its own internal name —
I used a `'default'` sentinel. If you'd rather have an explicit `bucketHours`
parameter or something else, I'm fine with changing it.

## 2. Bug: all-zero values with a correct total

Bucket labels are generated from the raw `startDate`, but the values are
truncated in SQL. If `startDate` doesn't sit on a bucket boundary, the labels
match no row, every bucket reads back as 0, and `total` still looks right. It's
a 200 response with nothing indicating anything went wrong.

Since the label format drops minutes, only the hour matters: with 12-hour
buckets a start at 00:xx or 12:xx lines up, the other 22 hours of the day don't.
So `now - 7 days` hits this most of the time. Same website, same window, only
the start hour differs:

```
start 09:15, unpatched  →  [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]   total 118
start 09:15, patched    →  [6, 16, 38, 19, 19, 11, 14]                  total 118
```

The patched values match `count(distinct session_id)` grouped by day from the
database exactly.

`startOfBucket` now snaps the start down to its bucket in the target timezone
before the labels are built. Lookups also go through a normalised key, because
Postgres pads to `YYYY-MM-DD HH:00:00` while the UTC paths emit ISO strings with
a trailing `Z`.

## 3. Bug: ClickHouse loses the total for explicit units

This one only shows up once `unit` is in play, which is why it hasn't surfaced
before.

`getDateSQL` returns a `DateTime` on ClickHouse. With a DateTime column the
`GROUPING SETS` subtotal row comes back as the epoch instead of an empty value,
so the `if (!x)` check in `formatResults` doesn't recognise it. The row gets
treated as a normal data point, matches no bucket, and is dropped — `total`
stays 0 while `values` are fine.

Formatting the truncated value to a String keeps the subtotal empty, same as the
default path already does. Against ClickHouse 24.12:

```
DateTime  → {"x":"1970-01-01 01:00:00","y":"3"}   ← looks like a bucket
String    → {"x":"","y":"3"}                      ← recognised as the subtotal
```

Note `%M` is *month* in ClickHouse, not minutes — the format string uses `%T`,
matching what the rest of the codebase does.

## DST

Day and coarser buckets are advanced as calendar steps in the target timezone,
not as fixed durations. A local day is 23 or 25 hours long across a DST
transition, so `now + 24h` drifts off midnight from the transition onwards and
every bucket after it matches no row:

```
Europe/Berlin, 2026-10-25 (25-hour day)
  fixed 24h    →  10-25 00:00   10-25 23:00   10-26 23:00   ← drifts
  calendar day →  10-25 00:00   10-26 00:00   10-27 00:00   ← stays put
```

Deriving each date from the previous instant isn't enough either: where the
transition falls on midnight (America/Santiago, America/Havana) that day's
bucket resolves to 23:00 of the day before, which reads back as the earlier
date and stalls the series. The loop therefore carries the local calendar date
forward. All three cases have regression tests.

**`unit=minute`** keeps the minute in the label — the previous fixed format
would have collapsed every minute of an hour onto the same key.

**Ranges beyond 10k buckets are rejected with a 400.** Unlike the sibling
endpoints this one fills gaps server-side, so an unbounded fine-grained range
(a year of minutes is >500k points) would build very large dense arrays for up
to 20 websites at once. Truncating instead would hand back a partial `values`
series next to a `total` covering the full range — two numbers in the same
response that disagree. Happy to change the limit or the wording.

## Why not just sum the buckets client-side

I tried that first. It's wrong: summing two 12-hour buckets into a day
double-counts sessions that cross the boundary, since `count(distinct
session_id)` is evaluated per bucket. On my data:

| | day 1 |
|---|---|
| 12-hour buckets summed | 5 |
| `unit=day` | 4 |
| `count(distinct session_id)` grouped by day | **4** |

Two of the five sites I sampled show this. Only truncating in the database gives
the right number.

## Testing

19 unit tests: default bucketing, hour/day/month on both backends, the different
date renderings, the ClickHouse subtotal row, five DST scenarios (both European
transitions, the repeated autumn hour, and a zone whose transition falls on
midnight), minute resolution, the range limit, and unaligned starts on both the
calendar and the duration path.

Beyond that I ran the patched build against my own instance's database and
compared three sources — unpatched 3.3.0, the patched build, and direct SQL —
across 39 assertions:

- hourly and daily values match `count(distinct session_id)` exactly, for all 18
  websites
- without `unit`, the patched build returns an identical response to 3.3.0
- the all-zero bug reproduces on 3.3.0 and is gone afterwards
- invalid `unit` → 400, more than 20 ids → 400

Postgres was tested with the real dataset; ClickHouse 24.12 with the generated
SQL, which is how the subtotal issue turned up.

Happy to adjust anything here, including splitting this into separate PRs.
