### PR TITLE
fix: otp paste not filling all fields on mobile

### DIFF
--- a/src/app/login/LoginForm.tsx
+++ b/src/app/login/LoginForm.tsx
@@ -41,7 +41,12 @@ export function LoginForm() {
         <Logo />
       </Icon>
       <Heading>umami</Heading>
-      <Form onSubmit={handleSubmit} error={getErrorMessage(error)} style={{ minWidth: 300 }}>
+      <Form
+        onSubmit={handleSubmit}
+        error={getErrorMessage(error)}
+        defaultValues={{ username: '', password: '' }}
+        style={{ minWidth: 300 }}
+      >
         <FormField
           label={t(labels.username)}
           data-test="input-username"

--- a/src/app/login/two-factor/LoginTwoFactorPage.tsx
+++ b/src/app/login/two-factor/LoginTwoFactorPage.tsx
@@ -100,7 +100,12 @@ export function LoginTwoFactorPage() {
           <Text style={{ color: 'var(--color-danger, red)' }}>{lockMessage}</Text>
         )}
 
-        <Form onSubmit={handleSubmit} error={error ?? undefined} style={{ minWidth: 300 }}>
+        <Form
+          onSubmit={handleSubmit}
+          error={error ?? undefined}
+          defaultValues={{ backupCode: '' }}
+          style={{ minWidth: 300 }}
+        >
           {!useBackup ? (
             <Column gap="2">
               <Text weight="bold">{t(labels.twoFactorEnterCode)}</Text>

--- a/src/components/common/OtpInput.test.tsx
+++ b/src/components/common/OtpInput.test.tsx
@@ -1,0 +1,42 @@
+import { fireEvent } from '@testing-library/react';
+import { expect, test, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { OtpInput } from './OtpInput';
+
+function getDigitInput(index: number) {
+  return screen.getByLabelText(`Digit ${index + 1}`) as HTMLInputElement;
+}
+
+test('typing individual digits fills fields in order and advances focus', async () => {
+  const onChange = vi.fn();
+  const { user } = render(<OtpInput value="" onChange={onChange} />);
+
+  await user.click(getDigitInput(0));
+  await user.keyboard('1');
+
+  expect(onChange).toHaveBeenLastCalledWith('1');
+});
+
+test('a real paste event distributes the code across all fields and calls onComplete', async () => {
+  const onChange = vi.fn();
+  const onComplete = vi.fn();
+  const { user } = render(<OtpInput value="" onChange={onChange} onComplete={onComplete} />);
+
+  await user.click(getDigitInput(0));
+  await user.paste('123456');
+
+  expect(onChange).toHaveBeenLastCalledWith('123456');
+  expect(onComplete).toHaveBeenCalledWith('123456');
+});
+
+test('a multi-character value delivered via onChange (mobile paste fallback) fills all fields', () => {
+  const onChange = vi.fn();
+  const onComplete = vi.fn();
+  render(<OtpInput value="" onChange={onChange} onComplete={onComplete} />);
+
+  const input = getDigitInput(0);
+  fireEvent.change(input, { target: { value: '123456' } });
+
+  expect(onChange).toHaveBeenLastCalledWith('123456');
+  expect(onComplete).toHaveBeenCalledWith('123456');
+});

--- a/src/components/common/OtpInput.tsx
+++ b/src/components/common/OtpInput.tsx
@@ -27,8 +27,28 @@ export function OtpInput({ value, onChange, onComplete, disabled }: OtpInputProp
     }
   };
 
+  const applyPastedValue = (digitsStr: string) => {
+    const pasted = digitsStr.replace(/\D/g, '').slice(0, LENGTH);
+    const next = Array.from({ length: LENGTH }, (_, i) => pasted[i] ?? '');
+    const newVal = next.join('');
+    onChange(newVal);
+    if (newVal.length === LENGTH) {
+      onComplete?.(newVal);
+      focusInput(refs.current[LENGTH - 1]);
+    } else {
+      focusInput(refs.current[pasted.length]);
+    }
+  };
+
   const handleInput = (index: number, raw: string) => {
-    const char = raw.replace(/\D/g, '').slice(-1);
+    const digitsOnly = raw.replace(/\D/g, '');
+
+    if (digitsOnly.length > 1) {
+      applyPastedValue(digitsOnly);
+      return;
+    }
+
+    const char = digitsOnly;
     if (!char) return;
     update(index, char);
     if (index < LENGTH - 1) {
@@ -56,16 +76,7 @@ export function OtpInput({ value, onChange, onComplete, disabled }: OtpInputProp
 
   const handlePaste = (e: ClipboardEvent<HTMLInputElement & HTMLTextAreaElement>) => {
     e.preventDefault();
-    const pasted = e.clipboardData.getData('text').replace(/\D/g, '').slice(0, LENGTH);
-    const next = Array.from({ length: LENGTH }, (_, i) => pasted[i] ?? '');
-    const newVal = next.join('');
-    onChange(newVal);
-    if (newVal.length === LENGTH) {
-      onComplete?.(newVal);
-      focusInput(refs.current[LENGTH - 1]);
-    } else {
-      focusInput(refs.current[pasted.length]);
-    }
+    applyPastedValue(e.clipboardData.getData('text'));
   };
 
   return (


### PR DESCRIPTION
Pasting a 2FA code on mobile devices only filled the last digit into a single field instead of spreading it across all 6 fields. Some mobile keyboards don't fire a real `paste` event with `clipboardData`, so the otp code came through `onChange` instead, now that path is handled too.

In addition to that: Fixed a `react-hook-form` warning on the login/2FA forms (missing `defaultValues`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789774748&installation_model_id=22160&pr_number=4465&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4465&signature=569830f5f0fecb255c7a0179dd3e9fc12937f6a832d544af32ded579d0f4defa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->