### PR TITLE
fix: creating a board without a description returns 500

### DIFF
--- a/src/app/api/boards/route.ts
+++ b/src/app/api/boards/route.ts
@@ -75,6 +75,9 @@ export async function POST(request: Request) {
     ...body,
     type: normalizeBoardType(body.type),
     id: uuid(),
+    // The column is NOT NULL with no default, so an omitted description —
+    // which the request schema allows — reaches Prisma as undefined and throws.
+    description: body.description ?? '',
     parameters: body.parameters ?? {},
     userId: !teamId ? auth.user.id : undefined,
   };

--- a/tests/e2e/api-board.spec.ts
+++ b/tests/e2e/api-board.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+import { type Auth, authHeaders, loginViaApi } from './helpers';
+
+test.describe('Board API tests', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  let auth: Auth;
+  let boardId = '';
+
+  test.beforeAll(async ({ request }) => {
+    auth = await loginViaApi(request);
+  });
+
+  test.afterAll(async ({ request }) => {
+    if (boardId) {
+      await request.delete(`/api/boards/${boardId}`, { headers: authHeaders(auth) });
+    }
+  });
+
+  test('creates a board without a description', async ({ request }) => {
+    const response = await request.post('/api/boards', {
+      headers: authHeaders(auth),
+      data: { name: 'Playwright board', type: 'mixed' },
+    });
+
+    expect(response.status()).toBe(200);
+
+    const body = await response.json();
+
+    boardId = body.id;
+
+    expect(body).toHaveProperty('name', 'Playwright board');
+    expect(body).toHaveProperty('description', '');
+  });
+});


### PR DESCRIPTION
### Problem

`POST /api/boards` returns 500 when `description` is omitted. The request schema marks it `.optional()`, but `board.description` is `VARCHAR(500) NOT NULL` with no default, so it reaches Prisma as `undefined`:

```
Invalid `prisma.board.create()` invocation
Argument `description` is missing.
```

The UI always sends a description, so this only bites API clients — I hit it writing an API test.

### Fix

Default it to an empty string in the create route, matching what the UI sends today. No schema change, no migration.

### Test

`tests/e2e/api-board.spec.ts` creates a board with `{ name, type }` only and asserts 200 plus `description: ''`. Verified it fails (500) without the one-line change and passes with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789827955&installation_model_id=22160&pr_number=4469&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4469&signature=193e6f1d3c088e2df96bf68a1317cad6396c2b3782b6cee3918ac227aedd184a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->