### PR TITLE
fix: hide sidebar scrollbar when collapsed

### DIFF
--- a/src/app/(main)/SideNav.tsx
+++ b/src/app/(main)/SideNav.tsx
@@ -14,6 +14,7 @@ import { WebsiteNav } from '@/app/(main)/websites/[websiteId]/WebsiteNav';
 import { IconLabel } from '@/components/common/IconLabel';
 import Link from '@/components/common/Link';
 import { OverlayScrollArea } from '@/components/common/OverlayScrollArea';
+import styles from '@/components/common/OverlayScrollArea.module.css';
 import { useGlobalState, useMessages, useNavigation } from '@/components/hooks';
 import {
   Globe,
@@ -104,7 +105,10 @@ export function SideNav(props: any) {
           <PanelButton />
         </Row>
       </Row>
-      <OverlayScrollArea style={{ flexGrow: 1, minHeight: 0 }}>
+      <OverlayScrollArea
+        className={isCollapsed ? styles.collapsed : undefined}
+        style={{ flexGrow: 1, minHeight: 0 }}
+      >
         {websiteId ? (
           <WebsiteNav websiteId={websiteId} isCollapsed={isCollapsed} />
         ) : pathname.includes('/settings') ? (

--- a/src/components/common/OverlayScrollArea.module.css
+++ b/src/components/common/OverlayScrollArea.module.css
@@ -6,6 +6,10 @@
   --overlay-scrollbar-vertical-margin-right: 2px;
 }
 
+.collapsed > [data-orientation] {
+  display: none;
+}
+
 .root > :first-child {
   padding-right: var(--overlay-scrollbar-viewport-padding-right);
 }


### PR DESCRIPTION
## Description

When the sidebar is collapsed to the icon rail, the overlay scrollbar (track + thumb) remains visible, which adds visual clutter in a 60px-wide rail.

This hides the scrollbar visuals only in the collapsed state. Scrolling still works via wheel, trackpad, touch, and keyboard — only the indicator is hidden. The expanded sidebar is unchanged.

Closes #4464

<img width="131" height="907" alt="image" src="https://github.com/user-attachments/assets/5108fb7d-2f59-4c78-b065-12f6c7f7acb4" />

## Changes

- `OverlayScrollArea.module.css`: add a `.collapsed` rule that hides the scrollbar track/thumb
- `SideNav.tsx`: apply that class when `sidenav-collapsed` is true

## Notes

- `OverlayScrollArea.tsx` itself is untouched; the change is app-level per the existing pattern of customizing scrollbars from consumers
- `biome check` passes on both changed files (full-repo `pnpm lint` has pre-existing failures on `dev`, unrelated to this PR)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789920455&installation_model_id=22160&pr_number=4472&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4472&signature=5a1bd3d1e6d2b8f91ddbda46fbbdb780e8119b481a37b392c1b9c3f5b779abd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->