### PR TITLE
fix(tracker): ignore clicks whose target is not an Element

### DIFF
--- a/src/tracker/index.ts
+++ b/src/tracker/index.ts
@@ -346,7 +346,11 @@ type MetricEntry = PerformanceEntry & {
       }
     };
     const onClick = (e: MouseEvent) => {
-      const el = e.target as Element;
+      const el = e.target;
+      // The listener is on `document` in the capture phase, so it receives every
+      // click in the page — including ones dispatched on `document` itself or on
+      // a non-element node, where `closest` does not exist.
+      if (!(el instanceof Element)) return;
       const eventEl = el.closest(`[${eventNameAttribute}]`);
       if (!eventEl) return;
 


### PR DESCRIPTION
Closes #4473.

## The bug

`onClick` is registered on `document` in the capture phase, so it receives every click in the page. `e.target` was cast to `Element` and `closest()` called on it unconditionally:

```ts
const el = e.target as Element;
const eventEl = el.closest(`[${eventNameAttribute}]`);
```

`Document` does not implement `Element` — `typeof document.closest` is `"undefined"` — so any click whose target is not an Element throws out of the listener:

```
TypeError: e.target.closest is not a function
```

## Reproduction

On any page with the tracker loaded:

```js
document.dispatchEvent(new MouseEvent('click', { bubbles: true }));
```

Browser extensions and embedded widgets dispatch synthetic clicks on `document` routinely, which is how this reached us: a real visitor on Chrome 151 / macOS, captured by our own `window.onerror` handler, filename pointing at the tracker.

## The change

Replace the cast with an `instanceof Element` guard. It also covers text nodes and `window` targets, not just `document`.

Functional impact of the bug was small — an exception in one listener does not stop the others, so pageview beacons were unaffected and only that one click's `data-umami-event` tracking was lost — but the throw is unavoidable and unsilenceable from the host page, and it lands in the host site's own error reporting attributed to their code.

## Verification

- Reproduced on a live page running the shipped tracker (umami 3.3.0, `postgresql-latest` image): the uncaught error matched the reported one down to the column offset.
- `tsc --noEmit` clean on `src/tracker/index.ts` with the DOM lib — `instanceof Element` narrows `EventTarget | null` to `Element`, so no cast is needed for the `closest` call.
- Branched from `dev` per CONTRIBUTING.md.

I did not run the full `pnpm build` / `pnpm lint` — the change is confined to this one function and typechecks in isolation, but let me know if you want the full run before merging.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789929026&installation_model_id=22160&pr_number=4474&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4474&signature=01be5c67635276707e6be1ff5413ee2d70b61b64121c42e856d558d28e8f40fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->