### PR TITLE
fix(reports): count only rows that have a value for the selected metric

### DIFF
--- a/src/queries/sql/reports/getPerformance.ts
+++ b/src/queries/sql/reports/getPerformance.ts
@@ -82,7 +82,7 @@ async function relationalQuery(
       percentile_cont(0.5) within group (order by ttfb) as ttfb_p50,
       percentile_cont(0.75) within group (order by ttfb) as ttfb_p75,
       percentile_cont(0.95) within group (order by ttfb) as ttfb_p95,
-      count(*) as count
+      count(${metric}) as count
     from website_event
     ${cohortQuery}
     ${joinSessionQuery}
@@ -172,7 +172,7 @@ async function clickhouseQuery(
       quantile(0.5)(ttfb) as ttfb_p50,
       quantile(0.75)(ttfb) as ttfb_p75,
       quantile(0.95)(ttfb) as ttfb_p95,
-      count() as count
+      count(${metric}) as count
     from website_event
     ${cohortQuery}
     where website_event.website_id = {websiteId:UUID}

--- a/src/queries/sql/reports/getPerformanceMetrics.ts
+++ b/src/queries/sql/reports/getPerformanceMetrics.ts
@@ -49,7 +49,7 @@ async function relationalQuery(
       percentile_cont(0.5) within group (order by ${metric}) as p50,
       percentile_cont(0.75) within group (order by ${metric}) as p75,
       percentile_cont(0.95) within group (order by ${metric}) as p95,
-      count(*) as count
+      count(${metric}) as count
     from website_event
     ${cohortQuery}
     ${joinSessionQuery}
@@ -83,7 +83,7 @@ async function clickhouseQuery(
       quantile(0.5)(${metric}) as p50,
       quantile(0.75)(${metric}) as p75,
       quantile(0.95)(${metric}) as p95,
-      count() as count
+      count(${metric}) as count
     from website_event
     ${cohortQuery}
     where website_event.website_id = {websiteId:UUID}


### PR DESCRIPTION
## Problem

In the performance report, the sample size shown next to a Web Vital does not
describe that metric.

`getPerformance` and `getPerformanceMetrics` compute percentiles with
`percentile_cont(...) within group (order by <metric>)` (Postgres) and
`quantile(...)(<metric>)` (ClickHouse). Both skip NULL rows. The count next to
them is `count(*)` / `count()`, which does not.

Web Vitals are sparse. CLS and INP are Chromium-only, so Safari, iOS and
Firefox pageviews store a `website_event` row with `event_type = 5` and no
value for those columns. The two numbers therefore describe different
populations.

This is visible in the UI, which labels the number `sampleSize`:

```tsx
{t(labels.sampleSize)}: {formatLongNumber(data.summary?.count || 0)}
```

## Evidence

Self-hosted instance, Postgres, one website, 14 days, `event_type = 5`:

| Metric | Rows with a value | Reported sample size |
|---|---|---|
| TTFB | 1681 | 1681 |
| FCP | 1483 | 1681 |
| LCP | 1300 | 1681 |
| CLS | 345 | 1681 |
| INP | **112** | **1681** |

So the report claims an INP p75 of 88 ms over 1681 samples, when 112 rows
carry an INP value. The smaller the coverage, the more confident the number
looks.

## Fix

Count the selected metric column instead of every row:

```sql
count(${metric}) as count
```

Same change on both engines, in `getPerformance.ts` (the `summary` the UI
labels "sample size") and in `getPerformanceMetrics.ts` (the `count` returned
for pages, titles, devices and browsers).

Verified on the same data:

```
 inp_p75 | count_before | count_after
---------+--------------+-------------
      88 |         1681 |         112
```

## Notes

- `metric` is validated by `z.enum(['lcp','inp','cls','fcp','ttfb'])` in
  `schema.ts`, so interpolating it here is no different from the existing
  percentile expressions in the same queries.
- The Web Vitals columns are nullable on both engines, so `count(column)`
  excludes missing values on ClickHouse as well as on Postgres.
- The UI already re-queries when the selected metric changes (`metric:
  selectedMetric` is part of the query parameters), so the summary count
  follows the selection with no UI change.
- No existing tests cover these two query files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790245860&installation_model_id=22160&pr_number=4478&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4478&signature=70ee5070a3de3ed7b4c9c73323655dcc9c9c070dbfda204df57fec8cff1a70d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->