### PR TITLE
Keep typed page paths selectable in reports

### DIFF
--- a/src/components/input/WebsiteValueComboBox.test.tsx
+++ b/src/components/input/WebsiteValueComboBox.test.tsx
@@ -65,7 +65,7 @@ test('clears the selected website value when the input is cleared', () => {
   expect(onChange).toHaveBeenCalledWith('');
 });
 
-test('combines values from both Journey step types', () => {
+test('combines values from both Journey step types with the typed value', () => {
   render(
     <WebsiteValueComboBox
       label="Start step"
@@ -74,11 +74,12 @@ test('combines values from both Journey step types', () => {
       additionalType="event"
       startDate={new Date('2026-08-01')}
       endDate={new Date('2026-08-03')}
-      value=""
+      value="/"
       onChange={() => {}}
     />,
   );
 
+  expect(screen.getByText('/')).toBeInTheDocument();
   expect(screen.getByText('/home')).toBeInTheDocument();
   expect(screen.getByText('signup')).toBeInTheDocument();
 });

--- a/src/components/input/WebsiteValueComboBox.tsx
+++ b/src/components/input/WebsiteValueComboBox.tsx
@@ -56,12 +56,14 @@ export function WebsiteValueComboBox({
   }, [type, additionalType]);
 
   const items = useMemo(() => {
-    const values = [...(primaryQuery.data || []), ...(additionalQuery.data || [])]
-      .map(({ value }) => value)
-      .filter(Boolean);
+    const values = [
+      value,
+      ...(primaryQuery.data || []).map(({ value }) => value),
+      ...(additionalQuery.data || []).map(({ value }) => value),
+    ].filter(Boolean);
 
     return [...new Set<string>(values)];
-  }, [primaryQuery.data, additionalQuery.data]);
+  }, [value, primaryQuery.data, additionalQuery.data]);
 
   return (
     <div className={cn('flex flex-col gap-1', className)}>


### PR DESCRIPTION
Fixes #4479

## Problem

Report page selectors only retain values returned by the ten-result lookup. Broad searches such as `/` can omit the exact path, causing the ComboBox to clear a valid typed value.

## Changes

Keep the current typed value in the deduplicated option list alongside the queried path and event values.

## User impact

Journey and Funnel reports can select paths such as `/` regardless of the date range or which other paths rank in the lookup results.

## Verification

- `pnpm test` — 95 files and 740 tests passed
- Focused `WebsiteValueComboBox` test — 2 passed
- `pnpm exec tsc --noEmit` — passed
- Biome lint and format checks on both changed files — passed
- `pnpm build` with the supported database and Geo checks skipped — passed
- Repository-wide `pnpm lint` still reports the existing `src/app/not-found.tsx` hook-name error; both changed files are clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790340766&installation_model_id=22160&pr_number=4490&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4490&signature=1bd3e8b23cf07b8660ec2a05729ba837c3f680610b19bab7ad7e47a4e5fcfeff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->