### PR TITLE
feat: make ClickHouse connection limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ The connection URL format:
 postgresql://username:mypassword@localhost:5432/mydb
 ```
 
+For deployments using ClickHouse through `CLICKHOUSE_URL`, `CLICKHOUSE_MAX_OPEN_CONNECTIONS` can
+override the client connection limit with a positive integer. When unset, the bundled ClickHouse
+client currently defaults to 10 connections. Each Umami server instance has its own connection pool,
+so five replicas configured with 20 can open up to 100 connections total.
+
 ### Build the Application
 
 ```bash

--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -7,6 +7,16 @@ import { PrismaClient } from '../generated/prisma/client.js';
 
 const MIN_VERSION = '9.4.0';
 const MIN_VERSION_NUM = 90400;
+const maxOpenConnections = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+
+if (
+  maxOpenConnections !== undefined &&
+  (!/^[1-9]\d*$/.test(maxOpenConnections) ||
+    !Number.isSafeInteger(Number(maxOpenConnections)))
+) {
+  console.log('CLICKHOUSE_MAX_OPEN_CONNECTIONS must be a positive integer.');
+  process.exit(1);
+}
 
 if (process.env.SKIP_DB_CHECK) {
   console.log('Skipping database check.');

--- a/scripts/check-db.js
+++ b/scripts/check-db.js
@@ -7,20 +7,22 @@ import { PrismaClient } from '../generated/prisma/client.js';
 
 const MIN_VERSION = '9.4.0';
 const MIN_VERSION_NUM = 90400;
+
+if (process.env.SKIP_DB_CHECK) {
+  console.log('Skipping database check.');
+  process.exit(0);
+}
+
 const maxOpenConnections = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
 
 if (
+  process.env.CLICKHOUSE_URL &&
   maxOpenConnections !== undefined &&
   (!/^[1-9]\d*$/.test(maxOpenConnections) ||
     !Number.isSafeInteger(Number(maxOpenConnections)))
 ) {
   console.log('CLICKHOUSE_MAX_OPEN_CONNECTIONS must be a positive integer.');
   process.exit(1);
-}
-
-if (process.env.SKIP_DB_CHECK) {
-  console.log('Skipping database check.');
-  process.exit(0);
 }
 
 const url = new URL(process.env.DATABASE_URL);

--- a/src/lib/clickhouse.test.ts
+++ b/src/lib/clickhouse.test.ts
@@ -1,5 +1,29 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { CLICKHOUSE_DATE_FORMATS } from './clickhouse';
+
+const createClient = vi.hoisted(() => vi.fn((_options: unknown) => ({})));
+
+vi.mock('@clickhouse/client', () => ({ createClient }));
+
+async function connect(maxOpenConnections?: string) {
+  vi.stubEnv('CLICKHOUSE_URL', 'http://default:password@localhost:8123/umami');
+  vi.stubEnv('CLICKHOUSE_MAX_OPEN_CONNECTIONS', maxOpenConnections);
+  vi.stubEnv('NODE_ENV', 'production');
+
+  vi.resetModules();
+
+  const { default: clickhouse } = await import('./clickhouse');
+
+  return clickhouse.connect();
+}
+
+beforeEach(() => {
+  createClient.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('CLICKHOUSE_DATE_FORMATS', () => {
   test('uses date format tokens compatible with ClickHouse 22.8 and newer', () => {
@@ -9,4 +33,29 @@ describe('CLICKHOUSE_DATE_FORMATS', () => {
       minute: '%Y-%m-%d %R:00',
     });
   });
+});
+
+describe('ClickHouse connection limit', () => {
+  test('uses the client default when CLICKHOUSE_MAX_OPEN_CONNECTIONS is unset', async () => {
+    await connect();
+
+    expect(createClient).toHaveBeenCalledOnce();
+    expect(createClient.mock.calls[0][0]).not.toHaveProperty('max_open_connections');
+  });
+
+  test('sets max_open_connections from CLICKHOUSE_MAX_OPEN_CONNECTIONS', async () => {
+    await connect('25');
+
+    expect(createClient.mock.calls[0][0]).toHaveProperty('max_open_connections', 25);
+  });
+
+  test.each(['', '0', '-1', '1.5', 'ten', '10connections', '9007199254740992'])(
+    'rejects invalid CLICKHOUSE_MAX_OPEN_CONNECTIONS value %j',
+    async value => {
+      await expect(connect(value)).rejects.toThrow(
+        'CLICKHOUSE_MAX_OPEN_CONNECTIONS must be a positive integer.',
+      );
+      expect(createClient).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/src/lib/clickhouse.test.ts
+++ b/src/lib/clickhouse.test.ts
@@ -5,8 +5,11 @@ const createClient = vi.hoisted(() => vi.fn((_options: unknown) => ({})));
 
 vi.mock('@clickhouse/client', () => ({ createClient }));
 
-async function connect(maxOpenConnections?: string) {
-  vi.stubEnv('CLICKHOUSE_URL', 'http://default:password@localhost:8123/umami');
+async function connect(maxOpenConnections?: string, enabled = true) {
+  vi.stubEnv(
+    'CLICKHOUSE_URL',
+    enabled ? 'http://default:password@localhost:8123/umami' : undefined,
+  );
   vi.stubEnv('CLICKHOUSE_MAX_OPEN_CONNECTIONS', maxOpenConnections);
   vi.stubEnv('NODE_ENV', 'production');
 
@@ -47,6 +50,11 @@ describe('ClickHouse connection limit', () => {
     await connect('25');
 
     expect(createClient.mock.calls[0][0]).toHaveProperty('max_open_connections', 25);
+  });
+
+  test('ignores CLICKHOUSE_MAX_OPEN_CONNECTIONS when ClickHouse is disabled', async () => {
+    await expect(connect('invalid', false)).resolves.toBeUndefined();
+    expect(createClient).not.toHaveBeenCalled();
   });
 
   test.each(['', '0', '-1', '1.5', 'ten', '10connections', '9007199254740992'])(

--- a/src/lib/clickhouse.ts
+++ b/src/lib/clickhouse.ts
@@ -25,7 +25,7 @@ const REGEX_OPERATORS: Operator[] = [OPERATORS.regex, OPERATORS.notRegex];
 
 let clickhouse: ClickHouseClient;
 const enabled = Boolean(process.env.CLICKHOUSE_URL);
-const maxOpenConnections = getMaxOpenConnections();
+const maxOpenConnections = enabled ? getMaxOpenConnections() : undefined;
 
 function getMaxOpenConnections() {
   const value = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;

--- a/src/lib/clickhouse.ts
+++ b/src/lib/clickhouse.ts
@@ -25,6 +25,23 @@ const REGEX_OPERATORS: Operator[] = [OPERATORS.regex, OPERATORS.notRegex];
 
 let clickhouse: ClickHouseClient;
 const enabled = Boolean(process.env.CLICKHOUSE_URL);
+const maxOpenConnections = getMaxOpenConnections();
+
+function getMaxOpenConnections() {
+  const value = process.env.CLICKHOUSE_MAX_OPEN_CONNECTIONS;
+
+  if (value === undefined) {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+
+  if (!/^[1-9]\d*$/.test(value) || !Number.isSafeInteger(parsed)) {
+    throw new Error('CLICKHOUSE_MAX_OPEN_CONNECTIONS must be a positive integer.');
+  }
+
+  return parsed;
+}
 
 function getClient() {
   const clickhouseUrl = process.env.CLICKHOUSE_URL;
@@ -47,6 +64,7 @@ function getClient() {
     database: pathname.replace('/', ''),
     username: username,
     password,
+    ...(maxOpenConnections === undefined ? {} : { max_open_connections: maxOpenConnections }),
   });
 
   if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
## Summary

- add optional `CLICKHOUSE_MAX_OPEN_CONNECTIONS` configuration
- validate positive integers during database preflight
- preserve the ClickHouse client default when unset
- document the default and per-instance pool sizing

Closes #4491.

## Verification

- `pnpm test` — 95 files, 748 tests
- `pnpm exec tsc --noEmit`
- `pnpm build`
- changed-file Biome lint
- production Docker image build
- Docker Compose integration: default peaked at 10 connections; configured `25` peaked at 25 with 50/50 successful `/api/send` requests; invalid `0` exited before health startup

Full `pnpm lint` remains blocked by pre-existing diagnostics on `dev`; the changed files pass Biome.

_AI assistance disclosure: This contribution was implemented and tested with AI assistance and reviewed by Arthur Braga Alfredo._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4492"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790367615&installation_model_id=22160&pr_number=4492&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4492&signature=0447a950ab1e1aa714a310dab41189770821f3cef0934e09385c96ef6d96a92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->