### PR TITLE
Keep commas in search filter values

### DIFF
--- a/src/components/common/FilterRecord.test.tsx
+++ b/src/components/common/FilterRecord.test.tsx
@@ -45,3 +45,19 @@ test('keeps commas in regex filter values', () => {
 
   expect(screen.getByLabelText('Filter value')).toHaveValue(value);
 });
+
+test('keeps commas when changing to a search operator', () => {
+  const value = '^[a-zA-Z0-9]{21,22}$';
+  const props = {
+    type: 'path',
+    startDate: new Date('2026-08-01'),
+    endDate: new Date('2026-08-02'),
+    name: 'path',
+    value,
+  };
+  const { rerender } = render(<FilterRecord {...props} operator="eq" />);
+
+  rerender(<FilterRecord {...props} operator="re" />);
+
+  expect(screen.getByLabelText('Filter value')).toHaveValue(value);
+});

--- a/src/components/common/FilterRecord.test.tsx
+++ b/src/components/common/FilterRecord.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { expect, test, vi } from 'vitest';
+import { FilterRecord } from './FilterRecord';
+
+vi.mock('@umami/react-zen', () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  Column: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Grid: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Icon: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Label: ({ children }: { children: ReactNode }) => <label>{children}</label>,
+  ListItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Loading: () => <div>Loading</div>,
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TextField: ({ value }: { value: string }) => (
+    <input aria-label="Filter value" value={value} readOnly />
+  ),
+}));
+
+vi.mock('@/components/common/Empty', () => ({ Empty: () => <div>Empty</div> }));
+vi.mock('@/components/common/MultiSelect', () => ({
+  MultiSelect: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  MultiSelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/hooks', () => ({
+  useFilters: () => ({ fields: [], operators: [] }),
+  useFormat: () => ({ formatValue: (value: string) => value }),
+  useWebsiteValuesQuery: () => ({ data: [], isLoading: false }),
+}));
+vi.mock('@/components/icons', () => ({ X: () => null }));
+
+test('keeps commas in regex filter values', () => {
+  const value = '^[a-zA-Z0-9]{21,22}$';
+
+  render(
+    <FilterRecord
+      type="path"
+      startDate={new Date('2026-08-01')}
+      endDate={new Date('2026-08-02')}
+      name="path"
+      operator="re"
+      value={value}
+    />,
+  );
+
+  expect(screen.getByLabelText('Filter value')).toHaveValue(value);
+});

--- a/src/components/common/FilterRecord.tsx
+++ b/src/components/common/FilterRecord.tsx
@@ -9,7 +9,7 @@ import {
   Select,
   TextField,
 } from '@umami/react-zen';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Empty } from '@/components/common/Empty';
 import { MultiSelect, MultiSelectItem } from '@/components/common/MultiSelect';
 import { useFilters, useFormat, useWebsiteValuesQuery } from '@/components/hooks';
@@ -29,6 +29,12 @@ export interface FilterRecordProps {
   onChange?: (name: string, value: string) => void;
 }
 
+function getSelectedValues(value: string | string[], operator: string) {
+  if (Array.isArray(value)) return value;
+  if (!value) return [];
+  return isSearchOperator(operator) ? [value] : value.split(',');
+}
+
 export function FilterRecord({
   websiteId,
   type,
@@ -43,14 +49,7 @@ export function FilterRecord({
 }: FilterRecordProps) {
   const { fields, operators } = useFilters();
   const isSearch = isSearchOperator(operator);
-  const initValues = Array.isArray(value)
-    ? value
-    : value
-      ? isSearch
-        ? [value]
-        : value.split(',')
-      : [];
-  const [selected, setSelected] = useState<string[]>(initValues);
+  const [selected, setSelected] = useState<string[]>(() => getSelectedValues(value, operator));
   const [search, setSearch] = useState('');
   const { formatValue } = useFormat();
   const { data, isLoading } = useWebsiteValuesQuery({
@@ -61,6 +60,10 @@ export function FilterRecord({
     endDate,
   });
   const items = data?.filter(({ value }) => value) || [];
+
+  useEffect(() => {
+    setSelected(getSelectedValues(value, operator));
+  }, [operator, value]);
 
   const handleSearch = (value: string) => {
     setSearch(value);

--- a/src/components/common/FilterRecord.tsx
+++ b/src/components/common/FilterRecord.tsx
@@ -42,7 +42,14 @@ export function FilterRecord({
   onChange,
 }: FilterRecordProps) {
   const { fields, operators } = useFilters();
-  const initValues = Array.isArray(value) ? value : value ? value.split(',') : [];
+  const isSearch = isSearchOperator(operator);
+  const initValues = Array.isArray(value)
+    ? value
+    : value
+      ? isSearch
+        ? [value]
+        : value.split(',')
+      : [];
   const [selected, setSelected] = useState<string[]>(initValues);
   const [search, setSearch] = useState('');
   const { formatValue } = useFormat();
@@ -53,7 +60,6 @@ export function FilterRecord({
     startDate,
     endDate,
   });
-  const isSearch = isSearchOperator(operator);
   const items = data?.filter(({ value }) => value) || [];
 
   const handleSearch = (value: string) => {


### PR DESCRIPTION
## Problem

Editing a search filter initialized every string value by splitting on commas. Regex quantifiers such as `{21,22}` were therefore truncated in the input even though the URL parser had preserved the full expression.

## Fix

Keep search-operator values as one string when initializing `FilterRecord`; retain comma splitting for the existing multi-value operators. Add a component regression using the reported regex shape.

## User impact

Regex, contains, and other free-text filter values containing commas remain fully visible and editable instead of showing only the prefix before the first comma.

## Verification

- Focused regressions: 2 passed, including an operator transition that preserves the full comma-bearing value.
- TypeScript: `tsc --noEmit` passed after generating the Prisma client with a placeholder local database URL.
- Biome check on both changed files passed.
- Full Vitest run: 93 files and 732 tests passed; 4 unrelated suites could not load the repository's PostCSS plugin on this Windows environment.
- Full repository lint reaches existing diagnostics outside this diff; both changed files are clean.
- `git diff --check` passed.

Fixes #4489

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790551824&installation_model_id=22160&pr_number=4496&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4496&signature=fbbd491b93133bbbfdc198fbedd8b39eb658013b40b98c05d986a6c3ee5f4ba4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->