### PR TITLE
fix(teams): respect basePath in Manage teams menu link

### DIFF
--- a/src/components/input/TeamsButton.tsx
+++ b/src/components/input/TeamsButton.tsx
@@ -87,15 +87,16 @@ export function TeamsButton() {
               </MenuItem>
             ))}
             <MenuSeparator />
-            <MenuItem id="manage-teams">
-              <a href="/settings/teams" style={{ width: '100%' }}>
-                <Row alignItems="center" justifyContent="space-between" gap>
-                  <Text align="center">Manage teams</Text>
-                  <Icon>
-                    <ArrowRight />
-                  </Icon>
-                </Row>
-              </a>
+            <MenuItem
+              id="manage-teams"
+              onAction={() => handleNavigate(getUrl('/settings/teams'))}
+            >
+              <Row alignItems="center" justifyContent="space-between" gap width="100%">
+                <Text align="center">Manage teams</Text>
+                <Icon>
+                  <ArrowRight />
+                </Icon>
+              </Row>
             </MenuItem>
           </MenuSection>
         </Menu>


### PR DESCRIPTION
Fixes #4499

The "Manage teams" item in the teams dropdown used a raw `<a href="/settings/teams">`, which bypasses the Next.js router and ignores `BASE_PATH`. On subfolder deployments it pointed to `example.com/settings/teams` instead of `example.com/subfolder/settings/teams`.

Changed it to navigate through `handleNavigate(getUrl('/settings/teams'))`, the same pattern the team links in this menu already use. `router.push` prepends the configured basePath, and cloud mode keeps working through `getUrl`.

Verified with `tsc --noEmit` (no new errors) and `biome lint` on the changed file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856001&installation_model_id=22160&pr_number=4502&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4502&signature=10f1e818ec08192c9b81c70d7df4edafa806a0bb5c5496580f6d62cb43af8575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->