### PR TITLE
fix(replays): compute replay duration from full recording span

### DIFF
--- a/src/queries/sql/replays/getSessionReplays.ts
+++ b/src/queries/sql/replays/getSessionReplays.ts
@@ -49,7 +49,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters, session
     : '';
 
   const havingQuery = minDurationMs
-    ? `having sum(extract(epoch from sr.ended_at - sr.started_at) * 1000) >= {{minDurationMs}}`
+    ? `having extract(epoch from max(sr.ended_at) - min(sr.started_at)) * 1000 >= {{minDurationMs}}`
     : '';
 
   return pagedRawQuery(
@@ -67,7 +67,7 @@ async function relationalQuery(websiteId: string, filters: QueryFilters, session
       count(sr.replay_id) as "chunkCount",
       min(sr.started_at) as "startedAt",
       max(sr.ended_at) as "endedAt",
-      sum(extract(epoch from sr.ended_at - sr.started_at) * 1000)::bigint as "duration",
+      (extract(epoch from max(sr.ended_at) - min(sr.started_at)) * 1000)::bigint as "duration",
       max(sr.created_at) as "createdAt"
     from session_replay sr
     join session on session.session_id = sr.session_id
@@ -114,7 +114,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters, session
     : '';
 
   const havingQuery = minDurationMs
-    ? `having toInt64(sum(toUnixTimestamp64Milli(session_replay.ended_at) - toUnixTimestamp64Milli(session_replay.started_at))) >= {minDurationMs:Int64}`
+    ? `having toInt64(toUnixTimestamp64Milli(max(session_replay.ended_at)) - toUnixTimestamp64Milli(min(session_replay.started_at))) >= {minDurationMs:Int64}`
     : '';
 
   return pagedRawQuery(
@@ -132,7 +132,7 @@ async function clickhouseQuery(websiteId: string, filters: QueryFilters, session
       count(session_replay.replay_id) as chunkCount,
       min(session_replay.started_at) as startedAt,
       max(session_replay.ended_at) as endedAt,
-      toInt64(sum(toUnixTimestamp64Milli(session_replay.ended_at) - toUnixTimestamp64Milli(session_replay.started_at))) as duration,
+      toInt64(toUnixTimestamp64Milli(max(session_replay.ended_at)) - toUnixTimestamp64Milli(min(session_replay.started_at))) as duration,
       max(session_replay.created_at) as createdAt
     from session_replay
     join (


### PR DESCRIPTION
Fixes #4497

The replay list computed duration as `sum(ended_at - started_at)` across chunks, which only counts time *inside* each chunk. Many chunks contain a single event (full snapshots are flushed on their own, and oversized events are sent as fragments), so their span is exactly 0, and the time between chunks is never counted. A 4-minute recording can end up reported as 0:01, which then fails the default `minDuration=5` filter and disappears from the Replays page — while the player, which reads the raw event timestamps, correctly shows the full span.

Changed the duration to `max(ended_at) - min(started_at)` per visit (wall-clock span of the recording), in both the Postgres and ClickHouse queries, and applied the same expression to the `minDuration` HAVING clause so the filter and the displayed value stay consistent.

Verified with `tsc --noEmit` (no new errors) and `biome lint` on the changed file.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4503"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790856165&installation_model_id=22160&pr_number=4503&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4503&signature=b35c44141516d3d0249ca9c0771f486b7ef67f4e7b3c8616b5f4f4a1c57592e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->