### PR TITLE
feat: overview page comparing metrics and events across websites

### DIFF
--- a/src/app/(main)/MobileNav.tsx
+++ b/src/app/(main)/MobileNav.tsx
@@ -3,7 +3,7 @@ import { WebsiteNav } from '@/app/(main)/websites/[websiteId]/WebsiteNav';
 import { IconLabel } from '@/components/common/IconLabel';
 import Link from '@/components/common/Link';
 import { useMessages, useNavigation } from '@/components/hooks';
-import { Globe, Grid2x2, LayoutDashboard, LinkIcon } from '@/components/icons';
+import { ChartColumnStacked, Globe, Grid2x2, LayoutDashboard, LinkIcon } from '@/components/icons';
 import { MobileMenuButton } from '@/components/input/MobileMenuButton';
 import { UserButton } from '@/components/input/UserButton';
 import { Logo } from '@/components/svg';
@@ -29,6 +29,12 @@ export function MobileNav() {
       label: t(labels.websites),
       path: '/websites',
       icon: <Globe />,
+    },
+    {
+      id: 'overview',
+      label: t(labels.overview),
+      path: '/overview',
+      icon: <ChartColumnStacked />,
     },
     {
       id: 'links',

--- a/src/app/(main)/SideNav.tsx
+++ b/src/app/(main)/SideNav.tsx
@@ -16,6 +16,7 @@ import Link from '@/components/common/Link';
 import { OverlayScrollArea } from '@/components/common/OverlayScrollArea';
 import { useGlobalState, useMessages, useNavigation } from '@/components/hooks';
 import {
+  ChartColumnStacked,
   Globe,
   Grid2x2,
   LayoutDashboard,
@@ -53,6 +54,12 @@ export function SideNav(props: any) {
       label: t(labels.websites),
       path: '/websites',
       icon: <Globe />,
+    },
+    {
+      id: 'overview',
+      label: t(labels.overview),
+      path: '/overview',
+      icon: <ChartColumnStacked />,
     },
     {
       id: 'links',

--- a/src/app/(main)/overview/OverviewPage.tsx
+++ b/src/app/(main)/overview/OverviewPage.tsx
@@ -1,0 +1,361 @@
+'use client';
+import {
+  Column,
+  DataColumn,
+  DataTable,
+  Icon,
+  ListItem,
+  Row,
+  Select,
+  Text,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@umami/react-zen';
+import { colord } from 'colord';
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { BarChart } from '@/components/charts/BarChart';
+import { LoadingPanel } from '@/components/common/LoadingPanel';
+import { MultiSelect, MultiSelectItem } from '@/components/common/MultiSelect';
+import { PageBody } from '@/components/common/PageBody';
+import { PageHeader } from '@/components/common/PageHeader';
+import { Panel } from '@/components/common/Panel';
+import {
+  useApi,
+  useDateParameters,
+  useDateRange,
+  useLocale,
+  useLoginQuery,
+  useMessages,
+  useNavigation,
+  useUserWebsitesQuery,
+} from '@/components/hooks';
+import { ChartArea, ChartColumnStacked, ChartLine } from '@/components/icons';
+import { DateFilter } from '@/components/input/DateFilter';
+import { renderDateLabels } from '@/lib/charts';
+import { CHART_COLORS } from '@/lib/constants';
+import { generateTimeSeries, getDateRangeValue } from '@/lib/date';
+import { formatLongNumber } from '@/lib/format';
+import { getItem, setItem } from '@/lib/storage';
+
+const MAX_WEBSITES = 20;
+// Which table columns the user keeps visible; per browser, like other view
+// preferences (e.g. the date range default).
+const COLUMNS_KEY = 'umami.overview.columns';
+
+type ChartType = 'bar' | 'line' | 'area';
+
+// Stacked bars answer "how much in total, and who contributed"; lines answer
+// "who is trending up"; area is the stacked reading with a smoother shape.
+const CHART_TYPES: { id: ChartType; icon: ReactNode }[] = [
+  { id: 'bar', icon: <ChartColumnStacked /> },
+  { id: 'line', icon: <ChartLine /> },
+  { id: 'area', icon: <ChartArea /> },
+];
+
+type Point = { x: string; y: number };
+type EventPoint = { x: string; t: string; y: number };
+
+interface OverviewWebsite {
+  id: string;
+  name: string;
+  domain: string;
+  pageviews: Point[];
+  sessions: Point[];
+  events: EventPoint[];
+}
+
+function sum(points: { y: number }[]) {
+  return points.reduce((total, point) => total + Number(point.y), 0);
+}
+
+// One series per website for the chosen metric. Built-in metrics come from the
+// pageview/session series; anything else is a custom event name.
+function seriesFor(website: OverviewWebsite, metric: string): Point[] {
+  if (metric === 'pageviews') return website.pageviews;
+  if (metric === 'visitors') return website.sessions;
+
+  return website.events.filter(event => event.x === metric).map(({ t, y }) => ({ x: t, y }));
+}
+
+export function OverviewPage() {
+  const { t, labels } = useMessages();
+  const { user } = useLoginQuery();
+  const { teamId, router, updateParams } = useNavigation();
+  const { locale, dateLocale } = useLocale();
+  const { dateRange } = useDateRange();
+  const { startAt, endAt, unit, timezone } = useDateParameters();
+  const { get, useQuery } = useApi();
+
+  const websitesQuery = useUserWebsitesQuery(
+    { userId: user?.id, teamId },
+    { pageSize: MAX_WEBSITES },
+  );
+  const websites: { id: string; name: string; domain: string }[] = websitesQuery.data?.data ?? [];
+
+  const [selected, setSelected] = useState<string[]>([]);
+  const [metric, setMetric] = useState('pageviews');
+  const [chartType, setChartType] = useState<ChartType>('bar');
+  // null = every column (the default until the user customises the table).
+  const [columns, setColumns] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    const saved = getItem(COLUMNS_KEY);
+    if (Array.isArray(saved)) setColumns(saved);
+  }, []);
+
+  // Default to every website the user can see, once the list has loaded.
+  useEffect(() => {
+    if (selected.length === 0 && websites.length > 0) {
+      setSelected(websites.slice(0, MAX_WEBSITES).map(website => website.id));
+    }
+  }, [websites]);
+
+  const { data, isLoading, error } = useQuery<{
+    data: OverviewWebsite[];
+    startDate?: string | null;
+    endDate?: string | null;
+  }>({
+    queryKey: ['websites:overview', { ids: selected, startAt, endAt, unit, timezone }],
+    queryFn: () =>
+      get('/websites/overview', { ids: selected.join(','), startAt, endAt, unit, timezone }),
+    enabled: selected.length > 0,
+  });
+
+  const rows = data?.data ?? [];
+
+  // Event names seen across the selected websites, most frequent first.
+  const eventNames = useMemo(() => {
+    const totals = new Map<string, number>();
+    for (const website of rows) {
+      for (const event of website.events) {
+        totals.set(event.x, (totals.get(event.x) ?? 0) + Number(event.y));
+      }
+    }
+    return Array.from(totals.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([name]) => name);
+  }, [rows]);
+
+  const metricLabel = (value: string) =>
+    value === 'pageviews' ? t(labels.views) : value === 'visitors' ? t(labels.visitors) : value;
+
+  const chartData: any = useMemo(() => {
+    return {
+      __id: Date.now(),
+      datasets: rows.map((website, index) => {
+        const color = CHART_COLORS[index % CHART_COLORS.length];
+        const series = generateTimeSeries(
+          seriesFor(website, metric),
+          dateRange.startDate,
+          dateRange.endDate,
+          unit,
+          dateLocale,
+        );
+
+        if (chartType === 'bar') {
+          return {
+            label: website.name,
+            data: series,
+            type: 'bar',
+            borderColor: color,
+            backgroundColor: color,
+            borderWidth: 1,
+            barPercentage: 0.9,
+            categoryPercentage: 0.9,
+          };
+        }
+
+        // generateTimeSeries leaves buckets with no rows as null. A bar renders
+        // the same for null and 0, but a line breaks at null (Chart.js spanGaps
+        // is off by default) and a stacked area cannot stack across the hole.
+        // These are counts, so an empty bucket genuinely is zero — fill it,
+        // rather than spanning the gap and inventing a slope across idle time.
+        return {
+          label: website.name,
+          data: series.map(point => ({ ...point, y: point.y ?? 0 })),
+          type: 'line',
+          borderColor: color,
+          backgroundColor: chartType === 'area' ? colord(color).alpha(0.25).toRgbString() : color,
+          fill: chartType === 'area',
+          borderWidth: 2,
+          tension: 0.3,
+          pointRadius: 2,
+        };
+      }),
+    };
+  }, [rows, metric, chartType, dateRange, unit, dateLocale]);
+
+  const renderXLabel = useCallback(renderDateLabels(unit, locale), [unit, locale]);
+
+  const tableRows = useMemo(() => {
+    return rows.map(website => {
+      const row: Record<string, any> = {
+        id: website.id,
+        name: website.name,
+        domain: website.domain,
+        pageviews: sum(website.pageviews),
+        visitors: sum(website.sessions),
+      };
+      for (const name of eventNames) {
+        row[`event:${name}`] = sum(website.events.filter(event => event.x === name));
+      }
+      return row;
+    });
+  }, [rows, eventNames]);
+
+  // "All time" spans the earliest to the latest data across the selected
+  // websites, mirroring WebsiteDateFilter's handling for a single website.
+  const hasData = Boolean(data?.startDate && data?.endDate);
+
+  const handleDateChange = (date: string) => {
+    if (date === 'all' && hasData) {
+      router.push(
+        updateParams({
+          date: `${getDateRangeValue(new Date(data.startDate), new Date(data.endDate))}:all`,
+          offset: undefined,
+          unit: undefined,
+        }),
+      );
+      return;
+    }
+    router.push(updateParams({ date, offset: undefined, unit: undefined }));
+  };
+
+  // Built-in metrics first, then every event name seen in the data. The picker
+  // in the page header toggles these; name and domain are always shown.
+  const allColumns = useMemo(
+    () => [
+      { id: 'pageviews', label: t(labels.views) },
+      { id: 'visitors', label: t(labels.visitors) },
+      ...eventNames.map(name => ({ id: `event:${name}`, label: name })),
+    ],
+    [eventNames, t, labels],
+  );
+  const visibleColumns = columns
+    ? allColumns.filter(column => columns.includes(column.id))
+    : allColumns;
+
+  const handleColumnsChange = (values: string[]) => {
+    setColumns(values);
+    setItem(COLUMNS_KEY, values);
+  };
+
+  const numberCell = (key: string) => (row: any) => (
+    <Text style={{ fontVariantNumeric: 'tabular-nums' }}>{formatLongNumber(row[key] ?? 0)}</Text>
+  );
+
+  return (
+    <PageBody>
+      <Column gap="6" margin="2">
+        <PageHeader title={t(labels.overview)}>
+          <MultiSelect
+            value={visibleColumns.map(column => column.id)}
+            onChange={handleColumnsChange}
+            placeholder={t(labels.fields)}
+            renderValue={values => `${t(labels.fields)} (${values.length}/${allColumns.length})`}
+          >
+            {allColumns.map(column => (
+              <MultiSelectItem key={column.id} value={column.id}>
+                {column.label}
+              </MultiSelectItem>
+            ))}
+          </MultiSelect>
+        </PageHeader>
+        <Row gap="3" wrap="wrap" alignItems="flex-end">
+          <Column gap="1" style={{ minWidth: 260 }}>
+            <Text size="sm" color="muted">
+              {t(labels.websites)}
+            </Text>
+            <MultiSelect
+              value={selected}
+              onChange={values => setSelected(values.slice(0, MAX_WEBSITES))}
+              placeholder={t(labels.selectWebsite)}
+              renderValue={values =>
+                values.length === websites.length
+                  ? `${t(labels.all)} (${values.length})`
+                  : values
+                      .map(id => websites.find(website => website.id === id)?.name ?? id)
+                      .join(', ')
+              }
+            >
+              {websites.map(website => (
+                <MultiSelectItem key={website.id} value={website.id}>
+                  {website.name}
+                </MultiSelectItem>
+              ))}
+            </MultiSelect>
+          </Column>
+          <Column gap="1" style={{ minWidth: 200 }}>
+            <Text size="sm" color="muted">
+              {t(labels.metrics)}
+            </Text>
+            <Select value={metric} onChange={value => setMetric(String(value))}>
+              <ListItem id="pageviews">{t(labels.views)}</ListItem>
+              <ListItem id="visitors">{t(labels.visitors)}</ListItem>
+              {eventNames.map(name => (
+                <ListItem key={name} id={name}>
+                  {name}
+                </ListItem>
+              ))}
+            </Select>
+          </Column>
+          <Column gap="1">
+            <Text size="sm" color="muted">
+              {t(labels.chart)}
+            </Text>
+            <ToggleGroup
+              value={[chartType]}
+              onChange={keys => {
+                const next = keys[0] as ChartType;
+                if (next) setChartType(next);
+              }}
+            >
+              {CHART_TYPES.map(({ id, icon }) => (
+                <ToggleGroupItem key={id} id={id} aria-label={id}>
+                  <Icon>{icon}</Icon>
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+          </Column>
+          <DateFilter value={dateRange.value} onChange={handleDateChange} showAllTime={hasData} />
+          {dateRange.value?.endsWith(':all') && (
+            <Text size="sm" color="muted">
+              {t(labels.allTime)}
+            </Text>
+          )}
+        </Row>
+        <Panel>
+          <LoadingPanel data={data} isLoading={isLoading} error={error} isEmpty={rows.length === 0}>
+            <Column gap="3">
+              <Text weight="bold">{metricLabel(metric)}</Text>
+              <BarChart
+                chartData={chartData}
+                unit={unit}
+                minDate={dateRange.startDate}
+                maxDate={dateRange.endDate}
+                renderXLabel={renderXLabel}
+                stacked={chartType !== 'line'}
+                height="400px"
+              />
+            </Column>
+          </LoadingPanel>
+        </Panel>
+        <Panel>
+          <DataTable data={tableRows}>
+            <DataColumn id="name" label={t(labels.name)}>
+              {(row: any) => <Text weight="bold">{row.name}</Text>}
+            </DataColumn>
+            <DataColumn id="domain" label={t(labels.domain)}>
+              {(row: any) => <Text color="muted">{row.domain}</Text>}
+            </DataColumn>
+            {visibleColumns.map(column => (
+              <DataColumn key={column.id} id={column.id} label={column.label} align="end">
+                {numberCell(column.id)}
+              </DataColumn>
+            ))}
+          </DataTable>
+        </Panel>
+      </Column>
+    </PageBody>
+  );
+}

--- a/src/app/(main)/overview/page.tsx
+++ b/src/app/(main)/overview/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+import { OverviewPage } from './OverviewPage';
+
+export default function () {
+  return <OverviewPage />;
+}
+
+export const metadata: Metadata = {
+  title: 'Overview',
+};

--- a/src/app/api/websites/overview/route.ts
+++ b/src/app/api/websites/overview/route.ts
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import prisma from '@/lib/prisma';
+import { parseRequest } from '@/lib/request';
+import { json } from '@/lib/response';
+import { timezoneParam, unitParam } from '@/lib/schema';
+import { canViewBatchWebsites } from '@/permissions/website';
+import {
+  getEventStats,
+  getPageviewStats,
+  getSessionStats,
+  getWebsiteDateRange,
+} from '@/queries/sql';
+
+// Cross-website comparison: the same date-bucketed series the single-website
+// overview and events pages already use, for several websites in one call.
+// Consumers (the /overview page) stack them by website. Only websites the
+// caller may view come back; unknown or forbidden ids are silently dropped,
+// mirroring /api/websites/charts.
+const schema = z.object({
+  ids: z
+    .string()
+    .transform(value =>
+      value
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean),
+    )
+    .pipe(z.array(z.uuid()).min(1).max(20)),
+  startAt: z.coerce.number().int(),
+  endAt: z.coerce.number().int(),
+  unit: unitParam.optional(),
+  timezone: timezoneParam.optional(),
+});
+
+export async function GET(request: Request) {
+  const { auth, query, error } = await parseRequest(request, schema);
+
+  if (error) {
+    return error();
+  }
+
+  const websiteIds = await canViewBatchWebsites(auth, query.ids);
+
+  if (!websiteIds.length) {
+    return json({ data: [] });
+  }
+
+  const filters = {
+    startDate: new Date(query.startAt),
+    endDate: new Date(query.endAt),
+    unit: query.unit || 'day',
+    timezone: query.timezone || 'UTC',
+  };
+
+  const websites = await prisma.client.website.findMany({
+    where: { id: { in: websiteIds }, deletedAt: null },
+    select: { id: true, name: true, domain: true },
+    orderBy: { name: 'asc' },
+  });
+
+  const data = await Promise.all(
+    websites.map(async website => {
+      const [pageviews, sessions, events, range] = await Promise.all([
+        getPageviewStats(website.id, filters),
+        getSessionStats(website.id, filters),
+        getEventStats(website.id, {}, filters),
+        getWebsiteDateRange(website.id),
+      ]);
+
+      return { ...website, pageviews, sessions, events, range };
+    }),
+  );
+
+  // Earliest/latest data across the selected websites, so the page can offer
+  // an "all time" range the same way a single website's date filter does.
+  const starts = data.map(website => website.range?.startDate).filter(Boolean);
+  const ends = data.map(website => website.range?.endDate).filter(Boolean);
+  const startDate = starts.length ? new Date(Math.min(...starts.map(d => +new Date(d)))) : null;
+  const endDate = ends.length ? new Date(Math.max(...ends.map(d => +new Date(d)))) : null;
+
+  return json({
+    data: data.map(({ range: _range, ...website }) => website),
+    startDate,
+    endDate,
+  });
+}


### PR DESCRIPTION
Refs #4513

> **Draft / RFC.** This is a working prototype (running on my own instance) opened early to get
> feedback, not a finished feature. Happy to rename it, move it (own page vs. Dashboard widget vs.
> Boards component), trim or extend the scope, or close it if this is not a direction you want.
> Suggestions very welcome.

## What

Adds an **Overview** page that puts several websites on one chart and one table, so an instance that
hosts a family of related sites can answer "which site grew?" without opening each website page.

- `src/app/(main)/overview/` — page + client component: website multi-select (defaults to every
  website the user can view), metric select (Views / Visitors / any custom event name found in the
  data), the standard `DateFilter` with an "All time" option, a `BarChart` with a chart-type toggle
  (stacked bars / lines / stacked area, one colour per website), and a totals table (views,
  visitors, one column per event name) with a column picker in the page header that is remembered
  per browser.
- `src/app/api/websites/overview/route.ts` — `GET /api/websites/overview?ids=&startAt=&endAt=&unit=&timezone=`.
  Composes the existing `getPageviewStats`, `getSessionStats`, `getEventStats` and
  `getWebsiteDateRange` per website; authorisation via `canViewBatchWebsites`, mirroring
  `/api/websites/charts`. Forbidden or unknown ids are dropped, not rejected.
- `SideNav.tsx` / `MobileNav.tsx` — one entry each, reusing the existing `label.overview`, `label.chart` and `label.fields` keys.

## Why

Dashboard and Boards give one widget per website: independent charts with independent axes and no
stacking or totals, and no way to switch all of them to the same custom event. The Websites list's
sparkline is fixed to visitors over seven days. Comparing sites day by day currently means opening
each website in its own tab. See the linked issue for the full use case.

## Open questions

- Is a dedicated page right, or should this be a Boards / Dashboard component type?
- "Overview" reuses an existing label; a dedicated label (e.g. "Compare") would mean new i18n keys.
- Should the column picker persist per user (database) instead of per browser (localStorage)?
- Cap of 20 websites mirrors `/api/websites/charts`; fine, or should it page?

## Notes for review

- No migrations, no new dependencies, no new i18n keys. Only `@umami/react-zen` and `Chart.js`.
- Works on both Prisma and ClickHouse because the route only composes existing query functions.
- `ids` is capped at 20 like `/api/websites/charts`.
- The event-name list and the table's event columns are derived from the response, so nothing
  needs configuring per instance.
- `pnpm build` and `pnpm lint` pass; the tree has been type-checked with `tsc --noEmit`.

## Screenshots

<img width="1319" height="757" alt="image" src="https://github.com/user-attachments/assets/09dc61ba-a769-4227-a007-b1fbe3a67fa9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791181087&installation_model_id=22160&pr_number=4514&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4514&signature=6796179d1b4f24000bea374f15eca30e5ca59215cde40d1b930803570d3d4f39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->