### PR TITLE
Add ISK (Icelandic Króna) to revenue currencies

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -697,6 +697,7 @@ export const CURRENCIES = [
   { id: 'PLN', name: 'Polish Złoty' },
   { id: 'NOK', name: 'Norwegian Krone' },
   { id: 'DKK', name: 'Danish Krone' },
+  { id: 'ISK', name: 'Icelandic Króna' },
   { id: 'NZD', name: 'New Zealand Dollar' },
   { id: 'ZAR', name: 'South African Rand' },
   { id: 'MXN', name: 'Mexican Peso' },


### PR DESCRIPTION
## Summary

Adds `ISK` (Icelandic Króna) to the `CURRENCIES` list used by the Revenue report.

Events tracked with `{ revenue: 12500, currency: 'ISK' }` are stored correctly today, but the Revenue report can only aggregate currencies from this list, so Icelandic sites see $0.00 with no way to select ISK. One-line addition, placed with the other Nordic currencies.

## Test plan

- Track an event with `currency: 'ISK'`, open Revenue, select "ISK — Icelandic Króna": totals appear.
- Existing currencies unaffected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791212759&installation_model_id=22160&pr_number=4516&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4516&signature=24f9620223b7263de47d1cee702081e878d31fa3c26590ffdfcf889df424d210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->