### PR TITLE
fix(sessions): keep earlier linked identities visible after a colliding identify

### DIFF
--- a/packages/api-client/src/generated/types.ts
+++ b/packages/api-client/src/generated/types.ts
@@ -16652,6 +16652,7 @@ export interface operations {
         content: {
           'application/json': {
             canDelete: unknown;
+            distinctIds: unknown;
             stitchedSessionCount: unknown;
           };
         };

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -1614,7 +1614,7 @@
       "name": "MIT"
     },
     "title": "Umami API",
-    "version": "3.3.0"
+    "version": "3.3.1"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -35280,11 +35280,13 @@
                 "schema": {
                   "properties": {
                     "canDelete": {},
+                    "distinctIds": {},
                     "stitchedSessionCount": {}
                   },
                   "required": [
                     "canDelete",
-                    "stitchedSessionCount"
+                    "stitchedSessionCount",
+                    "distinctIds"
                   ],
                   "type": "object"
                 }

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.test.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.test.tsx
@@ -1,0 +1,57 @@
+import { expect, test, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { SessionInfo } from './SessionInfo';
+
+vi.mock('@/components/hooks', () => ({
+  useFormat: () => ({ formatValue: (value: string) => value }),
+  useLocale: () => ({ locale: 'en-US' }),
+  useMessages: () => ({
+    t: (value: string) => value,
+    labels: {
+      distinctId: 'Distinct ID',
+      lastSeen: 'Last seen',
+      firstSeen: 'First seen',
+      country: 'Country',
+      region: 'Region',
+      city: 'City',
+      browser: 'Browser',
+      os: 'OS',
+      device: 'Device',
+    },
+  }),
+  useRegionNames: () => ({ getRegionName: (region: string) => region }),
+}));
+
+vi.mock('@/components/common/DateDistance', () => ({
+  DateDistance: ({ date }: { date: Date }) => <span>{String(date)}</span>,
+}));
+
+vi.mock('@/components/common/TypeIcon', () => ({
+  TypeIcon: () => null,
+}));
+
+function createSessionData(overrides = {}) {
+  return {
+    id: 'session-1',
+    firstAt: new Date('2026-09-03T10:00:00.000Z'),
+    lastAt: new Date('2026-09-04T10:00:00.000Z'),
+    ...overrides,
+  };
+}
+
+test('renders every identity linked to a colliding session, newest first', () => {
+  render(
+    <SessionInfo
+      data={createSessionData({ distinctId: 'user-b', distinctIds: ['user-b', 'user-a'] })}
+    />,
+  );
+
+  expect(screen.getByText('user-a')).toBeInTheDocument();
+  expect(screen.getByText('user-b')).toBeInTheDocument();
+});
+
+test('renders the single distinctId unchanged when no list is provided', () => {
+  render(<SessionInfo data={createSessionData({ distinctId: 'user-a' })} />);
+
+  expect(screen.getByText('user-a')).toBeInTheDocument();
+});

--- a/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
+++ b/src/app/(main)/websites/[websiteId]/sessions/SessionInfo.tsx
@@ -12,12 +12,25 @@ export function SessionInfo({ data }) {
   const { formatValue } = useFormat();
   const { getRegionName } = useRegionNames(locale);
   const distinctId = data?.distinctId?.trim();
+  const distinctIds = (data?.distinctIds ?? []).map(id => id?.trim()).filter(Boolean);
   const stitchedSessionCount = data?.stitchedSessionCount;
 
   return (
     <Grid columns="repeat(auto-fit, minmax(200px, 1fr)" gap>
       <Info label={t(labels.distinctId)} icon={<KeyRound />}>
-        {distinctId ? <span style={{ overflowWrap: 'anywhere' }}>{distinctId}</span> : '—'}
+        {distinctIds.length > 1 ? (
+          <Column gap="1">
+            {distinctIds.map(id => (
+              <span key={id} style={{ overflowWrap: 'anywhere' }}>
+                {id}
+              </span>
+            ))}
+          </Column>
+        ) : distinctId ? (
+          <span style={{ overflowWrap: 'anywhere' }}>{distinctId}</span>
+        ) : (
+          '—'
+        )}
       </Info>
 
       <Info label={t(labels.lastSeen)} icon={<Calendar />}>

--- a/src/app/api/websites/[websiteId]/sessions/[sessionId]/contract.generated.ts
+++ b/src/app/api/websites/[websiteId]/sessions/[sessionId]/contract.generated.ts
@@ -140,8 +140,9 @@ const operation2 = defineOperation({
               properties: {
                 canDelete: {},
                 stitchedSessionCount: {},
+                distinctIds: {},
               },
-              required: ['canDelete', 'stitchedSessionCount'],
+              required: ['canDelete', 'stitchedSessionCount', 'distinctIds'],
             },
           },
         },

--- a/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.test.ts
+++ b/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.test.ts
@@ -71,6 +71,70 @@ test('GET returns not found when the session does not exist', async () => {
   expect(getLinkedSessionIdsMock).not.toHaveBeenCalled();
 });
 
+test('GET keeps earlier linked identities visible after a colliding identify', async () => {
+  parseRequestMock.mockResolvedValue({ auth: {}, error: undefined });
+  canViewWebsiteSectionMock.mockResolvedValue(true);
+  isRelationalOnlyMock.mockReturnValue(true);
+  canDeleteWebsiteMock.mockResolvedValue(false);
+  // The session hash collided (shared IP + identical user agent), so user B's
+  // identify reassigned the primary distinctId that user A linked first.
+  getWebsiteSessionMock.mockResolvedValue({
+    id: 'session-1',
+    distinctId: 'user-b',
+  });
+  getLinkedDistinctIdsMock.mockResolvedValue(['user-a', 'user-b']);
+  getLinkedSessionIdsMock.mockImplementation(async (_websiteId, distinctId) =>
+    distinctId === 'user-a'
+      ? [{ sessionId: 'session-1', createdAt: '2026-09-03T10:00:00.000Z' }]
+      : [{ sessionId: 'session-1', createdAt: '2026-09-04T10:00:00.000Z' }],
+  );
+
+  const response = await GET(
+    new Request('http://localhost/api/websites/website-1/sessions/session-1'),
+    {
+      params: Promise.resolve({ websiteId: 'website-1', sessionId: 'session-1' }),
+    },
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    distinctId: 'user-b',
+    distinctIds: ['user-b', 'user-a'],
+    stitchedSessionCount: 1,
+  });
+  expect(getLinkedDistinctIdsMock).toHaveBeenCalledWith('website-1', 'session-1');
+  expect(getLinkedSessionIdsMock).toHaveBeenCalledWith('website-1', 'user-a');
+  expect(getLinkedSessionIdsMock).toHaveBeenCalledWith('website-1', 'user-b');
+});
+
+test('GET dedupes the primary distinctId against the link history', async () => {
+  parseRequestMock.mockResolvedValue({ auth: {}, error: undefined });
+  canViewWebsiteSectionMock.mockResolvedValue(true);
+  isRelationalOnlyMock.mockReturnValue(true);
+  canDeleteWebsiteMock.mockResolvedValue(false);
+  getWebsiteSessionMock.mockResolvedValue({
+    id: 'session-1',
+    distinctId: 'user-a',
+  });
+  getLinkedDistinctIdsMock.mockResolvedValue(['user-a']);
+  getLinkedSessionIdsMock.mockResolvedValue([
+    { sessionId: 'session-2', createdAt: '2026-07-24T00:00:00.000Z' },
+  ]);
+
+  const response = await GET(
+    new Request('http://localhost/api/websites/website-1/sessions/session-1'),
+    {
+      params: Promise.resolve({ websiteId: 'website-1', sessionId: 'session-1' }),
+    },
+  );
+
+  expect(response.status).toBe(200);
+  await expect(response.json()).resolves.toMatchObject({
+    distinctIds: ['user-a'],
+    stitchedSessionCount: 2,
+  });
+});
+
 test('GET includes canDelete when relational storage and delete permission are available', async () => {
   parseRequestMock.mockResolvedValue({ auth: {}, error: undefined });
   canViewWebsiteSectionMock.mockResolvedValue(true);
@@ -80,6 +144,7 @@ test('GET includes canDelete when relational storage and delete permission are a
     id: 'session-1',
     distinctId: 'distinct-1',
   });
+  getLinkedDistinctIdsMock.mockResolvedValue(['distinct-1']);
   getLinkedSessionIdsMock.mockResolvedValue([
     { sessionId: 'session-2', createdAt: '2026-07-24T00:00:00.000Z' },
   ]);

--- a/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.test.ts
+++ b/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.test.ts
@@ -71,55 +71,38 @@ test('GET returns not found when the session does not exist', async () => {
   expect(getLinkedSessionIdsMock).not.toHaveBeenCalled();
 });
 
-test('GET keeps earlier linked identities visible after a colliding identify', async () => {
-  parseRequestMock.mockResolvedValue({ auth: {}, error: undefined });
-  canViewWebsiteSectionMock.mockResolvedValue(true);
-  isRelationalOnlyMock.mockReturnValue(true);
-  canDeleteWebsiteMock.mockResolvedValue(false);
-  // The session hash collided (shared IP + identical user agent), so user B's
-  // identify reassigned the primary distinctId that user A linked first.
-  getWebsiteSessionMock.mockResolvedValue({
-    id: 'session-1',
-    distinctId: 'user-b',
-  });
-  getLinkedDistinctIdsMock.mockResolvedValue(['user-a', 'user-b']);
-  getLinkedSessionIdsMock.mockImplementation(async (_websiteId, distinctId) =>
-    distinctId === 'user-a'
-      ? [{ sessionId: 'session-1', createdAt: '2026-09-03T10:00:00.000Z' }]
-      : [{ sessionId: 'session-1', createdAt: '2026-09-04T10:00:00.000Z' }],
-  );
-
-  const response = await GET(
-    new Request('http://localhost/api/websites/website-1/sessions/session-1'),
-    {
-      params: Promise.resolve({ websiteId: 'website-1', sessionId: 'session-1' }),
+test.each([
+  {
+    name: 'unions the link history with the primary after a colliding identify',
+    // Session hash collided (shared IP + identical UA), so user B's identify
+    // reassigned the primary distinctId that user A linked first.
+    primary: 'user-b',
+    linked: ['user-a', 'user-b'],
+    sessions: {
+      'user-a': [{ sessionId: 'session-1', createdAt: '2026-09-03T10:00:00.000Z' }],
+      'user-b': [{ sessionId: 'session-1', createdAt: '2026-09-04T10:00:00.000Z' }],
     },
-  );
-
-  expect(response.status).toBe(200);
-  await expect(response.json()).resolves.toMatchObject({
-    distinctId: 'user-b',
     distinctIds: ['user-b', 'user-a'],
     stitchedSessionCount: 1,
-  });
-  expect(getLinkedDistinctIdsMock).toHaveBeenCalledWith('website-1', 'session-1');
-  expect(getLinkedSessionIdsMock).toHaveBeenCalledWith('website-1', 'user-a');
-  expect(getLinkedSessionIdsMock).toHaveBeenCalledWith('website-1', 'user-b');
-});
-
-test('GET dedupes the primary distinctId against the link history', async () => {
+  },
+  {
+    name: 'dedupes a primary that is already in the link history',
+    primary: 'user-a',
+    linked: ['user-a'],
+    sessions: {
+      'user-a': [{ sessionId: 'session-2', createdAt: '2026-07-24T00:00:00.000Z' }],
+    },
+    distinctIds: ['user-a'],
+    stitchedSessionCount: 2,
+  },
+])('GET $name', async ({ primary, linked, sessions, distinctIds, stitchedSessionCount }) => {
   parseRequestMock.mockResolvedValue({ auth: {}, error: undefined });
   canViewWebsiteSectionMock.mockResolvedValue(true);
   isRelationalOnlyMock.mockReturnValue(true);
   canDeleteWebsiteMock.mockResolvedValue(false);
-  getWebsiteSessionMock.mockResolvedValue({
-    id: 'session-1',
-    distinctId: 'user-a',
-  });
-  getLinkedDistinctIdsMock.mockResolvedValue(['user-a']);
-  getLinkedSessionIdsMock.mockResolvedValue([
-    { sessionId: 'session-2', createdAt: '2026-07-24T00:00:00.000Z' },
-  ]);
+  getWebsiteSessionMock.mockResolvedValue({ id: 'session-1', distinctId: primary });
+  getLinkedDistinctIdsMock.mockResolvedValue(linked);
+  getLinkedSessionIdsMock.mockImplementation(async (_websiteId, distinctId) => sessions[distinctId]);
 
   const response = await GET(
     new Request('http://localhost/api/websites/website-1/sessions/session-1'),
@@ -130,9 +113,14 @@ test('GET dedupes the primary distinctId against the link history', async () => 
 
   expect(response.status).toBe(200);
   await expect(response.json()).resolves.toMatchObject({
-    distinctIds: ['user-a'],
-    stitchedSessionCount: 2,
+    distinctId: primary,
+    distinctIds,
+    stitchedSessionCount,
   });
+  expect(getLinkedDistinctIdsMock).toHaveBeenCalledWith('website-1', 'session-1');
+  linked.forEach(id =>
+    expect(getLinkedSessionIdsMock).toHaveBeenCalledWith('website-1', id),
+  );
 });
 
 test('GET includes canDelete when relational storage and delete permission are available', async () => {

--- a/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.ts
+++ b/src/app/api/websites/[websiteId]/sessions/[sessionId]/route.ts
@@ -31,9 +31,13 @@ export async function GET(
   }
 
   let sessionIds = [sessionId];
-  const distinctIds = data.distinctId
-    ? [data.distinctId]
-    : await getLinkedDistinctIds(websiteId, sessionId);
+  // A colliding identify reassigns the primary distinctId, so the link history
+  // is the only record of the identities previously attached to this session.
+  const distinctIds = Array.from(
+    new Set(
+      [data.distinctId, ...(await getLinkedDistinctIds(websiteId, sessionId))].filter(Boolean),
+    ),
+  );
 
   if (!data.distinctId && distinctIds.length === 1) {
     data.distinctId = distinctIds[0];
@@ -54,6 +58,7 @@ export async function GET(
     ...data,
     canDelete,
     stitchedSessionCount,
+    distinctIds,
   });
 }
 


### PR DESCRIPTION
## Summary

When two different real users collide on the same session hash (shared corporate NAT IP + identical User-Agent), the second `identify()` reassigns the session's primary `distinctId`. The session profile then showed only the latest identity, and the previously linked one disappeared with no indication two people ever shared that session.

The link history in `session_link` already records every identity ever linked to the session, but the session GET route only consulted it while `session.distinct_id` was still null. Once the first identify set the primary, every later collision skipped the history entirely.

This changes the route to always union the primary `distinctId` with `getLinkedDistinctIds`, so:

- stitching resolves sessions through every linked identity, not just the current primary
- the response now carries `distinctIds` (all identities ever linked, primary first)
- the session profile's Distinct ID cell renders every linked identity when there is more than one

The primary `distinctId` keeps its current last-wins behavior, matching the ClickHouse read path (`argMax(distinctId, max_time)`), so no data semantics change on the write side.

Fixes #4512

## Why

Without this there is no way to distinguish "this session was always User B" from "this session used to be User A" on a colliding session, which is the exact data-integrity problem reported: events keep the right per-event `distinctId`, but the stitched profile silently rewrites history.

## Verification

- before, on current `dev`: the session GET with primary `user-b` and link history `[user-a, user-b]` returned stitching for `user-b` only; `GET keeps earlier linked identities visible after a colliding identify` fails on the pre-fix tree
- after: `npx vitest run src/app/api/websites/[websiteId]/sessions/[sessionId]/route.test.ts`: union + `distinctIds: ['user-b', 'user-a']`, both links drive `stitchedSessionCount`
- `npx vitest run src/app/(main)/websites/[websiteId]/sessions/SessionInfo.test.tsx`: profile renders both `user-b` and `user-a`
- `npx biome check` clean on all four changed files

## Notes

- `distinctIds` is additive on the response; existing consumers of `distinctId` are unchanged
- repeated identifies of the same user are unchanged: the send-path cache token already skips the identity writes

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305899&installation_model_id=22160&pr_number=4518&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4518&signature=bb0f316adc1887c4a5ddfa53947a96d7f780aedd52d989d1a504431e3560309e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->