### PR TITLE
fix(metrics): respect reduced motion in numeric counters

### DIFF
--- a/src/components/hooks/useReducedMotion.test.tsx
+++ b/src/components/hooks/useReducedMotion.test.tsx
@@ -1,0 +1,77 @@
+import { act, render, screen } from '@testing-library/react';
+import { hydrateRoot } from 'react-dom/client';
+import { renderToString } from 'react-dom/server';
+import { beforeEach, expect, test, vi } from 'vitest';
+import { useReducedMotion } from './useReducedMotion';
+
+let reduced: boolean;
+let listeners: Set<() => void>;
+
+beforeEach(() => {
+  reduced = true;
+  listeners = new Set();
+  vi.spyOn(window, 'matchMedia').mockImplementation(query => ({
+    get matches() {
+      return reduced;
+    },
+    media: query,
+    onchange: null,
+    addEventListener: (_event, listener) => listeners.add(listener as () => void),
+    removeEventListener: (_event, listener) => listeners.delete(listener as () => void),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+});
+
+function Preference() {
+  return <span>{useReducedMotion() ? 'reduced' : 'animated'}</span>;
+}
+
+test('responds to browser preference changes and unsubscribes', () => {
+  const view = render(<Preference />);
+  expect(screen.getByText('reduced')).toBeInTheDocument();
+  act(() => {
+    reduced = false;
+    for (const listener of listeners) listener();
+  });
+  expect(screen.getByText('animated')).toBeInTheDocument();
+  act(() => {
+    reduced = true;
+    for (const listener of listeners) listener();
+  });
+  expect(screen.getByText('reduced')).toBeInTheDocument();
+  view.unmount();
+  expect(listeners.size).toBe(0);
+});
+
+test('hydrates the server snapshot without a mismatch, then applies the preference', async () => {
+  const container = document.createElement('div');
+  container.innerHTML = renderToString(<Preference />);
+  expect(container.textContent).toBe('animated');
+  const onRecoverableError = vi.fn();
+  let root: ReturnType<typeof hydrateRoot>;
+  await act(async () => {
+    root = hydrateRoot(container, <Preference />, { onRecoverableError });
+  });
+  expect(container.textContent).toBe('reduced');
+  expect(onRecoverableError).not.toHaveBeenCalled();
+  act(() => root.unmount());
+});
+
+test('supports environments without matchMedia', () => {
+  vi.spyOn(window, 'matchMedia').mockRestore();
+  const original = window.matchMedia;
+  Object.defineProperty(window, 'matchMedia', { value: undefined, configurable: true });
+  try {
+    const view = render(<Preference />);
+    expect(screen.getByText('animated')).toBeInTheDocument();
+    view.unmount();
+  } finally {
+    Object.defineProperty(window, 'matchMedia', {
+      value: original,
+      configurable: true,
+      writable: true,
+    });
+  }
+});

--- a/src/components/hooks/useReducedMotion.ts
+++ b/src/components/hooks/useReducedMotion.ts
@@ -1,0 +1,22 @@
+import { useSyncExternalStore } from 'react';
+
+const QUERY = '(prefers-reduced-motion: reduce)';
+
+function subscribe(onChange: () => void) {
+  const media = window.matchMedia?.(QUERY);
+  media?.addEventListener('change', onChange);
+  return () => media?.removeEventListener('change', onChange);
+}
+
+function getSnapshot() {
+  return window.matchMedia?.(QUERY).matches ?? false;
+}
+
+// Match the server render during hydration before reading the browser setting.
+function getServerSnapshot() {
+  return false;
+}
+
+export function useReducedMotion() {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/components/metrics/ListTable.tsx
+++ b/src/components/metrics/ListTable.tsx
@@ -1,10 +1,11 @@
 import { Column, Grid, Row, Text } from '@umami/react-zen';
-import { useReducedMotion, useSpring, useTransform } from 'motion/react';
+import { useSpring, useTransform } from 'motion/react';
 import { type ReactNode, useEffect } from 'react';
 import { List, type RowComponentProps } from 'react-window';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
 import { Empty } from '@/components/common/Empty';
 import { useMessages, useMobile } from '@/components/hooks';
+import { useReducedMotion } from '@/components/hooks/useReducedMotion';
 import { formatLongNumber } from '@/lib/format';
 
 const ITEM_SIZE = 30;

--- a/src/components/metrics/ListTable.tsx
+++ b/src/components/metrics/ListTable.tsx
@@ -1,5 +1,5 @@
 import { Column, Grid, Row, Text } from '@umami/react-zen';
-import { useSpring, useTransform } from 'motion/react';
+import { useReducedMotion, useSpring, useTransform } from 'motion/react';
 import { type ReactNode, useEffect } from 'react';
 import { List, type RowComponentProps } from 'react-window';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
@@ -43,6 +43,7 @@ export function ListTable({
 }: ListTableProps) {
   const { t, labels } = useMessages();
   const { isPhone } = useMobile();
+  const reducedMotion = useReducedMotion();
 
   const getRow = (row: ListData, index: number) => {
     const { label, count, percent } = row;
@@ -53,7 +54,7 @@ export function ListTable({
         label={renderLabel ? renderLabel(row, index) : (label ?? t(labels.unknown))}
         value={count}
         percent={percent}
-        animate={animate && !virtualize}
+        animate={animate && !virtualize && !reducedMotion}
         showPercentage={showPercentage}
         change={renderChange ? renderChange(row, index) : null}
         formatCount={formatCount}
@@ -145,7 +146,9 @@ const AnimatedRow = ({
       >
         {change}
         <Text weight="bold">
-          <AnimatedDiv title={String(value)}>{yText}</AnimatedDiv>
+          <AnimatedDiv title={String(value)}>
+            {animate ? yText : formatCount ? formatCount(y) : formatLongNumber(y)}
+          </AnimatedDiv>
         </Text>
       </Row>
       {showPercentage && (
@@ -158,7 +161,7 @@ const AnimatedRow = ({
           color="muted"
           paddingLeft="3"
         >
-          <AnimatedDiv>{widthText}</AnimatedDiv>
+          <AnimatedDiv>{animate ? widthText : `${percent?.toFixed?.(0)}%`}</AnimatedDiv>
         </Row>
       )}
     </Grid>

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -1,7 +1,8 @@
 import { Button, Column, Icon, Row, Text, Tooltip, TooltipTrigger } from '@umami/react-zen';
-import { useReducedMotion, useSpring, useTransform } from 'motion/react';
+import { useSpring, useTransform } from 'motion/react';
 import { type ReactNode, useEffect } from 'react';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
+import { useReducedMotion } from '@/components/hooks/useReducedMotion';
 import { Info } from '@/components/icons';
 import { ChangeLabel } from '@/components/metrics/ChangeLabel';
 import { formatNumber } from '@/lib/format';

--- a/src/components/metrics/MetricCard.tsx
+++ b/src/components/metrics/MetricCard.tsx
@@ -1,5 +1,5 @@
 import { Button, Column, Icon, Row, Text, Tooltip, TooltipTrigger } from '@umami/react-zen';
-import { useSpring, useTransform } from 'motion/react';
+import { useReducedMotion, useSpring, useTransform } from 'motion/react';
 import { type ReactNode, useEffect } from 'react';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
 import { Info } from '@/components/icons';
@@ -28,6 +28,7 @@ export const MetricCard = ({
   showLabel = true,
   showChange = false,
 }: MetricCardProps) => {
+  const reducedMotion = useReducedMotion();
   const diff = value - change;
   const pct = diff !== 0 ? ((value - diff) / diff) * 100 : value !== 0 ? 100 : 0;
   const x = Number(value) || 0;
@@ -38,12 +39,14 @@ export const MetricCard = ({
   const pctText = useTransform(pctSpring, n => `${Math.abs(~~n)}%`);
 
   useEffect(() => {
-    xSpring.set(x);
-  }, [x, xSpring]);
+    if (reducedMotion) xSpring.jump(x);
+    else xSpring.set(x);
+  }, [x, xSpring, reducedMotion]);
 
   useEffect(() => {
-    pctSpring.set(p);
-  }, [p, pctSpring]);
+    if (reducedMotion) pctSpring.jump(p);
+    else pctSpring.set(p);
+  }, [p, pctSpring, reducedMotion]);
 
   return (
     <Column
@@ -73,11 +76,13 @@ export const MetricCard = ({
         </Row>
       )}
       <Text size="4xl" weight="bold" wrap="nowrap">
-        <AnimatedDiv title={value?.toString()}>{valueText}</AnimatedDiv>
+        <AnimatedDiv title={value?.toString()}>
+          {reducedMotion ? formatValue(x) : valueText}
+        </AnimatedDiv>
       </Text>
       {showChange && (
         <ChangeLabel value={change} title={formatValue(change)} reverseColors={reverseColors}>
-          <AnimatedDiv>{pctText}</AnimatedDiv>
+          <AnimatedDiv>{reducedMotion ? `${Math.abs(~~p)}%` : pctText}</AnimatedDiv>
         </ChangeLabel>
       )}
     </Column>

--- a/src/components/metrics/PerformanceCard.tsx
+++ b/src/components/metrics/PerformanceCard.tsx
@@ -1,5 +1,5 @@
 import { Column, Text } from '@umami/react-zen';
-import { useSpring, useTransform } from 'motion/react';
+import { useReducedMotion, useSpring, useTransform } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
 import { Badge } from '@/components/common/Badge';
@@ -40,6 +40,7 @@ export const PerformanceCard = ({
   selected = false,
 }: PerformanceCardProps) => {
   const { t, labels } = useMessages();
+  const reducedMotion = useReducedMotion();
   const rating = getRating(metric, value);
   const prevMetricRef = useRef(metric);
   const metricChanged = prevMetricRef.current !== metric;
@@ -50,9 +51,9 @@ export const PerformanceCard = ({
   const display = useTransform(spring, n => formatValue(n));
 
   useEffect(() => {
-    if (metricChanged) spring.jump(target);
+    if (metricChanged || reducedMotion) spring.jump(target);
     else spring.set(target);
-  }, [target, metricChanged, spring]);
+  }, [target, metricChanged, spring, reducedMotion]);
 
   return (
     <Column
@@ -71,7 +72,7 @@ export const PerformanceCard = ({
         {label}
       </Text>
       <Text size="4xl" weight="bold" wrap="nowrap">
-        <AnimatedDiv>{display}</AnimatedDiv>
+        <AnimatedDiv>{reducedMotion ? formatValue(target) : display}</AnimatedDiv>
       </Text>
       <Badge variant={RATING_VARIANTS[rating]}>
         {t(labels[rating === 'needs-improvement' ? 'needsImprovement' : rating])}

--- a/src/components/metrics/PerformanceCard.tsx
+++ b/src/components/metrics/PerformanceCard.tsx
@@ -1,9 +1,10 @@
 import { Column, Text } from '@umami/react-zen';
-import { useReducedMotion, useSpring, useTransform } from 'motion/react';
+import { useSpring, useTransform } from 'motion/react';
 import { useEffect, useRef } from 'react';
 import { AnimatedDiv } from '@/components/common/AnimatedDiv';
 import { Badge } from '@/components/common/Badge';
 import { useMessages } from '@/components/hooks';
+import { useReducedMotion } from '@/components/hooks/useReducedMotion';
 import { WEB_VITALS_THRESHOLDS } from '@/lib/constants';
 import { formatNumber } from '@/lib/format';
 import styles from './PerformanceCard.module.css';

--- a/src/components/metrics/reducedMotion.test.tsx
+++ b/src/components/metrics/reducedMotion.test.tsx
@@ -4,14 +4,20 @@ import { ListTable } from './ListTable';
 import { MetricCard } from './MetricCard';
 import { PerformanceCard } from './PerformanceCard';
 
-const preference = vi.hoisted(() => ({ reduced: true }));
-vi.mock('motion/react', async importOriginal => ({
-  ...(await importOriginal<typeof import('motion/react')>()),
-  useReducedMotion: () => preference.reduced,
-}));
+const preference = { reduced: true };
 
 beforeEach(() => {
   preference.reduced = true;
+  vi.spyOn(window, 'matchMedia').mockImplementation(query => ({
+    matches: query === '(prefers-reduced-motion: reduce)' && preference.reduced,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
 });
 
 test('shows the final metric and percentage immediately with reduced motion', () => {

--- a/src/components/metrics/reducedMotion.test.tsx
+++ b/src/components/metrics/reducedMotion.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, expect, test, vi } from 'vitest';
+import { render, screen } from '@/test/render';
+import { ListTable } from './ListTable';
+import { MetricCard } from './MetricCard';
+import { PerformanceCard } from './PerformanceCard';
+
+const preference = vi.hoisted(() => ({ reduced: true }));
+vi.mock('motion/react', async importOriginal => ({
+  ...(await importOriginal<typeof import('motion/react')>()),
+  useReducedMotion: () => preference.reduced,
+}));
+
+beforeEach(() => {
+  preference.reduced = true;
+});
+
+test('shows the final metric and percentage immediately with reduced motion', () => {
+  const { rerender } = render(
+    <MetricCard value={120} change={20} showChange formatValue={n => `${n} visits`} />,
+  );
+  expect(screen.getByText('120 visits')).toBeInTheDocument();
+  expect(screen.getByText('20%')).toBeInTheDocument();
+  rerender(<MetricCard value={180} change={60} showChange formatValue={n => `${n} visits`} />);
+  expect(screen.getByText('180 visits')).toBeInTheDocument();
+  expect(screen.getByText('50%')).toBeInTheDocument();
+});
+
+test('updates performance values without intermediate numbers', () => {
+  const { rerender } = render(
+    <PerformanceCard metric="lcp" value={1200} label="LCP" formatValue={n => `${n} ms`} />,
+  );
+  expect(screen.getByText('1200 ms')).toBeInTheDocument();
+  rerender(<PerformanceCard metric="lcp" value={1800} label="LCP" formatValue={n => `${n} ms`} />);
+  expect(screen.getByText('1800 ms')).toBeInTheDocument();
+});
+
+test('shows final list counts and percentages with reduced motion', () => {
+  const { rerender } = render(
+    <ListTable
+      data={[{ label: 'Home', count: 42, percent: 75 }]}
+      formatCount={n => `${n} views`}
+    />,
+  );
+  expect(screen.getByText('42 views')).toBeInTheDocument();
+  expect(screen.getByText('75%')).toBeInTheDocument();
+  rerender(
+    <ListTable
+      data={[{ label: 'Home', count: 84, percent: 50 }]}
+      formatCount={n => `${n} views`}
+    />,
+  );
+  expect(screen.getByText('84 views')).toBeInTheDocument();
+  expect(screen.getByText('50%')).toBeInTheDocument();
+});
+
+test('retains the animated metric path without a reduced-motion preference', () => {
+  preference.reduced = false;
+  render(<MetricCard value={120} formatValue={n => `${n} visits`} />);
+  expect(screen.getByText('0 visits')).toBeInTheDocument();
+});
+
+test('still honors the explicit list animation opt-out', () => {
+  preference.reduced = false;
+  render(
+    <ListTable
+      animate={false}
+      data={[{ label: 'Home', count: 42, percent: 75 }]}
+      formatCount={n => `${n} views`}
+    />,
+  );
+  expect(screen.getByText('42 views')).toBeInTheDocument();
+  expect(screen.getByText('75%')).toBeInTheDocument();
+});


### PR DESCRIPTION
Numeric counters now respect the browser's reduced-motion preference. Metric cards, performance cards and list counts display their final values without counting through intermediate numbers. Normal animation and the existing list `animate={false}` option are preserved.

Addresses the system-preference part of #3651. This does not add an application settings toggle. The shared media-query hook follows preference changes and uses a stable server snapshot to avoid hydration mismatches.

Validation on `8ecc219f6eb24cb248b7dfe962eed8643fa333df`, based on `dev` `9eef6f2`:

- All **852 unit tests passed**, including eight new tests for counters, preference changes, listener cleanup, hydration and missing `matchMedia`. Three counter regressions fail against the original components.
- `pnpm build` passed with a disposable PostgreSQL database. Next's existing configuration skips TypeScript errors during build: standalone `tsc --noEmit` still reports three existing errors, with output identical to unchanged `dev` (two `Row.flexWrap` errors and a deep type instantiation in a 2FA test). Repository lint has the same six baseline errors; all six changed files pass Biome check.
- Factory operator run **FC-20260908-B82814** passed both Linux Chromium scenarios with zero retries and no page errors. DOM observations show final values throughout reduced-motion updates and intermediate values during normal animation. [Pinned report, samples and source identity](https://github.com/jackwalkerlabs/umami/tree/bbc1459509a5f069e745834b96fc9786cc9c0a16).

Browser checks use actual components in a standalone fixture with synthetic data and localization/mobile adapters, not a complete dashboard workflow. They run through Factory's shipped DockerRunner with a separate RunStore, not its production queue.

![Component fixture after a reduced-motion update](https://raw.githubusercontent.com/jackwalkerlabs/umami/bbc1459509a5f069e745834b96fc9786cc9c0a16/reduce.png)

Test setup: Node 24.20.0, pnpm 10.30.1, frozen lockfile installation with lifecycle scripts disabled, then Prisma generation and workspace builds. The stock Vitest run rejects the existing Next PostCSS configuration. Unit runs used an operator-only config merging `vitest.config.ts` with `{ css: { postcss: { plugins: [] } } }`; no assertions or test exclusions changed. That override is not part of this PR.

Reviewer QA: enable reduced motion in the OS or browser, load a report, and change its data range. Counts, percentages and performance values should update directly. Disable reduced motion and confirm the counters animate again.

AI disclosure: heavy Codex assistance. Codex implemented, reviewed and ran the checks under the submitter's authorization. No independent human review is claimed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791418756&installation_model_id=22160&pr_number=4522&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4522&signature=cbaa96bb916c6ead3de34b04cdb2183040edf07bce9d34610c70c50b3dc9a198"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->