### PR TITLE
perf(postgres): avoid sorting rows for visitor counts

### DIFF
--- a/src/lib/prisma.test.ts
+++ b/src/lib/prisma.test.ts
@@ -24,9 +24,10 @@ vi.mock('@/generated/prisma/client', () => ({
 }));
 
 let getRawQueryClient!: typeof import('./prisma').getRawQueryClient;
+let prisma!: typeof import('./prisma').default;
 
 beforeAll(async () => {
-  ({ getRawQueryClient } = await import('./prisma'));
+  ({ getRawQueryClient, default: prisma } = await import('./prisma'));
 });
 
 interface RawQueryClient {
@@ -78,5 +79,60 @@ describe('getRawQueryClient', () => {
     const client = createClient();
 
     expect(getRawQueryClient(client, { write: true })).toBe(client);
+  });
+});
+
+describe('pagedRawQuery default ordering', () => {
+  function mockQueries(count = '4') {
+    const queryRaw = vi.mocked((prisma.client as any).$queryRawUnsafe);
+    queryRaw.mockClear();
+    queryRaw.mockImplementation(async (sql: string) =>
+      sql.includes('count(*) as num') ? [{ num: count }] : [{ id: 1 }],
+    );
+    return queryRaw;
+  }
+
+  test.each([undefined, 5])(
+    'applies trusted default order only to the page query with cap %s',
+    async maxResults => {
+      const queryRaw = mockQueries('5');
+      const result = await prisma.pagedRawQuery(
+        'select * from thing',
+        {},
+        { page: 2, pageSize: 2, maxResults },
+        'test',
+        'max(created_at) desc, session_id',
+      );
+
+      expect(queryRaw).toHaveBeenCalledTimes(2);
+      expect(queryRaw.mock.calls[0][0]).not.toContain('order by max(created_at) desc');
+      expect(queryRaw.mock.calls[1][0]).toContain('order by max(created_at) desc, session_id');
+      expect(queryRaw.mock.calls[1][0]).toContain('limit 2 offset 2');
+      expect(result).toEqual({
+        data: [{ id: 1 }],
+        count: 5,
+        page: 2,
+        pageSize: 2,
+        isCapped: !!maxResults,
+        orderBy: undefined,
+      });
+    },
+  );
+
+  test('keeps explicit ordering and legacy no-order behavior', async () => {
+    const queryRaw = mockQueries();
+    const result = await prisma.pagedRawQuery(
+      'select * from thing',
+      {},
+      { page: 1, pageSize: 2, orderBy: 'name', sortDescending: true },
+      undefined,
+      'max(created_at) desc, session_id',
+    );
+    expect(queryRaw.mock.calls[1][0]).toContain('order by name desc');
+    expect(queryRaw.mock.calls[1][0]).not.toContain('order by max(created_at) desc, session_id');
+    expect(result.orderBy).toBe('name');
+    queryRaw.mockClear();
+    await prisma.pagedRawQuery('select * from thing', {}, { page: 1, pageSize: 2 });
+    expect(queryRaw.mock.calls[1][0]).not.toMatch(/order by/);
   });
 });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -786,6 +786,7 @@ async function pagedRawQuery(
   queryParams: Record<string, any>,
   filters: QueryFilters,
   name?: string,
+  defaultOrderBy?: string,
 ) {
   const { page = 1, pageSize, orderBy, sortDescending = false } = filters;
   const size = +pageSize || DEFAULT_PAGE_SIZE;
@@ -793,7 +794,7 @@ async function pagedRawQuery(
   const direction = sortDescending ? 'desc' : 'asc';
 
   const statements = [
-    orderBy && `order by ${orderBy} ${direction}`,
+    orderBy ? `order by ${orderBy} ${direction}` : defaultOrderBy && `order by ${defaultOrderBy}`,
     +size > 0 && `limit ${+size} offset ${offset}`,
   ]
     .filter(n => n)

--- a/src/queries/sql/sessions/getWebsiteSessions.ts
+++ b/src/queries/sql/sessions/getWebsiteSessions.ts
@@ -75,11 +75,11 @@ async function relationalQuery(websiteId: string, filters: QueryFilters) {
       session.country, 
       session.region, 
       session.city
-    order by max(website_event.created_at) desc, session.session_id
     `,
     queryParams,
     filters,
     FUNCTION_NAME,
+    'max(website_event.created_at) desc, session.session_id',
   );
 }
 


### PR DESCRIPTION
### Summary

Move PostgreSQL visitor ordering to the data-page query so it is no longer
included in the count query. Preserve the existing timestamp/session-ID ordering,
pagination and count cap. Other callers retain their existing behavior;
ClickHouse is unchanged.

### Why

`pagedRawQuery` wraps the visitor query for counting, inheriting its `ORDER BY`.
In the observed PostgreSQL plan, this sorted matching visitor groups before
applying `maxResults`, preventing early termination even though the count does
not depend on their order.

An optional default-order argument keeps the visitor's full ordering expression
on the page query without including it in the shared count wrapper.

### Validation

- Regression tests cover capped/uncapped counts, page-only ordering, explicit
  ordering precedence and existing callers without a default.
- On the dev port with a fresh frozen-lockfile install:
  - `pnpm exec vitest run src/lib/prisma.test.ts src/lib/sort.test.ts`: 12 passed.
  - Changed-file Biome lint: passed.
  - `SKIP_DB_CHECK=1 pnpm build`: completed; database checks/migrations were
    skipped, and the upstream build configuration skips type checking.
  - Full `pnpm lint`: fails with 6 errors in unchanged files (the not-found
    page and SVG assets). Running the same Biome 2.5.11 on unpatched dev also
    reports 6 errors and 14 warnings. These are not introduced by this patch.
- Earlier A/B measurements on **v3.3.1 (`ca661c7`), not this dev revision** used
  a fixed synthetic PostgreSQL dataset. For a 181-day range, count-query median
  time decreased from approximately 542 to 56 ms; API time decreased from
  931 to 550 ms. Measured API responses matched. Shorter ranges did not show
  a meaningful API improvement.
- These results motivate the change; they are not production measurements or
  a speedup guarantee for current `dev` or other data distributions.

Historical methods, samples and limitations:
[visitor count experiment](https://github.com/dongwonmoon/umami-performance-lab/blob/be6c814d72e0f4aea8475308a3fdefa383437b15/experiments/visitor-count-order.md).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791441390&installation_model_id=22160&pr_number=4523&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4523&signature=867180324bd711728604689d4877a3817409f769d9c3a0ef61c499a7284c9df6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->