### PR TITLE
Add a Kane CLI natural-language E2E test for the public dashboard

### DIFF
--- a/tests/kane-cli/public-dashboard_test.md
+++ b/tests/kane-cli/public-dashboard_test.md
@@ -1,0 +1,11 @@
+# Umami — public analytics dashboard renders
+
+A Kane CLI natural-language end-to-end test that verifies Umami's shared/public
+analytics dashboard loads and displays its key metrics and chart. Runs in a real
+browser (Kane CLI also automates mobile apps on the iOS Simulator and Android
+Emulator).
+
+## Open the public demo dashboard and verify metrics
+Go to https://umami.is/demo.
+Wait for the analytics dashboard to load.
+Assert that the dashboard shows a visitors or views number and a traffic chart.


### PR DESCRIPTION
## Add a Kane CLI natural-language end-to-end test

This adds one plain-markdown, natural-language end-to-end test covering loading Umami's public demo analytics dashboard and verifying the visitors/views metrics and traffic chart render.

**Why it might help**
- Readable by anyone: no selectors, no scripting. It lives in the repo as a `test.md` and re-runs on every deploy.
- Kane CLI drives a real browser, verifies each step with a visual/network check, and produces a sharable evidence report (video, steps, network). It also automates mobile apps on the iOS Simulator and Android Emulator.

**Evidence from a live run (passed):**
https://test-manager.lambdatest.com/projects/01KJSH1ECPR455A3XRGBKR3NV3/test-cases/01M237HV37D9RKTRKN7CM79J02/dashboard/share/US_JUFYX2K79J8RUP9JLY9MHZVO9H09S7LSUWK75Q5XQNJNC8ZWD3F0366BKN48WVEP?type=summary&agentView=true&fqdn=summary-page

**How to run**
```
kane-cli testmd run tests/kane-cli/public-dashboard_test.md --agent
```

Opening this for your consideration; approval is entirely yours. Happy to adjust the flow, the file location, or the format.
