### PR TITLE
Use correlated EXISTS for PostgreSQL session activity data

### DIFF
--- a/src/queries/sql/sessions/getSessionActivity.ts
+++ b/src/queries/sql/sessions/getSessionActivity.ts
@@ -31,11 +31,12 @@ async function relationalQuery(websiteId: string, sessionIds: string[], filters:
       event_name as "eventName",
       visit_id as "visitId",
       hostname,
-      event_id IN (select website_event_id 
-                   from event_data
-                   where website_id = {{websiteId::uuid}}
-                      and created_at between {{startDate}} and {{endDate}}) AS "hasData"
-    from website_event
+      EXISTS (select 1
+              from event_data d
+              where d.website_event_id = e.event_id
+                and d.website_id = {{websiteId::uuid}}
+                and d.created_at between {{startDate}} and {{endDate}}) AS "hasData"
+    from website_event e
     where website_id = {{websiteId::uuid}}
       and session_id = any({{sessionIds}}::uuid[])
       and event_type != ${EVENT_TYPE.performance}


### PR DESCRIPTION
## Summary

Implement the correlated `EXISTS` proposed in #4526 for PostgreSQL session activity queries.

The existing `hasData` expression checks event IDs against site/date-wide `event_data`. Depending on the data and query plan, opening a session profile can repeatedly scan a large materialized result. The correlated check lets PostgreSQL look up properties for each event using the existing `website_event_id` index.

Website/date predicates, returned fields, ordering, and the 500-row limit are unchanged. No new index or configuration is required. The ClickHouse implementation is unchanged.

## Verification

- Compared all returned fields for 500 rows on synthetic PostgreSQL 15.19 data; the results matched.
- Ran a small source-derived SQL check covering date boundaries, NULL dates, other-site data, multiple sessions, missing qualifying properties, multiple properties, and performance-event exclusion.
- Build passed with `SKIP_DB_CHECK=1` (database checks/migrations skipped).
- Three related unit tests passed; the changed file passes lint.
- Full lint fails on existing diagnostics: the unmodified and patched versions of the same `dev` revision produce identical diagnostics (6 errors, 13 warnings, 11 infos).

These are SQL-level checks using temporary tables, not a production or API performance benchmark. The diagnosis and proposed approach come from #4526; this change implements that approach with independent verification.

[Source-derived SQL check](https://github.com/dongwonmoon/umami-performance-lab/blob/c3ecd02b882501a9f324ced4f817f71ed49b7ac0/scripts/session-activity-check.sh) · [Measurement summary and limitations](https://github.com/dongwonmoon/umami-performance-lab/blob/c3ecd02b882501a9f324ced4f817f71ed49b7ac0/evidence/2026-09-10/session-activity-summary.json)

Related: #4526

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791596989&installation_model_id=22160&pr_number=4528&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4528&signature=061640115c07f2a229349f01d04da599a38d44b4edff1d81d79969e470198092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->