### PR TITLE
wrap lavel in span to show the title

### DIFF
--- a/src/components/metrics/MetricLabel.tsx
+++ b/src/components/metrics/MetricLabel.tsx
@@ -1,4 +1,4 @@
-import { Row } from '@umami/react-zen';
+import { Row, Text } from '@umami/react-zen';
 import { Favicon } from '@/components/common/Favicon';
 import { FilterLink } from '@/components/common/FilterLink';
 import { TypeIcon } from '@/components/common/TypeIcon';
@@ -154,11 +154,12 @@ function PathMetricLabel({ type, data }: MetricLabelProps) {
   );
 }
 
-function FullPathMetricLabel({ data }: Pick<MetricLabelProps, 'data'>) {
+function FullPathMetricLabel({ data }: Pick<MetricLabelProps, "data">) {
   const { t, labels } = useMessages();
   const { label } = data;
+  const text = label || `(${t(labels.none)})`;
 
-  return label || `(${t(labels.none)})`;
+  return <Text title={text}>{text}</Text>;
 }
 
 function DeviceMetricLabel({ data }: Pick<MetricLabelProps, 'data'>) {


### PR DESCRIPTION
In the full url tab, add title to the url to view truncated full urls

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/umami/pr/4533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791730593&installation_model_id=22160&pr_number=4533&repository=umami-software%2Fumami&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fumami%2Fpull%2F4533&signature=02e307ddcb7f37f67da525d9ec30640928636551b4a05a34124a08c8982afdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->